### PR TITLE
chore: rename phoenix-flow integration to baton

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -122,12 +122,13 @@ JWT_SECRET=your-secure-jwt-secret-key-here
 # IDENTITY_API_KEY=your-identity-api-key
 
 # ============================================
-# PHOENIX-FLOW TASK MANAGEMENT (Optional)
+# BATON TASK MANAGEMENT (Optional)
 # ============================================
-# Phoenix-Flow MCP server for task management with org context
-# Requires the phoenixFlow feature flag to be enabled
-# PHOENIX_FLOW_MCP_URL=https://your-phoenix-flow.railway.app/mcp
-# PHOENIX_FLOW_MCP_SECRET=your-mcp-secret
+# Baton MCP server for task management with org context
+# (Baton is the renamed phoenix-flow service)
+# Requires the `baton` feature flag to be enabled
+# BATON_MCP_URL=https://your-baton.railway.app/mcp
+# BATON_MCP_SECRET=your-mcp-secret
 # MCP_ORG_URL=https://your-mcp-org.railway.app
 # MCP_ORG_SECRET=your-org-secret
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,27 +60,27 @@ __tests__/        Jest test suites
 
 ## Key Pages
 
-| Route                 | Purpose                           |
-| --------------------- | --------------------------------- |
-| `/content`            | Content management list           |
-| `/content/new`        | Create new content                |
-| `/tasks`              | Kanban task board (phoenix-flow)  |
-| `/settings`           | User/account settings             |
-| `/settings/platforms` | Platform connection settings      |
-| `/pricing`            | Pricing page with tier comparison |
+| Route                 | Purpose                                          |
+| --------------------- | ------------------------------------------------ |
+| `/content`            | Content management list                          |
+| `/content/new`        | Create new content                               |
+| `/tasks`              | Kanban task board (baton, formerly phoenix-flow) |
+| `/settings`           | User/account settings                            |
+| `/settings/platforms` | Platform connection settings                     |
+| `/pricing`            | Pricing page with tier comparison                |
 
 ## Integrations
 
-### Phoenix-Flow (Task Management)
+### Baton (Task Management — formerly phoenix-flow)
 
-- **Client:** `lib/integrations/phoenix-flow.ts` -- MCP client for phoenix-flow server
+- **Client:** `lib/integrations/baton.ts` -- MCP client for baton server
 - **API routes:** `app/api/tasks/` (CRUD), `app/api/org/health/` (org metrics)
 - **UI:** `app/(dashboard)/tasks/page.tsx` -- Kanban board
-- **Feature flag:** `phoenixFlow` (disabled by default)
-- **Env vars:** `PHOENIX_FLOW_MCP_URL`, `PHOENIX_FLOW_MCP_SECRET`
-- Phoenix-flow exposes 9 MCP tools: list_projects, get_tasks, create_task, update_task, sync_to_yaml, get_org_roadmap, list_org_projects, search_org_tasks, get_org_health
+- **Feature flag:** `baton` (disabled by default)
+- **Env vars:** `BATON_MCP_URL`, `BATON_MCP_SECRET`
+- Baton exposes 9 MCP tools: list_projects, get_tasks, create_task, update_task, sync_to_yaml, get_org_roadmap, list_org_projects, search_org_tasks, get_org_health
 - Org-level tools (roadmap, health) are proxied from **mcp-org**
-- Connects to Retort -- agents read tasks from phoenix-flow via MCP
+- Connects to Retort -- agents read tasks from baton via MCP
 
 ## Teams
 

--- a/app/(dashboard)/tasks/page.tsx
+++ b/app/(dashboard)/tasks/page.tsx
@@ -2,12 +2,12 @@
 
 /**
  * Task Board Page
- * Kanban-style task management board powered by phoenix-flow MCP.
+ * Kanban-style task management board powered by baton MCP.
  */
 
 import { useState, useEffect, useCallback, type FormEvent } from 'react';
 import styles from '@/styles/Tasks.module.css';
