### PR TITLE
chore: seed .todo.yaml and .roadmap.yaml for baton sync

### DIFF
--- a/.roadmap.yaml
+++ b/.roadmap.yaml
@@ -1,0 +1,36 @@
+version: "1.0"
+scope: roadmap
+repo: neuralliquid/omnipost
+updated_at: 2026-05-11
+
+tasks:
+  - id: alpha-launch
+    title: "Alpha launch — Phases 1-4 of ALPHA_LAUNCH_PLAN.md"
+    description: "Auth/middleware unblock, core flow polish, analytics & tracking, launch prep. All four phases marked COMPLETED in docs/ALPHA_LAUNCH_PLAN.md."
+    priority: high
+    status: done
+    quarter: "2026-Q2"
+    tags: [alpha, launch]
+
+  - id: post-alpha-cost-ops
+    title: "Post-alpha — route all AI calls through sluice for per-call cost attribution in docket"
+    description: "aiGateway feature flag exists. Flip on once verified in prod and confirm spend appears in docket."
+    priority: medium
+    status: todo
+    quarter: "2026-Q2"
+    tags: [sluice, docket, cost-ops]
+
+  - id: post-alpha-real-platforms
+    title: "Post-alpha — replace mock platform OAuth with real provider flows"
+    priority: medium
+    status: todo
+    quarter: "2026-Q3"
+    tags: [oauth, platforms]
+
+  - id: post-alpha-baton-integration
+    title: "Post-alpha — deepen baton integration: bidirectional task sync, agent assignments"
+    description: "lib/integrations/baton.ts already wired with feature flag. app/(dashboard)/tasks/ is a Kanban board backed by baton. Next: expand beyond view-only to write paths."
+    priority: medium
+    status: todo
+    quarter: "2026-Q3"
+    tags: [baton, integration, agents]

--- a/.todo.yaml
+++ b/.todo.yaml
@@ -1,0 +1,35 @@
+version: "1.0"
+scope: todo
+repo: neuralliquid/omnipost
+updated_at: 2026-05-11
+# Alpha launch (Phases 1-4 in docs/ALPHA_LAUNCH_PLAN.md) complete. This file
+# tracks remaining/follow-up items, not the launch-prep work itself.
+
+tasks:
+  - id: open-graph-tags
+    title: "Add Open Graph tags for social sharing"
+    description: "Outstanding item from ALPHA_LAUNCH_PLAN.md Phase 4. Most launch work shipped; OG tags noted but not yet implemented."
+    priority: medium
+    status: todo
+    tags: [seo, marketing, alpha]
+
+  - id: fix-stale-ci-badge
+    title: "Fix stale phoenixvc/omnipost CI badge in README"
+    description: "README references github.com/phoenixvc/omnipost/actions but the canonical repo is neuralliquid/omnipost. Update badge URLs."
+    priority: low
+    status: todo
+    tags: [docs, neuralliquid, hygiene]
+
+  - id: real-oauth-platforms
+    title: "Replace mock OAuth in platform settings with real provider flows"
+    description: "app/(dashboard)/settings/platforms/ ships with mock OAuth — wiring real OAuth is the next logical step now that auth middleware is hardened."
+    priority: medium
+    status: todo
+    tags: [oauth, platforms]
+
+  - id: verify-sluice-baton-flags
+    title: "Verify aiGateway (sluice) + baton feature flags work end-to-end in prod"
+    description: "Both integrations are feature-flagged. Confirm flag toggling actually swaps the path correctly in deployed env (lib/clients/sluice-gateway.ts, lib/integrations/baton.ts)."
+    priority: medium
+    status: todo
+    tags: [sluice, baton, feature-flags, integration]


### PR DESCRIPTION
## Summary

- Adds `.todo.yaml` and `.roadmap.yaml` at repo root so baton's `POST /:id/sync-yaml` can pull this repo's tasks into the shared task graph.
- `.todo.yaml` captures post-alpha follow-ups (OG tags, stale CI badge fix, real OAuth, verifying sluice+baton flags). The alpha launch (Phases 1-4 of `docs/ALPHA_LAUNCH_PLAN.md`) is already complete.
- `.roadmap.yaml` records the alpha as done and outlines post-alpha cost-ops (route AI through sluice), OAuth, and deeper baton integration.
- Schema matches the working pattern used by `phoenixvc/sluice` and `phoenixvc/docket`.

No code changes. Pure data files.

## Test plan

- [ ] `pnpm run type-check` still passes.
- [ ] `pnpm run build` still passes.
- [ ] After merge, run baton's `sync_repo_yaml` against the omnipost project — verify tasks land.