### PR TITLE
fix: resolve pre-existing TS errors in scheduler tests

### DIFF
--- a/__tests__/api/scheduler-routes.test.ts
+++ b/__tests__/api/scheduler-routes.test.ts
@@ -15,10 +15,14 @@ jest.mock('../../app/api/_utils/audit', () => ({
 }));
 
 // Mock scheduler module
-const mockSchedule = jest.fn();
-const mockGetAllJobs = jest.fn();
-const mockGetJobsByStatus = jest.fn();
-const mockGetJobsByCampaign = jest.fn();
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const mockSchedule = jest.fn<any>();
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const mockGetAllJobs = jest.fn<any>();
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const mockGetJobsByStatus = jest.fn<any>();
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const mockGetJobsByCampaign = jest.fn<any>();
 
 // Mock the sanitize module
 jest.mock('../../app/api/_utils/sanitize', () => ({


### PR DESCRIPTION
## Summary
- Fix `jest.fn()` mock typing in `scheduler-routes.test.ts` that caused TS2345 errors in CI
- Pre-existing issue unrelated to video pipeline — `jest.fn()` without type params returns `Mock<never>`

## Test plan
- [ ] `pnpm run type-check` passes
- [ ] CI build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)