### PR TITLE
chore(infra): rename to omnipost, drop region suffix per ADR-0027

### DIFF
--- a/.agentkit/spec/project.yaml
+++ b/.agentkit/spec/project.yaml
@@ -7,7 +7,7 @@ project:
   tagline: "One platform. All channels."
   type: SaaS
   repository: https://github.com/phoenixvc/omnipost
-  live_url: https://nl-dev-omnipost-app-euw.azurewebsites.net
+  live_url: https://nl-dev-omnipost-app.azurewebsites.net
 
 stack:
   framework: Next.js 16

--- a/.agents/context/product-marketing-context.md
+++ b/.agents/context/product-marketing-context.md
@@ -10,7 +10,7 @@ AI agents should read this before using any marketing skill.
 - **Category**: SaaS Multi-Platform Content Publishing
 - **Type**: B2B/B2C web application
 - **License**: MIT (open-source)
-- **Live Demo**: https://nl-dev-omnipost-app-euw.azurewebsites.net
+- **Live Demo**: https://nl-dev-omnipost-app.azurewebsites.net
 
 ## Target Users
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -3,7 +3,7 @@
 ## 📌 Quick Reference
 
 **Repository:** phoenixvc/omnipost  
-**Live Demo:** [https://nl-dev-omnipost-app-euw.azurewebsites.net](https://nl-dev-omnipost-app-euw.azurewebsites.net)
+**Live Demo:** [https://nl-dev-omnipost-app.azurewebsites.net](https://nl-dev-omnipost-app.azurewebsites.net)
 
 ## Project Overview
 
@@ -862,7 +862,7 @@ pnpm install
 **Last Updated:** March 30, 2026
 **Maintained By:** Development Team
 **Questions?** See CONTRIBUTING.md or create an issue
-**Live Demo:** https://nl-dev-omnipost-app-euw.azurewebsites.net
+**Live Demo:** https://nl-dev-omnipost-app.azurewebsites.net
 
 ---
 

--- a/.github/workflows/azure-webapps-node.yml
+++ b/.github/workflows/azure-webapps-node.yml
@@ -19,7 +19,7 @@ env:
   NODE_VERSION: '20.x'
   AZURE_WEBAPP_PACKAGE_PATH: '.'
   ORG_CODE: 'nl'
-  PROJECT_NAME: 'cc'
+  PROJECT_NAME: 'omnipost'
   REGION_CODE: 'euw'
   LOCATION: 'westeurope'
 

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -18,7 +18,7 @@ env:
   NODE_VERSION: '20.x'
   AZURE_WEBAPP_PACKAGE_PATH: '.'
   ORG_CODE: 'nl'
-  PROJECT_NAME: 'cc'
+  PROJECT_NAME: 'omnipost'
   REGION_CODE: 'euw'
   LOCATION: 'westeurope'
   DNS_ZONE: 'nexamesh.ai'
@@ -211,12 +211,12 @@ jobs:
         with:
           inlineScript: |
             # Get the default hostname
-            HOSTNAME=$(az webapp show --name ${{ needs.infrastructure.outputs.app_name }} --resource-group ${{ env.ORG_CODE }}-prod-${{ env.PROJECT_NAME }}-rg-${{ env.REGION_CODE }} --query defaultHostName -o tsv)
+            HOSTNAME=$(az webapp show --name ${{ needs.infrastructure.outputs.app_name }} --resource-group ${{ env.ORG_CODE }}-prod-${{ env.PROJECT_NAME }}-rg --query defaultHostName -o tsv)
             echo "WEBAPP_HOSTNAME=${HOSTNAME}" >> $GITHUB_OUTPUT
             echo "Web App hostname: ${HOSTNAME}"
 
             # Get the custom domain verification ID for TXT record
-            VERIFICATION_ID=$(az webapp show --name ${{ needs.infrastructure.outputs.app_name }} --resource-group ${{ env.ORG_CODE }}-prod-${{ env.PROJECT_NAME }}-rg-${{ env.REGION_CODE }} --query customDomainVerificationId -o tsv)
+            VERIFICATION_ID=$(az webapp show --name ${{ needs.infrastructure.outputs.app_name }} --resource-group ${{ env.ORG_CODE }}-prod-${{ env.PROJECT_NAME }}-rg --query customDomainVerificationId -o tsv)
             echo "VERIFICATION_ID=${VERIFICATION_ID}" >> $GITHUB_OUTPUT
             echo "Domain verification ID retrieved"
 
@@ -431,7 +431,7 @@ jobs:
           echo "## 🚀 Deployment Summary" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "### URLs" >> $GITHUB_STEP_SUMMARY
-          echo "- **Azure URL:** https://${{ env.ORG_CODE }}-prod-${{ env.PROJECT_NAME }}-app-${{ env.REGION_CODE }}.azurewebsites.net" >> $GITHUB_STEP_SUMMARY
+          echo "- **Azure URL:** https://${{ env.ORG_CODE }}-prod-${{ env.PROJECT_NAME }}-app.azurewebsites.net" >> $GITHUB_STEP_SUMMARY
 
           if [ "${ENABLE_CUSTOM_DOMAIN}" = "true" ]; then
             echo "- **Custom Domain:** https://${{ env.APP_SUBDOMAIN }}.${{ env.DNS_ZONE }}" >> $GITHUB_STEP_SUMMARY

--- a/AZURE_DEPLOYMENT_FIX.md
+++ b/AZURE_DEPLOYMENT_FIX.md
@@ -100,7 +100,7 @@ The fix will be applied automatically on the next deployment:
 3. **Verify Health Endpoint**:
 
    ```bash
-   curl https://nl-dev-omnipost-app-euw.azurewebsites.net/api/health
+   curl https://nl-dev-omnipost-app.azurewebsites.net/api/health
    ```
 
    Expected response:
@@ -118,8 +118,8 @@ The fix will be applied automatically on the next deployment:
 4. **Check Azure Logs**:
 
    ```bash
-   az webapp log tail --name nl-dev-omnipost-app-euw \
-     --resource-group nl-dev-omnipost-rg-euw
+   az webapp log tail --name nl-dev-omnipost-app \
+     --resource-group nl-dev-omnipost-rg
    ```
 
    You should see:
@@ -138,13 +138,13 @@ The fix will be applied automatically on the next deployment:
 If you need to fix an existing deployment immediately without redeploying infrastructure:
 
 ```bash
-az webapp config set --name nl-dev-omnipost-app-euw \
-  --resource-group nl-dev-omnipost-rg-euw \
+az webapp config set --name nl-dev-omnipost-app \
+  --resource-group nl-dev-omnipost-rg \
   --startup-file "node server.js"
 
 # Restart the app
-az webapp restart --name nl-dev-omnipost-app-euw \
-  --resource-group nl-dev-omnipost-rg-euw
+az webapp restart --name nl-dev-omnipost-app \
+  --resource-group nl-dev-omnipost-rg
 ```
 
 **Note**: This is temporary. The next infrastructure deployment will apply the permanent fix from the Bicep template.

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -6,7 +6,7 @@
 import type { MetadataRoute } from 'next';
 
 const BASE_URL =
-  process.env.NEXT_PUBLIC_SITE_URL || 'https://nl-dev-omnipost-app-euw.azurewebsites.net';
+  process.env.NEXT_PUBLIC_SITE_URL || 'https://nl-dev-omnipost-app.azurewebsites.net';
 
 export default function robots(): MetadataRoute.Robots {
   const isProduction = process.env.NODE_ENV === 'production';

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -6,7 +6,7 @@
 import type { MetadataRoute } from 'next';
 
 const BASE_URL =
-  process.env.NEXT_PUBLIC_SITE_URL || 'https://nl-dev-omnipost-app-euw.azurewebsites.net';
+  process.env.NEXT_PUBLIC_SITE_URL || 'https://nl-dev-omnipost-app.azurewebsites.net';
 const lastModified = new Date('2026-03-30');
 
 export default function sitemap(): MetadataRoute.Sitemap {

--- a/docs/AZURE_SECRETS.md
+++ b/docs/AZURE_SECRETS.md
@@ -22,8 +22,8 @@ The application requires several environment variables and secrets to function p
 - **How to Set:**
   ```bash
   az webapp config appsettings set \
-    --name nl-dev-omnipost-app-euw \
-    --resource-group nl-dev-omnipost-rg-euw \
+    --name nl-dev-omnipost-app \
+    --resource-group nl-dev-omnipost-rg \
     --settings JWT_SECRET="your-generated-secret-here"
   ```
 
@@ -35,8 +35,8 @@ Configure these only if you're using the respective integrations:
 
 ```bash
 az webapp config appsettings set \
-  --name nl-dev-omnipost-app-euw \
-  --resource-group nl-dev-omnipost-rg-euw \
+  --name nl-dev-omnipost-app \
+  --resource-group nl-dev-omnipost-rg \
   --settings \
     AIRTABLE_API_KEY="your-api-key" \
     AIRTABLE_BASE_ID="your-base-id" \
@@ -47,8 +47,8 @@ az webapp config appsettings set \
 
 ```bash
 az webapp config appsettings set \
-  --name nl-dev-omnipost-app-euw \
-  --resource-group nl-dev-omnipost-rg-euw \
+  --name nl-dev-omnipost-app \
+  --resource-group nl-dev-omnipost-rg \
   --settings HUGGING_FACE_API_KEY="your-api-key"
 ```
 
@@ -56,8 +56,8 @@ az webapp config appsettings set \
 
 ```bash
 az webapp config appsettings set \
-  --name nl-dev-omnipost-app-euw \
-  --resource-group nl-dev-omnipost-rg-euw \
+  --name nl-dev-omnipost-app \
+  --resource-group nl-dev-omnipost-rg \
   --settings \
     EMAIL_USER="your-email@gmail.com" \
     GMAIL_CLIENT_ID="your-client-id" \
@@ -69,8 +69,8 @@ az webapp config appsettings set \
 
 ```bash
 az webapp config appsettings set \
-  --name nl-dev-omnipost-app-euw \
-  --resource-group nl-dev-omnipost-rg-euw \
+  --name nl-dev-omnipost-app \
+  --resource-group nl-dev-omnipost-rg \
   --settings SLACK_TOKEN="xoxb-your-slack-bot-token"
 ```
 
@@ -78,8 +78,8 @@ az webapp config appsettings set \
 
 ```bash
 az webapp config appsettings set \
-  --name nl-dev-omnipost-app-euw \
-  --resource-group nl-dev-omnipost-rg-euw \
+  --name nl-dev-omnipost-app \
+  --resource-group nl-dev-omnipost-rg \
   --settings \
     TWILIO_ACCOUNT_SID="your-account-sid" \
     TWILIO_AUTH_TOKEN="your-auth-token" \
@@ -91,32 +91,32 @@ az webapp config appsettings set \
 ```bash
 # Facebook
 az webapp config appsettings set \
-  --name nl-dev-omnipost-app-euw \
-  --resource-group nl-dev-omnipost-rg-euw \
+  --name nl-dev-omnipost-app \
+  --resource-group nl-dev-omnipost-rg \
   --settings \
     FACEBOOK_API_URL="https://graph.facebook.com" \
     FACEBOOK_API_KEY="your-api-key"
 
 # Instagram
 az webapp config appsettings set \
-  --name nl-dev-omnipost-app-euw \
-  --resource-group nl-dev-omnipost-rg-euw \
+  --name nl-dev-omnipost-app \
+  --resource-group nl-dev-omnipost-rg \
   --settings \
     INSTAGRAM_API_URL="https://graph.instagram.com" \
     INSTAGRAM_API_KEY="your-api-key"
 
 # LinkedIn
 az webapp config appsettings set \
-  --name nl-dev-omnipost-app-euw \
-  --resource-group nl-dev-omnipost-rg-euw \
+  --name nl-dev-omnipost-app \
+  --resource-group nl-dev-omnipost-rg \
   --settings \
     LINKEDIN_API_URL="https://api.linkedin.com" \
     LINKEDIN_API_KEY="your-api-key"
 
 # Twitter/X
 az webapp config appsettings set \
-  --name nl-dev-omnipost-app-euw \
-  --resource-group nl-dev-omnipost-rg-euw \
+  --name nl-dev-omnipost-app \
+  --resource-group nl-dev-omnipost-rg \
   --settings \
     TWITTER_API_URL="https://api.twitter.com" \
     TWITTER_API_KEY="your-api-key"
@@ -127,8 +127,8 @@ az webapp config appsettings set \
 ```bash
 # Sluice gateway URL and API key
 az webapp config appsettings set \
-  --name nl-dev-omnipost-app-euw \
-  --resource-group nl-dev-omnipost-rg-euw \
+  --name nl-dev-omnipost-app \
+  --resource-group nl-dev-omnipost-rg \
   --settings \
     SLUICE_GATEWAY_URL="https://nl-dev-omnipost-sluice-euw.azurecontainerapps.io" \
     SLUICE_API_KEY="your-gateway-api-key"
@@ -140,7 +140,7 @@ az webapp config appsettings set \
 
 Alternatively, you can configure these via the Azure Portal:
 
-1. Navigate to your App Service: `nl-dev-omnipost-app-euw`
+1. Navigate to your App Service: `nl-dev-omnipost-app`
 2. Go to **Settings** → **Configuration**
 3. Click **+ New application setting**
 4. Add each setting with its value
@@ -154,7 +154,7 @@ For production environments, store secrets in Azure Key Vault and reference them
 
    ```bash
    az keyvault secret set \
-     --vault-name nl-prod-content-creation-kv-euw \
+     --vault-name nl-prod-omnipost-kv \
      --name JWT-SECRET \
      --value "your-secret-value"
    ```
@@ -163,9 +163,9 @@ For production environments, store secrets in Azure Key Vault and reference them
 
    ```bash
    az webapp config appsettings set \
-     --name nl-prod-content-creation-app-euw \
-     --resource-group nl-prod-content-creation-rg-euw \
-     --settings JWT_SECRET="@Microsoft.KeyVault(VaultName=nl-prod-content-creation-kv-euw;SecretName=JWT-SECRET)"
+     --name nl-prod-omnipost-app \
+     --resource-group nl-prod-omnipost-rg \
+     --settings JWT_SECRET="@Microsoft.KeyVault(VaultName=nl-prod-omnipost-kv;SecretName=JWT-SECRET)"
    ```
 
 3. **Grant App Service access to Key Vault:**
@@ -173,18 +173,18 @@ For production environments, store secrets in Azure Key Vault and reference them
    ```bash
    # Enable managed identity
    az webapp identity assign \
-     --name nl-prod-content-creation-app-euw \
-     --resource-group nl-prod-content-creation-rg-euw
+     --name nl-prod-omnipost-app \
+     --resource-group nl-prod-omnipost-rg
 
    # Get the principal ID
    PRINCIPAL_ID=$(az webapp identity show \
-     --name nl-prod-content-creation-app-euw \
-     --resource-group nl-prod-content-creation-rg-euw \
+     --name nl-prod-omnipost-app \
+     --resource-group nl-prod-omnipost-rg \
      --query principalId -o tsv)
 
    # Grant access to Key Vault
    az keyvault set-policy \
-     --name nl-prod-content-creation-kv-euw \
+     --name nl-prod-omnipost-kv \
      --object-id $PRINCIPAL_ID \
      --secret-permissions get list
    ```
@@ -196,13 +196,13 @@ After setting secrets, verify they're available:
 ```bash
 # List all app settings
 az webapp config appsettings list \
-  --name nl-dev-omnipost-app-euw \
-  --resource-group nl-dev-omnipost-rg-euw \
+  --name nl-dev-omnipost-app \
+  --resource-group nl-dev-omnipost-rg \
   --query "[].{Name:name, Value:value}" \
   --output table
 
 # Test the health endpoint
-curl https://nl-dev-omnipost-app-euw.azurewebsites.net/api/health
+curl https://nl-dev-omnipost-app.azurewebsites.net/api/health
 ```
 
 ## GitHub Secrets for CI/CD

--- a/docs/AZURE_SECRETS.md
+++ b/docs/AZURE_SECRETS.md
@@ -124,13 +124,23 @@ az webapp config appsettings set \
 
 ### Sluice AI Gateway
 
+The Sluice gateway is deployed as an Azure Container App. ACA hostnames include a
+managed-environment hash that is allocated at deploy time and cannot be predicted
+statically — fetch the FQDN after the gateway is deployed:
+
 ```bash
-# Sluice gateway URL and API key
+# Look up the actual FQDN after deploy (replace <rg> with your resource group)
+SLUICE_GATEWAY_URL="https://$(az containerapp show \
+  -n nl-dev-omnipost-sluice \
+  -g nl-dev-omnipost-rg \
+  --query properties.configuration.ingress.fqdn -o tsv)"
+
+# Then apply it to the app settings
 az webapp config appsettings set \
   --name nl-dev-omnipost-app \
   --resource-group nl-dev-omnipost-rg \
   --settings \
-    SLUICE_GATEWAY_URL="https://nl-dev-omnipost-sluice-euw.azurecontainerapps.io" \
+    SLUICE_GATEWAY_URL="$SLUICE_GATEWAY_URL" \
     SLUICE_API_KEY="your-gateway-api-key"
 ```
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -155,7 +155,7 @@ If automatic DNS fails, configure manually:
 # Set variables
 DNS_ZONE="nexamesh.ai"
 DNS_RG="rg-dns-global"
-APP_HOSTNAME="nl-prod-content-creation-app-euw.azurewebsites.net"
+APP_HOSTNAME="nl-prod-omnipost-app.azurewebsites.net"
 
 # Create CNAME for main app
 az network dns record-set cname create \
@@ -225,8 +225,8 @@ If you encounter this issue:
 2. Redeploy infrastructure: The GitHub Actions workflow will update this automatically
 3. Manual fix (temporary):
    ```bash
-   az webapp config set --name nl-dev-omnipost-app-euw \
-     --resource-group nl-dev-omnipost-rg-euw \
+   az webapp config set --name nl-dev-omnipost-app \
+     --resource-group nl-dev-omnipost-rg \
      --startup-file "node server.js"
    ```
 
@@ -281,17 +281,17 @@ If you encounter this issue:
 
 ```bash
 # View app logs
-az webapp log tail --name nl-prod-content-creation-app-euw \
-  --resource-group nl-prod-content-creation-rg-euw
+az webapp log tail --name nl-prod-omnipost-app \
+  --resource-group nl-prod-omnipost-rg
 
 # Check app status
-az webapp show --name nl-prod-content-creation-app-euw \
-  --resource-group nl-prod-content-creation-rg-euw \
+az webapp show --name nl-prod-omnipost-app \
+  --resource-group nl-prod-omnipost-rg \
   --query state
 
 # List custom domains
-az webapp show --name nl-prod-content-creation-app-euw \
-  --resource-group nl-prod-content-creation-rg-euw \
+az webapp show --name nl-prod-omnipost-app \
+  --resource-group nl-prod-omnipost-rg \
   --query hostNames
 
 # View DNS records
@@ -299,8 +299,8 @@ az network dns record-set list --zone-name nexamesh.ai \
   --resource-group rg-dns-global --output table
 
 # Restart app
-az webapp restart --name nl-prod-content-creation-app-euw \
-  --resource-group nl-prod-content-creation-rg-euw
+az webapp restart --name nl-prod-omnipost-app \
+  --resource-group nl-prod-omnipost-rg
 ```
 
 ### Support Resources
@@ -315,17 +315,17 @@ az webapp restart --name nl-prod-content-creation-app-euw \
 
 ### URLs
 
-| Environment   | URL                                                          |
-| ------------- | ------------------------------------------------------------ |
-| Dev           | `https://nl-dev-content-creation-app-euw.azurewebsites.net`  |
-| Prod (Azure)  | `https://nl-prod-content-creation-app-euw.azurewebsites.net` |
-| Prod (Custom) | `https://omnipost.nexamesh.ai`                               |
-| API (Custom)  | `https://api.omnipost.nexamesh.ai`                           |
+| Environment   | URL                                              |
+| ------------- | ------------------------------------------------ |
+| Dev           | `https://nl-dev-omnipost-app.azurewebsites.net`  |
+| Prod (Azure)  | `https://nl-prod-omnipost-app.azurewebsites.net` |
+| Prod (Custom) | `https://omnipost.nexamesh.ai`                   |
+| API (Custom)  | `https://api.omnipost.nexamesh.ai`               |
 
 ### Resource Groups
 
-| Environment | Resource Group                    |
-| ----------- | --------------------------------- |
-| Dev         | `nl-dev-content-creation-rg-euw`  |
-| Prod        | `nl-prod-content-creation-rg-euw` |
-| DNS         | `rg-dns-global`                   |
+| Environment | Resource Group        |
+| ----------- | --------------------- |
+| Dev         | `nl-dev-omnipost-rg`  |
+| Prod        | `nl-prod-omnipost-rg` |
+| DNS         | `rg-dns-global`       |

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -57,13 +57,17 @@ infra/
 
 ### Resources Created
 
-| Resource             | Naming Pattern                       | Purpose                     |
-| -------------------- | ------------------------------------ | --------------------------- |
-| Resource Group       | `{org}-{env}-{project}-rg-{region}`  | Container for all resources |
-| App Service Plan     | `{org}-{env}-{project}-asp-{region}` | Hosting plan (Linux)        |
-| Web App              | `{org}-{env}-{project}-app-{region}` | Application hosting         |
-| Application Insights | `{org}-{env}-{project}-ai-{region}`  | Monitoring                  |
-| Log Analytics        | `{org}-{env}-{project}-law-{region}` | Logging                     |
+| Resource             | Naming Pattern              | Purpose                     |
+| -------------------- | --------------------------- | --------------------------- |
+| Resource Group       | `{org}-{env}-{project}-rg`  | Container for all resources |
+| App Service Plan     | `{org}-{env}-{project}-asp` | Hosting plan (Linux)        |
+| Web App              | `{org}-{env}-{project}-app` | Application hosting         |
+| Application Insights | `{org}-{env}-{project}-ai`  | Monitoring                  |
+| Log Analytics        | `{org}-{env}-{project}-law` | Logging                     |
+
+Region is no longer encoded in the resource name (per ADR-0027). It is
+expressed by the resource group's `location` property and by the `region`
+tag on every resource.
 
 ### Environment Configuration
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -159,6 +159,8 @@ If automatic DNS fails, configure manually:
 # Set variables
 DNS_ZONE="nexamesh.ai"
 DNS_RG="rg-dns-global"
+# Azure default App Service hostnames are region-independent — `<app>.azurewebsites.net`
+# resolves regardless of where the app is deployed (prod currently runs in westeurope).
 APP_HOSTNAME="nl-prod-omnipost-app.azurewebsites.net"
 
 # Create CNAME for main app

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # Documentation Directory
 
-> **🌐 Live Demo:** [https://nl-dev-omnipost-app-euw.azurewebsites.net](https://nl-dev-omnipost-app-euw.azurewebsites.net)
+> **🌐 Live Demo:** [https://nl-dev-omnipost-app.azurewebsites.net](https://nl-dev-omnipost-app.azurewebsites.net)
 
 This directory contains all project documentation organized by type and purpose.
 

--- a/docs/launch/BLOG_POST.md
+++ b/docs/launch/BLOG_POST.md
@@ -60,7 +60,7 @@ You're managing social presence for one or more brands, and your tool stack is g
 
 OmniPost is available now in alpha. Here's how to get up and running:
 
-1. **Sign up** at [omnipost.app](https://nl-dev-omnipost-app-euw.azurewebsites.net) -- it's free, no credit card required.
+1. **Sign up** at [omnipost.app](https://nl-dev-omnipost-app.azurewebsites.net) -- it's free, no credit card required.
 2. **Connect your platforms** -- link your Facebook, Instagram, LinkedIn, or Twitter accounts in under a minute.
 3. **Create your first post** -- write your content, let the AI adapt it, review the results, and hit publish.
 
@@ -80,4 +80,4 @@ Welcome to OmniPost. Publish everywhere, manage anywhere.
 
 ---
 
-_OmniPost is created by JustAGhosT. Try the live demo at [nl-dev-omnipost-app-euw.azurewebsites.net](https://nl-dev-omnipost-app-euw.azurewebsites.net)._
+_OmniPost is created by JustAGhosT. Try the live demo at [nl-dev-omnipost-app.azurewebsites.net](https://nl-dev-omnipost-app.azurewebsites.net)._

--- a/docs/launch/LAUNCH_EMAIL.md
+++ b/docs/launch/LAUNCH_EMAIL.md
@@ -38,7 +38,7 @@ Here's what you get:
 
 **Getting started takes about 2 minutes:**
 
-1. Go to [omnipost.app](https://nl-dev-omnipost-app-euw.azurewebsites.net)
+1. Go to [omnipost.app](https://nl-dev-omnipost-app.azurewebsites.net)
 2. Sign up (free, no credit card)
 3. Connect your first platform
 4. Create and publish your first cross-platform post
@@ -47,7 +47,7 @@ The Free tier gives you full access to core publishing and adaptation features. 
 
 This is an alpha. We're shipping early because we'd rather build with real user feedback than guess in private. If something breaks, if something's confusing, if something's missing -- tell us. Every piece of feedback goes directly to the team building the product.
 
-[Start Publishing Now](https://nl-dev-omnipost-app-euw.azurewebsites.net)
+[Start Publishing Now](https://nl-dev-omnipost-app.azurewebsites.net)
 
 Thanks for being here from the beginning. You're the reason we built this.
 

--- a/docs/launch/PRESS_RELEASE.md
+++ b/docs/launch/PRESS_RELEASE.md
@@ -8,7 +8,7 @@ _New tool lets content creators write once and publish to Facebook, Instagram, L
 
 ---
 
-**REMOTE -- March 30, 2026** -- OmniPost, an open-source content publishing platform, launched today in alpha, offering content creators and marketing teams an AI-powered solution for publishing across multiple social media platforms from a single dashboard. The platform is available immediately with a free tier at [omnipost.app](https://nl-dev-omnipost-app-euw.azurewebsites.net).
+**REMOTE -- March 30, 2026** -- OmniPost, an open-source content publishing platform, launched today in alpha, offering content creators and marketing teams an AI-powered solution for publishing across multiple social media platforms from a single dashboard. The platform is available immediately with a free tier at [omnipost.app](https://nl-dev-omnipost-app.azurewebsites.net).
 
 OmniPost addresses a persistent pain point for anyone managing a multi-platform social media presence: the hours spent reformatting the same content for different platforms. Rather than requiring users to manually adjust tone, character limits, image dimensions, and formatting for each destination, OmniPost's AI engine automatically adapts a single piece of content for Facebook, Instagram, LinkedIn, and Twitter. The platform also includes smart scheduling based on audience engagement patterns, AI image generation, unified cross-platform analytics, and built-in CRM features for connecting content performance to business outcomes.
 
@@ -24,7 +24,7 @@ OmniPost is available in three tiers: Free (core publishing and AI adaptation), 
 
 OmniPost is an AI-powered multi-platform content publishing platform that lets users write once and publish everywhere. Built on modern open-source technology and released under the MIT license, OmniPost combines content adaptation, smart scheduling, AI image generation, unified analytics, and CRM features in a single dashboard. The platform currently supports Facebook, Instagram, LinkedIn, and Twitter, with additional platforms planned.
 
-- **Website:** https://nl-dev-omnipost-app-euw.azurewebsites.net
+- **Website:** https://nl-dev-omnipost-app.azurewebsites.net
 - **GitHub:** https://github.com/phoenixvc/omnipost
 
 ---

--- a/docs/launch/PRODUCT_HUNT.md
+++ b/docs/launch/PRODUCT_HUNT.md
@@ -27,7 +27,7 @@ Write once, publish to Facebook, Instagram, LinkedIn, and Twitter. OmniPost's AI
 
 ## Links
 
-- **Website:** https://nl-dev-omnipost-app-euw.azurewebsites.net
+- **Website:** https://nl-dev-omnipost-app.azurewebsites.net
 - **GitHub:** https://github.com/phoenixvc/omnipost
 
 ---

--- a/docs/launch/SOCIAL_POSTS.md
+++ b/docs/launch/SOCIAL_POSTS.md
@@ -11,7 +11,7 @@ _Brand voice: Professional, approachable, technically confident, clear._
 
 > We just launched OmniPost -- write once, publish to Facebook, Instagram, LinkedIn, and Twitter simultaneously. AI adapts your content to each platform automatically. Free and open source.
 >
-> Try it: https://nl-dev-omnipost-app-euw.azurewebsites.net
+> Try it: https://nl-dev-omnipost-app.azurewebsites.net
 
 ### Tweet 2 -- Problem Hook
 
@@ -54,7 +54,7 @@ We're in alpha. The Free tier is available now with no credit card required.
 
 If you're a content creator, social media manager, or marketing team lead, I'd genuinely appreciate you taking it for a spin and sharing your honest feedback.
 
-Try it: https://nl-dev-omnipost-app-euw.azurewebsites.net
+Try it: https://nl-dev-omnipost-app.azurewebsites.net
 
 #ContentCreation #SaaS #OpenSource #MarketingTools #Launch
 
@@ -70,7 +70,7 @@ The result: content teams get back an entire workday each week. And because Omni
 
 Currently in alpha -- free to use, open source, and actively looking for feedback from marketing professionals.
 
-https://nl-dev-omnipost-app-euw.azurewebsites.net
+https://nl-dev-omnipost-app.azurewebsites.net
 
 ### LinkedIn 3 -- Open Source Angle
 
@@ -141,7 +141,7 @@ Hey everyone -- I've been working on OmniPost, a multi-platform content publishi
 
 **What I'm looking for**: Honest feedback from people who manage content across multiple platforms. What works? What's missing? What would make you switch from your current tool?
 
-Live demo: https://nl-dev-omnipost-app-euw.azurewebsites.net
+Live demo: https://nl-dev-omnipost-app.azurewebsites.net
 GitHub: github.com/phoenixvc/omnipost
 
 Happy to answer any questions about the tech or the product.
@@ -163,5 +163,5 @@ Key technical decisions:
 
 This is an alpha release. Looking for feedback on the core workflow and contributions from anyone interested in the stack.
 
-Demo: https://nl-dev-omnipost-app-euw.azurewebsites.net
+Demo: https://nl-dev-omnipost-app.azurewebsites.net
 Source: https://github.com/phoenixvc/omnipost

--- a/infra/README.md
+++ b/infra/README.md
@@ -81,10 +81,12 @@ embedding the region into every resource name.
 For NeuralLiquid (`nl`):
 
 - `omnipost` - This project (was `content-creation` / `cc` before 2026-05-10)
-- `rooivalk` - Counter-UAS platform (now spun out to Nexamesh org as `nexamesh-core`)
+- `rooivalk` - Counter-UAS platform [^rooivalk]
 - `autopr` - Autopr automation platform
 - `nl-core` - Shared NL foundation services
 - `nl-ai` - Shared NL AI services
+
+[^rooivalk]: `rooivalk` has since been spun out to the Nexamesh org as `nexamesh-core`; the code remains valid for any historical NL-owned resources.
 
 ### Type Codes
 

--- a/infra/README.md
+++ b/infra/README.md
@@ -1,6 +1,8 @@
 # Azure Infrastructure - Naming Conventions
 
-This infrastructure follows the **NeuralLiquid Azure Naming Standards v3**.
+This infrastructure follows the **NeuralLiquid Azure Naming Standards v3**, with
+the **region suffix dropped per [ADR-0027](https://github.com/JustAGhosT/mystira-workspace/blob/main/docs/architecture/adr/0027-azure-resource-naming-convention.md)**
+(originally a mystira ADR; adopted for omnipost on 2026-05-10).
 
 ## Recent Changes (December 2024)
 
@@ -40,14 +42,24 @@ See `main.bicep` for usage example.
 All resources follow the pattern:
 
 ```
-[org]-[env]-[project]-[type]-[region]
+[org]-[env]-[project]-[type]
 ```
 
 Resource groups use:
 
 ```
-[org]-[env]-[project]-rg-[region]
+[org]-[env]-[project]-rg
 ```
+
+The region is no longer encoded in the resource name. It is expressed by:
+
+- The Azure resource group's `location` property (authoritative)
+- The `region` tag on every resource (derived from the `region` parameter)
+
+Multi-region disambiguation, when needed, is handled by deploying into
+distinct resource groups (e.g. `nl-prod-omnipost-rg` in `westeurope`
+vs a future `nl-prod-omnipost-rg-2` in another region) rather than
+embedding the region into every resource name.
 
 ## Valid Values
 
@@ -68,8 +80,8 @@ Resource groups use:
 
 For NeuralLiquid (`nl`):
 
-- `content-creation` - This project
-- `rooivalk` - Counter-UAS platform
+- `omnipost` - This project (was `content-creation` / `cc` before 2026-05-10)
+- `rooivalk` - Counter-UAS platform (now spun out to Nexamesh org as `nexamesh-core`)
 - `autopr` - Autopr automation platform
 - `nl-core` - Shared NL foundation services
 - `nl-ai` - Shared NL AI services
@@ -112,26 +124,26 @@ For NeuralLiquid (`nl`):
 ### Development Environment (West Europe)
 
 ```
-nl-dev-content-creation-rg-euw         # Resource Group
-nl-dev-content-creation-app-euw        # App Service
-nl-dev-content-creation-asp-euw        # App Service Plan
-nl-dev-content-creation-api-euw        # API Service
-nl-dev-content-creation-db-euw         # Database
+nl-dev-omnipost-rg         # Resource Group
+nl-dev-omnipost-app        # App Service
+nl-dev-omnipost-asp        # App Service Plan
+nl-dev-omnipost-api        # API Service
+nl-dev-omnipost-db         # Database
 ```
 
 ### Production Environment (South Africa North)
 
 ```
-nl-prod-content-creation-rg-san        # Resource Group
-nl-prod-content-creation-app-san       # App Service
-nl-prod-content-creation-asp-san       # App Service Plan
+nl-prod-omnipost-rg        # Resource Group (location: southafricanorth)
+nl-prod-omnipost-app       # App Service
+nl-prod-omnipost-asp       # App Service Plan
 ```
 
 ### Staging Environment (West Europe)
 
 ```
-nl-staging-content-creation-rg-euw     # Resource Group
-nl-staging-content-creation-app-euw    # App Service
+nl-staging-omnipost-rg     # Resource Group
+nl-staging-omnipost-app    # App Service
 ```
 
 ## Usage
@@ -144,20 +156,21 @@ The `naming.sh` script generates standardized names:
 ./infra/naming.sh <org> <env> <project> <region>
 
 # Example:
-./infra/naming.sh nl dev content-creation euw
+./infra/naming.sh nl dev omnipost euw
 ```
 
-Output (as environment variables):
+The `<region>` argument is still required for backward compatibility but is
+no longer encoded in resource names (see ADR-0027). Output (as environment variables):
 
 ```bash
-RESOURCE_GROUP=nl-dev-content-creation-rg-euw
-APP_NAME=nl-dev-content-creation-app-euw
-ASP_NAME=nl-dev-content-creation-asp-euw
-API_NAME=nl-dev-content-creation-api-euw
-FUNC_NAME=nl-dev-content-creation-func-euw
-STORAGE_NAME=nl-dev-content-creation-storage-euw
-KV_NAME=nl-dev-content-creation-kv-euw
-DB_NAME=nl-dev-content-creation-db-euw
+RESOURCE_GROUP=nl-dev-omnipost-rg
+APP_NAME=nl-dev-omnipost-app
+ASP_NAME=nl-dev-omnipost-asp
+API_NAME=nl-dev-omnipost-api
+FUNC_NAME=nl-dev-omnipost-func
+STORAGE_NAME=nl-dev-omnipost-storage
+KV_NAME=nl-dev-omnipost-kv
+DB_NAME=nl-dev-omnipost-db
 ```
 
 ### Bicep Module (naming.bicep)
@@ -176,16 +189,16 @@ param org string = 'nl'
 param env string = 'dev'
 
 @description('Project name')
-param project string = 'content-creation'
+param project string = 'omnipost'
 
-@description('Region code')
+@description('Region code (kept for tags + future multi-region disambiguation; not used in resource names)')
 @allowed(['euw', 'san', 'saf', 'swe', 'eun', 'wus', 'eus', 'uks', 'usw', 'glob'])
 param region string = 'euw'
 
 // Generate names directly (available at deployment start)
 var base = '${org}-${env}-${project}'
-var appName = '${base}-app-${region}'
-var aspName = '${base}-asp-${region}'
+var appName = '${base}-app'
+var aspName = '${base}-asp'
 
 // Optional: Deploy naming module for validation
 module naming 'naming.bicep' = {
@@ -215,7 +228,7 @@ The workflow automatically generates names:
 ```yaml
 env:
   ORG_CODE: 'nl'
-  PROJECT_NAME: 'content-creation'
+  PROJECT_NAME: 'omnipost'
   REGION_CODE: 'euw'
 
 steps:
@@ -240,41 +253,71 @@ The naming script validates all inputs:
 
 ```bash
 # Valid
-./infra/naming.sh nl dev content-creation euw  # ✅
+./infra/naming.sh nl dev omnipost euw  # ✅
 
 # Invalid org code
-./infra/naming.sh xyz dev content-creation euw  # ❌ Error
+./infra/naming.sh xyz dev omnipost euw  # ❌ Error
 
 # Invalid environment
-./infra/naming.sh nl test content-creation euw  # ❌ Error (should be 'staging')
+./infra/naming.sh nl test omnipost euw  # ❌ Error (should be 'staging')
 
 # Invalid region
-./infra/naming.sh nl dev content-creation xyz   # ❌ Error
+./infra/naming.sh nl dev omnipost xyz   # ❌ Error
 ```
 
 ## Migration Notes
 
-### From Old Pattern
+### From legacy `cc` + region-suffixed names (2026-05-10)
 
-**Old (incorrect):**
+**Legacy (deployed to dev as `nl-dev-cc-rg-euw`, with parallel
+`nl-dev-omnipost-rg-euw`):**
+
+```
+nl-dev-cc-rg-euw
+nl-dev-cc-app-euw
+nl-dev-omnipost-rg-euw       # parallel deploy under new project name
+```
+
+**New (per ADR-0027 application; deployed afresh):**
+
+```
+nl-dev-omnipost-rg
+nl-dev-omnipost-app
+```
+
+**Changes:**
+
+1. Project code consolidated: `cc` (and the parallel `omnipost`) → `omnipost`
+2. Region suffix dropped from resource names (region is on the resource group's
+   `location` property and on the `region` resource tag)
+
+**Cutover:** the legacy `nl-dev-cc-rg-euw` and the parallel
+`nl-dev-omnipost-rg-euw` are decommissioned in a separate manual ops step
+once the new `nl-dev-omnipost-rg` deploy is healthy. Neither legacy RG had a
+custom domain, so DNS migration is not required.
+
+### Earlier (pre-NL-standards)
+
+**Pre-standard:**
 
 ```
 dev-euw-rg-content-creation
 dev-euw-app-content-creation
 ```
 
-**New (correct):**
+**NL-standard with region suffix (intermediate):**
 
 ```
 nl-dev-content-creation-rg-euw
 nl-dev-content-creation-app-euw
 ```
 
-**Changes:**
+**Current (this doc):**
 
-1. Added `nl` org code prefix
-2. Moved type code before region code
-3. Standardized segment order
+```
+nl-dev-omnipost-rg
+nl-dev-omnipost-app
+```
 
 ### Renaming Resources
 
@@ -297,11 +340,15 @@ All resources are automatically tagged:
 {
   "org": "nl",
   "environment": "dev",
-  "project": "content-creation",
+  "project": "omnipost",
   "region": "euw",
   "managedBy": "bicep"
 }
 ```
+
+The `region` tag is the canonical place to read the deployment region from a
+resource (in addition to the resource group's `location` property), since it
+is no longer in the resource name itself.
 
 ## References
 

--- a/infra/keyvault.bicep
+++ b/infra/keyvault.bicep
@@ -33,8 +33,9 @@ param jwtSecretValue string
 param jwtSecretExpirationEpoch int = dateTimeToEpoch(dateTimeAdd(utcNow(), 'P1Y'))
 
 // Generate Key Vault name (max 24 chars, alphanumeric + hyphens)
+// Region suffix dropped per ADR-0027; region param retained for tags/future multi-region
 var base = '${org}-${env}-${project}'
-var kvName = '${base}-kv-${region}'
+var kvName = '${base}-kv'
 
 resource keyVault 'Microsoft.KeyVault/vaults@2023-07-01' = {
   name: kvName

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -7,9 +7,9 @@ param org string = 'nl'
 param env string = 'dev'
 
 @description('Project name')
-param project string = 'cc'
+param project string = 'omnipost'
 
-@description('Region code (euw, san, saf, swe, etc.)')
+@description('Region code (kept for tags + future multi-region disambiguation; not used in resource names per ADR-0027)')
 @allowed(['euw', 'eun', 'wus', 'eus', 'san', 'saf', 'swe', 'uks', 'usw', 'glob'])
 param region string = 'euw'
 
@@ -45,9 +45,11 @@ param appSubdomain string = 'omnipost'
 param apiSubdomain string = 'api.omnipost'
 
 // Generate names directly (required for resource names - must be available at deployment start)
+// Region suffix dropped per ADR-0027 (mystira) applied to omnipost: region is already
+// expressed by the resource group's location property; the suffix added noise without value.
 var base = '${org}-${env}-${project}'
-var appName = '${base}-app-${region}'
-var appServicePlanName = '${base}-asp-${region}'
+var appName = '${base}-app'
+var appServicePlanName = '${base}-asp'
 
 // Generate tags
 var tags = {

--- a/infra/monitoring.bicep
+++ b/infra/monitoring.bicep
@@ -22,10 +22,10 @@ param tags object = {}
 @description('Web App resource ID for diagnostic settings')
 param webAppId string
 
-// Generate names
+// Generate names (region suffix dropped per ADR-0027; region param retained for tags/future multi-region)
 var base = '${org}-${env}-${project}'
-var appInsightsName = '${base}-ai-${region}'
-var logAnalyticsName = '${base}-law-${region}'
+var appInsightsName = '${base}-ai'
+var logAnalyticsName = '${base}-law'
 
 // Log Analytics Workspace (required for Application Insights)
 resource logAnalytics 'Microsoft.OperationalInsights/workspaces@2022-10-01' = {

--- a/infra/naming.bicep
+++ b/infra/naming.bicep
@@ -46,44 +46,47 @@ param project string
 param region string
 
 // Base naming pattern: [org]-[env]-[project]
+// Region suffix dropped per ADR-0027 (mystira) applied to omnipost. The `region` param is
+// retained for tags + future multi-region disambiguation but is no longer in resource names.
 var base = '${org}-${env}-${project}'
 
-// Resource Group: [org]-[env]-[project]-rg-[region]
-output rgName string = '${base}-rg-${region}'
+// Resource Group: [org]-[env]-[project]-rg
+output rgName string = '${base}-rg'
 
 // Compute Resources
-output name_app string = '${base}-app-${region}'
-output name_api string = '${base}-api-${region}'
-output name_func string = '${base}-func-${region}'
-output name_swa string = '${base}-swa-${region}'
-output name_asp string = '${base}-asp-${region}'
+output name_app string = '${base}-app'
+output name_api string = '${base}-api'
+output name_func string = '${base}-func'
+output name_swa string = '${base}-swa'
+output name_asp string = '${base}-asp'
 
 // Data Resources
-output name_db string = '${base}-db-${region}'
-output name_storage string = '${base}-storage-${region}'
-output name_cache string = '${base}-cache-${region}'
-output name_queue string = '${base}-queue-${region}'
+output name_db string = '${base}-db'
+output name_storage string = '${base}-storage'
+output name_cache string = '${base}-cache'
+output name_queue string = '${base}-queue'
 
 // Security Resources
-output name_kv string = '${base}-kv-${region}'
+output name_kv string = '${base}-kv'
 
 // AI Resources
-output name_ai string = '${base}-ai-${region}'
+output name_ai string = '${base}-ai'
 
 // Networking Resources
-output name_vnet string = '${base}-vnet-${region}'
-output name_subnet string = '${base}-subnet-${region}'
-output name_dns string = '${base}-dns-${region}'
+output name_vnet string = '${base}-vnet'
+output name_subnet string = '${base}-subnet'
+output name_dns string = '${base}-dns'
 
 // Monitoring Resources
-output name_log string = '${base}-log-${region}'
+output name_law string = '${base}-law'
+output name_log string = '${base}-law' // alias, kept for backward-compat with consumers using name_log
 
 // Container Resources
-output name_acr string = '${base}-acr-${region}'
+output name_acr string = '${base}-acr'
 
 // Metadata outputs
 output base string = base
-output fullPattern string = '[org]-[env]-[project]-[type]-[region]'
+output fullPattern string = '[org]-[env]-[project]-[type]'
 output tags object = {
   org: org
   environment: env

--- a/infra/naming.bicep
+++ b/infra/naming.bicep
@@ -78,8 +78,9 @@ output name_subnet string = '${base}-subnet'
 output name_dns string = '${base}-dns'
 
 // Monitoring Resources
+// NOTE: previous releases also exposed `name_log` (type code `log`); that type code was
+// merged into `law` per ADR-0027, and the alias has been removed (no remaining consumers).
 output name_law string = '${base}-law'
-output name_log string = '${base}-law' // alias, kept for backward-compat with consumers using name_log
 
 // Container Resources
 output name_acr string = '${base}-acr'

--- a/infra/naming.sh
+++ b/infra/naming.sh
@@ -43,8 +43,7 @@ generate_names() {
   local o=$1
   local e=$2
   local p=$3
-  # shellcheck disable=SC2034
-  local r=$4  # retained for backward compat / tags; not in names
+  _=$4  # region: retained for backward compat / tags; not in names
 
   local base="${o}-${e}-${p}"
 

--- a/infra/naming.sh
+++ b/infra/naming.sh
@@ -36,30 +36,33 @@ case "$region" in
     ;;
 esac
 
-# Function to generate resource names following [org]-[env]-[project]-[type]-[region]
+# Function to generate resource names following [org]-[env]-[project]-[type]
+# Region suffix dropped per ADR-0027 (mystira) applied to omnipost. The `region` arg is
+# retained for tag emission + backward-compat with callers; it no longer appears in names.
 generate_names() {
   local o=$1
   local e=$2
   local p=$3
-  local r=$4
-  
+  # shellcheck disable=SC2034
+  local r=$4  # retained for backward compat / tags; not in names
+
   local base="${o}-${e}-${p}"
-  
-  # Resource Group: [org]-[env]-[project]-rg-[region]
-  echo "RESOURCE_GROUP=${base}-rg-${r}"
-  
-  # App Service: [org]-[env]-[project]-app-[region]
-  echo "APP_NAME=${base}-app-${r}"
-  
-  # App Service Plan: [org]-[env]-[project]-asp-[region]
-  echo "ASP_NAME=${base}-asp-${r}"
-  
+
+  # Resource Group: [org]-[env]-[project]-rg
+  echo "RESOURCE_GROUP=${base}-rg"
+
+  # App Service: [org]-[env]-[project]-app
+  echo "APP_NAME=${base}-app"
+
+  # App Service Plan: [org]-[env]-[project]-asp
+  echo "ASP_NAME=${base}-asp"
+
   # Additional resource types (for future use)
-  echo "API_NAME=${base}-api-${r}"
-  echo "FUNC_NAME=${base}-func-${r}"
-  echo "STORAGE_NAME=${base}-storage-${r}"
-  echo "KV_NAME=${base}-kv-${r}"
-  echo "DB_NAME=${base}-db-${r}"
+  echo "API_NAME=${base}-api"
+  echo "FUNC_NAME=${base}-func"
+  echo "STORAGE_NAME=${base}-storage"
+  echo "KV_NAME=${base}-kv"
+  echo "DB_NAME=${base}-db"
 }
 
 # Generate and export names

--- a/infra/postgresql.bicep
+++ b/infra/postgresql.bicep
@@ -50,8 +50,8 @@ param storageSizeGB int = 32
 @maxValue(35)
 param backupRetentionDays int = 7
 
-// Naming convention: [org]-[env]-[project]-psql-[region]
-var serverName = '${org}-${env}-${project}-psql-${region}'
+// Naming convention: [org]-[env]-[project]-psql (region suffix dropped per ADR-0027)
+var serverName = '${org}-${env}-${project}-psql'
 
 resource postgresServer 'Microsoft.DBforPostgreSQL/flexibleServers@2023-12-01-preview' = {
   name: serverName

--- a/infra/sluice.bicep
+++ b/infra/sluice.bicep
@@ -42,11 +42,11 @@ param azureOpenAIApiKey string
 @secure()
 param sluiceApiKey string
 
-// Naming convention: [org]-[env]-[project]-[type]-[region]
+// Naming convention: [org]-[env]-[project]-[type] (region suffix dropped per ADR-0027)
 var base = '${org}-${env}-${project}'
-var containerAppEnvName = '${base}-cae-${region}'
-var containerAppName = '${base}-sluice-${region}'
-var logAnalyticsName = '${base}-log-${region}'
+var containerAppEnvName = '${base}-cae'
+var containerAppName = '${base}-sluice'
+var logAnalyticsName = '${base}-law'
 
 // Reference existing Log Analytics workspace (created by monitoring.bicep)
 resource logAnalytics 'Microsoft.OperationalInsights/workspaces@2023-09-01' existing = {

--- a/scripts/deploy-infrastructure.ps1
+++ b/scripts/deploy-infrastructure.ps1
@@ -17,7 +17,7 @@
     Short code for the location (e.g., 'euw' for West Europe). Default is 'euw'.
 
 .PARAMETER ProjectName
-    The name of the project. Default is 'content-creation'.
+    The name of the project. Default is 'omnipost'.
 
 .PARAMETER Sku
     The SKU for the App Service Plan. Default is 'B1'.
@@ -54,7 +54,7 @@ param(
     [string]$LocationCode = 'euw',
 
     [Parameter()]
-    [string]$ProjectName = 'content-creation',
+    [string]$ProjectName = 'omnipost',
 
     [Parameter()]
     [ValidateSet('B1', 'B2', 'B3', 'S1', 'S2', 'S3', 'P1v2', 'P2v2', 'P3v2')]
@@ -77,9 +77,11 @@ $InfraPath = Join-Path -Path (Split-Path -Parent $ScriptRoot) -ChildPath 'infra'
 $BicepFile = Join-Path -Path $InfraPath -ChildPath 'main.bicep'
 
 # Generate resource names following the naming convention
-$ResourceGroupName = "$Environment-$LocationCode-rg-$ProjectName"
-$AppName = "$Environment-$LocationCode-app-$ProjectName"
-$AppServicePlanName = "$AppName-asp"
+# Pattern: nl-<env>-<project>-<type> (region suffix dropped per ADR-0027)
+$OrgCode = 'nl'
+$ResourceGroupName = "$OrgCode-$Environment-$ProjectName-rg"
+$AppName = "$OrgCode-$Environment-$ProjectName-app"
+$AppServicePlanName = "$OrgCode-$Environment-$ProjectName-asp"
 
 function Write-Header {
     param([string]$Message)


### PR DESCRIPTION
## Summary

Resolves the deferred infra-rename items from PR #124 (the brand sweep) by combining two coupled changes into one PR:

1. **Project code consolidation**: `cc` (workflows + main.bicep) and `content-creation` (deploy-infrastructure.ps1, docs) → `omnipost`.
2. **Region suffix dropped from resource names** per [mystira ADR-0027](https://github.com/JustAGhosT/mystira-workspace/blob/main/docs/architecture/adr/0027-azure-resource-naming-convention.md), adopted for omnipost on 2026-05-10. Region is now expressed by the resource group's `location` property and the `region` resource tag — not in the name.

New canonical pattern: `nl-{env}-omnipost-{type}` (no `-{region}` postfix).

## Surfaces touched

- `infra/main.bicep`, `infra/naming.bicep`, `infra/monitoring.bicep`, `infra/keyvault.bicep`, `infra/postgresql.bicep`, `infra/sluice.bicep` — drop region from name interpolation; keep `region` param for tags + future multi-region disambiguation.
- `infra/naming.sh` — `region` arg retained for backward-compat (workflows still pass it) but no longer in emitted names.
- `infra/README.md` — full rewrite of naming pattern, examples, and migration history; references ADR-0027 explicitly.
- `.github/workflows/{azure-webapps-node,deploy-prod}.yml` — `PROJECT_NAME: 'cc' → 'omnipost'`. Manual RG references in deploy-prod.yml stripped of `${{ env.REGION_CODE }}`.
- `scripts/deploy-infrastructure.ps1` — default `ProjectName` flipped to `omnipost`; resource-name construction fixed to match `[org]-[env]-[project]-[type]` (was using a legacy ordering).
- `docs/AZURE_SECRETS.md`, `docs/DEPLOYMENT.md`, `AZURE_DEPLOYMENT_FIX.md` — example az-cli commands updated. (These were explicitly deferred from PR #124.)
- Marketing/site references — `app/{sitemap,robots}.ts`, `.agentkit/spec/project.yaml`, `.agents/context/`, `.github/copilot-instructions.md`, `docs/README.md`, `docs/launch/*` — live-demo URL updated to drop `-euw` from the Azure default-hostname. Custom domain (`omnipost.nexamesh.ai`) is unaffected.

## Cutover plan (separate manual ops, not in this PR)

1. Land this PR — code now targets the new naming, but no Azure resources are touched.
2. Fix the AAD federated-credential subjects so the `Infrastructure / Preview Changes (dev)` job stops failing on this repo (red since 2025-12-07; same root cause as PRs #75/77/78 on convolens). See org-meta handoff `2026-05-10-azure-rename-plan-omnipost-convolens.md`.
3. Run the dev infrastructure workflow — creates `nl-dev-omnipost-rg` (no suffix) and child resources cleanly.
4. Verify health.
5. ``az group delete --name nl-dev-cc-rg-euw --yes --no-wait``
6. ``az group delete --name nl-dev-omnipost-rg-euw --yes --no-wait`` (the parallel deploy under the previous naming)

Neither legacy RG had a custom domain bound, so DNS migration is not required. The `nl-dev-omnipost-app.azurewebsites.net` URL referenced in docs and `app/{sitemap,robots}.ts` will only resolve after step 3.

## Test plan

- [x] `az bicep build` succeeds for `infra/main.bicep` and `infra/naming.bicep`
- [ ] AAD federated credential subjects updated for `dev`/`staging`/`prod` (see cutover plan step 2)
- [ ] Dev infrastructure workflow run creates `nl-dev-omnipost-rg` cleanly
- [ ] Health endpoint reachable at `https://nl-dev-omnipost-app.azurewebsites.net/api/health`
- [ ] Old RGs deleted

🤖 Generated with [Claude Code](https://claude.com/claude-code)