-import type { Task, Project, CreateTaskInput } from '@/lib/integrations/phoenix-flow';
+import type { Task, Project, CreateTaskInput } from '@/lib/integrations/baton';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -370,9 +370,8 @@ export default function TasksPage() {
           <h2>Service Unavailable</h2>
           <p>{error}</p>
           <p>
-            Phoenix-Flow task management is not configured or the service is currently unreachable.
-            Enable it via the phoenixFlow feature flag and configure the PHOENIX_FLOW_MCP_URL
-            environment variable.
+            Baton task management is not configured or the service is currently unreachable. Enable
+            it via the `baton` feature flag and configure the BATON_MCP_URL environment variable.
           </p>
         </div>
       </div>

--- a/app/api/org/health/route.ts
+++ b/app/api/org/health/route.ts
@@ -1,16 +1,16 @@
 /**
  * Org Health API Route
- * GET - Organizational health metrics from mcp-org via phoenix-flow
+ * GET - Organizational health metrics from mcp-org via baton
  */
 
 import { NextRequest, NextResponse } from 'next/server';
 import { RateLimitPresets } from '@/app/api/_utils/rateLimit';
 import { checkAuthAndRateLimit, withErrorHandling } from '@/app/api/_utils/middleware';
-import { getOrgHealth, PhoenixFlowUnavailableError } from '@/lib/integrations/phoenix-flow';
+import { getOrgHealth, BatonUnavailableError } from '@/lib/integrations/baton';
 
 /**
  * GET /api/org/health
- * Returns org health metrics (proxied from mcp-org via phoenix-flow)
+ * Returns org health metrics (proxied from mcp-org via baton)
  */
 export const GET = withErrorHandling(async (request: Request) => {
   const nextRequest = request as NextRequest;
@@ -26,7 +26,7 @@ export const GET = withErrorHandling(async (request: Request) => {
     const health = await getOrgHealth();
     return NextResponse.json({ health });
   } catch (error: unknown) {
-    if (error instanceof PhoenixFlowUnavailableError) {
+    if (error instanceof BatonUnavailableError) {
       return NextResponse.json(
         { error: 'Organizational health service is unavailable' },
         { status: 503 }

--- a/app/api/tasks/[id]/route.ts
+++ b/app/api/tasks/[id]/route.ts
@@ -1,7 +1,7 @@
 /**
  * Single Task API Routes
- * GET   - Get task details (by filtering from phoenix-flow)
- * PATCH - Update a task via phoenix-flow MCP
+ * GET   - Get task details (by filtering from baton)
+ * PATCH - Update a task via baton MCP
  */
 
 import { NextRequest, NextResponse } from 'next/server';
@@ -10,7 +10,7 @@ import { RateLimitPresets } from '@/app/api/_utils/rateLimit';
 import { checkAuthAndRateLimit, withErrorHandling } from '@/app/api/_utils/middleware';
 import { ErrorResponses } from '@/app/api/_utils/responses';
 import { sanitizeText } from '@/app/api/_utils/sanitize';
-import { getTasks, updateTask, PhoenixFlowUnavailableError } from '@/lib/integrations/phoenix-flow';
+import { getTasks, updateTask, BatonUnavailableError } from '@/lib/integrations/baton';
 
 const VALID_TASK_STATUSES = ['todo', 'in_progress', 'done', 'blocked'] as const;
 const VALID_TASK_PRIORITIES = ['low', 'medium', 'high', 'critical'] as const;
@@ -62,7 +62,7 @@ export const GET = withErrorHandling(async (request: Request, { params }: RouteP
 
     return NextResponse.json({ task });
   } catch (error: unknown) {
-    if (error instanceof PhoenixFlowUnavailableError) {
+    if (error instanceof BatonUnavailableError) {
       return NextResponse.json(
         { error: 'Task management service is unavailable' },
         { status: 503 }
@@ -102,7 +102,7 @@ export const PATCH = withErrorHandling(async (request: Request, { params }: Rout
     const task = await updateTask(id, parseResult.data);
     return NextResponse.json({ task });
   } catch (error: unknown) {
-    if (error instanceof PhoenixFlowUnavailableError) {
+    if (error instanceof BatonUnavailableError) {
       return NextResponse.json(
         { error: 'Task management service is unavailable' },
         { status: 503 }

--- a/app/api/tasks/route.ts
+++ b/app/api/tasks/route.ts
@@ -1,7 +1,7 @@
 /**
  * Tasks API Routes
- * GET  - List tasks from phoenix-flow MCP
- * POST - Create a new task via phoenix-flow MCP
+ * GET  - List tasks from baton MCP
+ * POST - Create a new task via baton MCP
  */
 
 import { NextRequest, NextResponse } from 'next/server';
@@ -10,7 +10,7 @@ import { RateLimitPresets } from '@/app/api/_utils/rateLimit';
 import { checkAuthAndRateLimit, withErrorHandling } from '@/app/api/_utils/middleware';
 import { ErrorResponses } from '@/app/api/_utils/responses';
 import { sanitizeText } from '@/app/api/_utils/sanitize';
-import { getTasks, createTask, PhoenixFlowUnavailableError } from '@/lib/integrations/phoenix-flow';
+import { getTasks, createTask, BatonUnavailableError } from '@/lib/integrations/baton';
 
 // Valid status and priority values
 const VALID_TASK_STATUSES = ['todo', 'in_progress', 'done', 'blocked'] as const;
@@ -69,7 +69,7 @@ export const GET = withErrorHandling(async (request: Request) => {
     const tasks = await getTasks(projectId, status);
     return NextResponse.json({ tasks });
   } catch (error: unknown) {
-    if (error instanceof PhoenixFlowUnavailableError) {
+    if (error instanceof BatonUnavailableError) {
       return NextResponse.json(
         { error: 'Task management service is unavailable', tasks: [] },
         { status: 503 }
@@ -108,7 +108,7 @@ export const POST = withErrorHandling(async (request: Request) => {
     const task = await createTask(parseResult.data);
     return NextResponse.json({ task }, { status: 201 });
   } catch (error: unknown) {
-    if (error instanceof PhoenixFlowUnavailableError) {
+    if (error instanceof BatonUnavailableError) {
       return NextResponse.json(
         { error: 'Task management service is unavailable' },
         { status: 503 }

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -17,7 +17,7 @@
 | **Azure PostgreSQL**     | `infra/postgresql.bicep`                              | Free-tier Flexible Server (B1ms) for persistent user storage.                                                     |
 | **Retort Orchestration** | `.agentkit/spec/*.yaml`                               | Single-source YAML spec generating configs for 16+ AI tools.                                                      |
 | **Agent Rules**          | `.cursor/rules/` (10), `.windsurf/rules/` (10)        | Team-scoped coding rules for Claude, Cursor, Windsurf, Copilot.                                                   |
-| **Phoenix-Flow**         | `lib/integrations/phoenix-flow.ts`                    | MCP client for task management + org context (proxies mcp-org). Feature-flagged (`phoenixFlow`).                  |
+| **Baton**                | `lib/integrations/baton.ts`                           | MCP client for task management + org context (proxies mcp-org). Feature-flagged (`baton`). Formerly phoenix-flow. |
 
 ### Application Layer
 
@@ -28,7 +28,7 @@
 | **User Persistence**  | `app/api/auth/route.ts`, `prisma/schema.prisma`                                      | Registration/login backed by Prisma/PostgreSQL (replaced in-memory Map).                                                 |
 | **Analytics**         | `lib/analytics/`, `app/api/analytics/events/`, `hooks/useAnalytics.ts`               | AARRR event tracking with batched client tracker, wired into all pages.                                                  |
 | **Content Creation**  | `app/(dashboard)/content/new/`, `app/(dashboard)/content/`                           | Write → adapt per platform → schedule/publish flow.                                                                      |
-| **Task Board**        | `app/(dashboard)/tasks/`, `app/api/tasks/`                                           | Kanban board connected to phoenix-flow MCP.                                                                              |
+| **Task Board**        | `app/(dashboard)/tasks/`, `app/api/tasks/`                                           | Kanban board connected to baton MCP.                                                                                     |
 | **Platform Settings** | `app/(dashboard)/settings/platforms/`                                                | Connect/disconnect platforms with mock OAuth (real OAuth ready).                                                         |
 
 ### Marketing Layer
@@ -52,7 +52,7 @@
 | Dashboard         | `/dashboard`          | Client, metrics + Airtable                       |
 | Content List      | `/content`            | Client, draft/scheduled/published list           |
 | Content Create    | `/content/new`        | Client, write → adapt → schedule                 |
-| Tasks             | `/tasks`              | Client, Kanban board (phoenix-flow)              |
+| Tasks             | `/tasks`              | Client, Kanban board (baton)                     |
 | Settings          | `/settings`           | Client, settings hub                             |
 | Platform Settings | `/settings/platforms` | Client, connect/disconnect platforms             |
 
@@ -70,17 +70,17 @@
 
 ## Feature Flags
 
-| Flag                       | Default | Controls                                 |
-| -------------------------- | ------- | ---------------------------------------- |
-| `aiGateway`                | `false` | Sluice AI gateway routing                |
-| `externalIdentityProvider` | `false` | Social login via external identity API   |
-| `phoenixFlow`              | `false` | Task board + org context via MCP         |
-| `textParser`               | `true`  | AI text parsing (OpenAI/DeepSeek/Azure)  |
-| `imageGeneration`          | `true`  | AI image generation (HuggingFace/DALL-E) |
-| `summarization`            | `true`  | AI text summarization                    |
-| `leadManagement`           | `true`  | CRM lead management                      |
-| `outreachSequences`        | `true`  | Email/LinkedIn sequences                 |
-| `crmDashboard`             | `true`  | CRM analytics dashboard                  |
+| Flag                       | Default | Controls                                                |
+| -------------------------- | ------- | ------------------------------------------------------- |
+| `aiGateway`                | `false` | Sluice AI gateway routing                               |
+| `externalIdentityProvider` | `false` | Social login via external identity API                  |
+| `baton`                    | `false` | Task board + org context via MCP (formerly phoenixFlow) |
+| `textParser`               | `true`  | AI text parsing (OpenAI/DeepSeek/Azure)                 |
+| `imageGeneration`          | `true`  | AI image generation (HuggingFace/DALL-E)                |
+| `summarization`            | `true`  | AI text summarization                                   |
+| `leadManagement`           | `true`  | CRM lead management                                     |
+| `outreachSequences`        | `true`  | Email/LinkedIn sequences                                |
+| `crmDashboard`             | `true`  | CRM analytics dashboard                                 |
 
 ---
 
@@ -104,9 +104,9 @@ SLUICE_API_KEY=
 IDENTITY_API_URL=
 IDENTITY_API_KEY=
 
-# Optional — Phoenix-Flow
-PHOENIX_FLOW_MCP_URL=
-PHOENIX_FLOW_MCP_SECRET=
+# Optional — Baton (formerly phoenix-flow)
+BATON_MCP_URL=
+BATON_MCP_SECRET=
 
 # Optional — Platforms
 FACEBOOK_API_KEY=
@@ -171,14 +171,14 @@ pnpm test:e2e               # Playwright E2E tests (needs running dev server)
 
 ## Ecosystem Integrations
 
-| System               | Status                   | Connection                                             |
-| -------------------- | ------------------------ | ------------------------------------------------------ |
-| **Retort**           | Active                   | `.agentkit/spec/` → generates agent configs            |
-| **MarketingSkills**  | Active                   | 34 skills in `.agents/skills/`, validated              |
-| **Sluice**           | Ready (flag off)         | `lib/clients/sluice-gateway.ts` + `infra/sluice.bicep` |
-| **Phoenix-Flow**     | Ready (flag off)         | `lib/integrations/phoenix-flow.ts` + task board UI     |
-| **mcp-org**          | Ready (via phoenix-flow) | Org context proxied through phoenix-flow MCP           |
-| **Azure PostgreSQL** | Ready                    | `infra/postgresql.bicep` (free tier)                   |
+| System               | Status            | Connection                                                          |
+| -------------------- | ----------------- | ------------------------------------------------------------------- |
+| **Retort**           | Active            | `.agentkit/spec/` → generates agent configs                         |
+| **MarketingSkills**  | Active            | 34 skills in `.agents/skills/`, validated                           |
+| **Sluice**           | Ready (flag off)  | `lib/clients/sluice-gateway.ts` + `infra/sluice.bicep`              |
+| **Baton**            | Ready (flag off)  | `lib/integrations/baton.ts` + task board UI (formerly phoenix-flow) |
+| **mcp-org**          | Ready (via baton) | Org context proxied through baton MCP                               |
+| **Azure PostgreSQL** | Ready             | `infra/postgresql.bicep` (free tier)                                |
 
 ---
 

--- a/lib/featureFlags.ts
+++ b/lib/featureFlags.ts
@@ -74,7 +74,7 @@ export interface ExternalIdentityProviderFeatureFlag {
   apiUrl?: string;
 }
 
-export interface PhoenixFlowFeatureFlag {
+export interface BatonFeatureFlag {
   enabled: boolean;
   mcpUrl?: string;
 }
@@ -99,8 +99,8 @@ interface BaseFeatureFlags {
   aiGateway: AIGatewayFeatureFlag;
   // External Identity Provider
   externalIdentityProvider: ExternalIdentityProviderFeatureFlag;
-  // Phoenix-Flow Task Management (MCP)
-  phoenixFlow: PhoenixFlowFeatureFlag;
+  // Baton Task Management (MCP) — formerly phoenix-flow
+  baton: BatonFeatureFlag;
 }
 
 // Extend the base interface with an index signature for dynamic access
@@ -226,8 +226,8 @@ const featureFlags: FeatureFlags = {
   externalIdentityProvider: {
     enabled: false,
   },
-  // Phoenix-Flow Task Management - disabled by default
-  phoenixFlow: {
+  // Baton Task Management - disabled by default (formerly phoenix-flow)
+  baton: {
     enabled: false,
   },
 };

--- a/lib/integrations/baton.ts
+++ b/lib/integrations/baton.ts
@@ -1,9 +1,11 @@
 /**
- * Phoenix-Flow MCP Client Integration
+ * Baton MCP Client Integration
  *
- * Connects to phoenix-flow's MCP server for task management
+ * Connects to baton's MCP server for task management
  * with Portfolio -> Project -> Task hierarchy.
- * Phoenix-flow proxies org-level data from mcp-org.
+ * Baton proxies org-level data from mcp-org.
+ *
+ * Note: baton is the renamed phoenixvc/phoenix-flow service.
  */
 
 import featureFlags from '@/lib/featureFlags';
@@ -12,7 +14,7 @@ import featureFlags from '@/lib/featureFlags';
 // Types
 // ---------------------------------------------------------------------------
 
-export interface PhoenixFlowConfig {
+export interface BatonConfig {
   mcpUrl: string;
   mcpSecret: string;
 }
@@ -83,15 +85,15 @@ interface McpToolResult<T> {
 
 const REQUEST_TIMEOUT_MS = 10_000;
 
-function getConfig(): PhoenixFlowConfig | null {
-  const phoenixFlow = featureFlags.phoenixFlow as { enabled: boolean; mcpUrl?: string } | undefined;
+function getConfig(): BatonConfig | null {
+  const baton = featureFlags.baton as { enabled: boolean; mcpUrl?: string } | undefined;
 
-  if (!phoenixFlow?.enabled) {
+  if (!baton?.enabled) {
     return null;
   }
 
-  const mcpUrl = phoenixFlow.mcpUrl || process.env.PHOENIX_FLOW_MCP_URL;
-  const mcpSecret = process.env.PHOENIX_FLOW_MCP_SECRET;
+  const mcpUrl = baton.mcpUrl || process.env.BATON_MCP_URL;
+  const mcpSecret = process.env.BATON_MCP_SECRET;
 
   if (!mcpUrl || !mcpSecret) {
     return null;
@@ -107,7 +109,7 @@ function getConfig(): PhoenixFlowConfig | null {
 async function callMcpTool<T>(toolName: string, params: Record<string, unknown> = {}): Promise<T> {
   const config = getConfig();
   if (!config) {
-    throw new PhoenixFlowUnavailableError('Phoenix-Flow integration is not configured or disabled');
+    throw new BatonUnavailableError('Baton integration is not configured or disabled');
   }
 
   const controller = new AbortController();
@@ -126,24 +128,22 @@ async function callMcpTool<T>(toolName: string, params: Record<string, unknown> 
 
     if (!response.ok) {
       const errorText = await response.text().catch(() => 'Unknown error');
-      throw new Error(
-        `Phoenix-Flow MCP call "${toolName}" failed: ${response.status} ${errorText}`
-      );
+      throw new Error(`Baton MCP call "${toolName}" failed: ${response.status} ${errorText}`);
     }
 
     const data = (await response.json()) as McpToolResult<T>;
     return data.result;
   } catch (error: unknown) {
-    if (error instanceof PhoenixFlowUnavailableError) {
+    if (error instanceof BatonUnavailableError) {
       throw error;
     }
     if (error instanceof DOMException && error.name === 'AbortError') {
-      throw new PhoenixFlowUnavailableError(
-        `Phoenix-Flow MCP call "${toolName}" timed out after ${REQUEST_TIMEOUT_MS}ms`
+      throw new BatonUnavailableError(
+        `Baton MCP call "${toolName}" timed out after ${REQUEST_TIMEOUT_MS}ms`
       );
     }
-    throw new PhoenixFlowUnavailableError(
-      `Phoenix-Flow MCP call "${toolName}" failed: ${error instanceof Error ? error.message : String(error)}`
+    throw new BatonUnavailableError(
+      `Baton MCP call "${toolName}" failed: ${error instanceof Error ? error.message : String(error)}`
     );
   } finally {
     clearTimeout(timeout);
@@ -154,10 +154,10 @@ async function callMcpTool<T>(toolName: string, params: Record<string, unknown> 
 // Error class
 // ---------------------------------------------------------------------------
 
-export class PhoenixFlowUnavailableError extends Error {
+export class BatonUnavailableError extends Error {
   constructor(message: string) {
     super(message);
-    this.name = 'PhoenixFlowUnavailableError';
+    this.name = 'BatonUnavailableError';
   }
 }
 
@@ -166,7 +166,7 @@ export class PhoenixFlowUnavailableError extends Error {
 // ---------------------------------------------------------------------------
 
 /**
- * List all projects from phoenix-flow.
+ * List all projects from baton.
  */
 export async function listProjects(): Promise<Project[]> {
   return callMcpTool<Project[]>('list_projects');
@@ -221,8 +221,8 @@ export async function syncToYaml(): Promise<{ success: boolean }> {
 }
 
 /**
- * Check whether phoenix-flow is available and enabled.
+ * Check whether baton is available and enabled.
  */
-export function isPhoenixFlowEnabled(): boolean {
+export function isBatonEnabled(): boolean {
   return getConfig() !== null;
 }


### PR DESCRIPTION
## Summary

Tracks the upstream rename of `phoenixvc/phoenix-flow` → `phoenixvc/baton` (2026-04-26). Mechanical rename of every reference in the MCP integration layer.

## Changes

| Old | New |
|---|---|
| `lib/integrations/phoenix-flow.ts` | `lib/integrations/baton.ts` |
| `PhoenixFlowConfig` | `BatonConfig` |
| `PhoenixFlowFeatureFlag` | `BatonFeatureFlag` |
| `PhoenixFlowUnavailableError` | `BatonUnavailableError` |
| `isPhoenixFlowEnabled()` | `isBatonEnabled()` |
| `featureFlags.phoenixFlow` | `featureFlags.baton` |
| `PHOENIX_FLOW_MCP_URL` | `BATON_MCP_URL` |
| `PHOENIX_FLOW_MCP_SECRET` | `BATON_MCP_SECRET` |

Files touched: 9 (1 rename + 8 modifications). No behaviour change.

## Breaking changes

Anyone with a saved `data/feature-flags.json` or `.env.local` needs to re-key:
- `phoenixFlow` → `baton` in feature-flags JSON
- `PHOENIX_FLOW_MCP_*` → `BATON_MCP_*` in env vars

The `baton` flag is `false` by default (was `phoenixFlow: false`), so the visible-in-UI surface only triggers if someone has explicitly enabled the integration.

## Verification

- [x] `pnpm type-check` passes (clean repo, after `rm -rf .next`)
- [x] Pre-commit hook (lint-staged: eslint + prettier) passed
- [ ] `pnpm test` — not run locally (DB not configured); CI will cover
- [ ] Manual smoke test of `/tasks` page against a baton MCP — out of scope here, lives in baton repo verification

## Context

- Rename rationale: `phoenix-flow` was an outlier in the phoenixvc org's naming pattern. Internal tools use short single-word names (`deck`, `docket`, `sluice`, `retort`, `mcp-org`); the `phoenix-` prefix is reserved for org-facing brand products.
- Repo registry entry: `org-meta/registry/projects.yaml` (`aliases: [phoenix-flow, ai-cadence]`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)