### PR TITLE
fix: resolve pre-existing lint errors blocking CI

### DIFF
--- a/app/(dashboard)/content/page.tsx
+++ b/app/(dashboard)/content/page.tsx
@@ -106,15 +106,15 @@ export function ContentListPage() {
     setItems(loadDrafts());
   }, []);
 
-  if (isLoading) return <LoadingSpinner size="lg" label="Loading..." />;
-  if (!isAuthenticated) return null;
-
   const handleItemClick = useCallback(
     (item: StoredContent) => {
       track(events.FEATURE_USED, { featureName: 'content_view', context: item.id });
     },
     [track, events]
   );
+
+  if (isLoading) return <LoadingSpinner size="lg" label="Loading..." />;
+  if (!isAuthenticated) return null;
 
   // ── Empty state ─────────────────────────────────────────────────────────
 
@@ -166,9 +166,7 @@ export function ContentListPage() {
                 <h3 className={styles.contentItemTitle}>{item.title || 'Untitled'}</h3>
                 <div className={styles.contentItemMeta}>
                   <span>{formatDate(item.createdAt)}</span>
-                  {item.body && (
-                    <span>{item.body.length} chars</span>
-                  )}
+                  {item.body && <span>{item.body.length} chars</span>}
                 </div>
               </div>
               <div className={styles.contentItemRight}>
@@ -177,9 +175,7 @@ export function ContentListPage() {
                     {enabledPlatforms.length} platform{enabledPlatforms.length !== 1 ? 's' : ''}
                   </span>
                 )}
-                <span className={getBadgeClass(item.status)}>
-                  {getDisplayStatus(item.status)}
-                </span>
+                <span className={getBadgeClass(item.status)}>{getDisplayStatus(item.status)}</span>
               </div>
             </Link>
           );

--- a/e2e/fixtures/auth.ts
+++ b/e2e/fixtures/auth.ts
@@ -44,6 +44,7 @@ type AuthFixtures = {
  * });
  * ```
  */
+/* eslint-disable react-hooks/rules-of-hooks -- Playwright's use() is not React's use() hook */
 export const test = base.extend<AuthFixtures>({
   authenticatedPage: async ({ browser }, use) => {
     // Try to reuse previously-saved auth state; fall back to fresh login


### PR DESCRIPTION
## Summary
- Move `useCallback` before early returns in content page (`rules-of-hooks`)
- Disable `react-hooks/rules-of-hooks` for Playwright auth fixture (Playwright's `use()` is not React's `use()` hook)
- Fix `jest.fn()` mock typing in scheduler tests (TS2345)

## Test plan
- [ ] `pnpm run lint` passes
- [ ] `pnpm run type-check` passes
- [ ] CI build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)