### PR TITLE
fix(ci): correct parameter order in infrastructure job naming script

### DIFF
--- a/.github/workflows/azure-webapps-node.yml
+++ b/.github/workflows/azure-webapps-node.yml
@@ -71,7 +71,7 @@ jobs:
           chmod +x ./infra/naming.sh
           while IFS= read -r line; do
             echo "$line" >> $GITHUB_ENV
-          done < <(./infra/naming.sh ${{ github.event.inputs.environment || 'dev' }} ${{ env.LOCATION_CODE }} ${{ env.PROJECT_NAME }})
+          done < <(./infra/naming.sh ${{ env.ORG_CODE }} ${{ github.event.inputs.environment || 'dev' }} ${{ env.PROJECT_NAME }} ${{ env.REGION_CODE }})
 
       - name: Azure Login
         uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1


### PR DESCRIPTION
The infrastructure job's naming script was still using the old 3-parameter signature instead of the new 4-parameter [org]-[env]-[project]-[region] order.

This was causing the RESOURCE_GROUP environment variable to not be set, resulting in 'az group create' failing with 'expected one argument' error.

Fixed: Pass ORG_CODE as first parameter to naming.sh in infrastructure job.

## Description

<!-- Provide a brief description of the changes in this PR -->

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test updates

## Related Issues

<!-- Link to related issues using #issue_number -->

Closes #

## Changes Made

<!-- List the specific changes made in this PR -->

-
-
-

## Testing

<!-- Describe the testing you've done -->

- [ ] All existing tests pass
- [ ] New tests added for new functionality
- [ ] Manual testing completed
- [ ] Code has been linted

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Checklist

<!-- Mark completed items with an 'x' -->

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Additional Notes

<!-- Add any additional information about the PR here -->
