### PR TITLE
chore: add renovate verification and parallel CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,76 +2,156 @@ name: CI
 
 on:
   pull_request:
-    branches: [ main ]
+    branches: [main]
   push:
-    branches: [ main ]
+    branches: [main]
 
 jobs:
-  lint-and-test:
+  type-check:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    
-    strategy:
-      matrix:
-        node-version: [20.x]
-    
     steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
-      
-    - name: Setup pnpm
-      uses: pnpm/action-setup@fe02b34f77f8bc703788d5817da081398fad5dd2 # v4.0.0
-      
-    - name: Setup Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v4
-      with:
-        node-version: ${{ matrix.node-version }}
-        cache: 'pnpm'
-    
-    - name: Install dependencies
-      run: pnpm install --frozen-lockfile
-    
-    - name: Run TypeScript type check
-      run: pnpm run type-check
+      - name: Checkout code
+        uses: actions/checkout@v4
 
-    - name: Run ESLint
-      run: pnpm run lint
+      - name: Setup pnpm
+        uses: pnpm/action-setup@fe02b34f77f8bc703788d5817da081398fad5dd2 # v4.0.0
 
-    - name: Run tests
-      run: pnpm test
-      env:
-        JWT_SECRET: test-secret-key-for-ci
-    
-    - name: Check code formatting
-      run: pnpm run format:check
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20.x'
+          cache: pnpm
 
-    - name: Validate marketing skills
-      run: bash .agents/validate-skills.sh
-      
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run TypeScript type check
+        run: pnpm run type-check
+
+  lint:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@fe02b34f77f8bc703788d5817da081398fad5dd2 # v4.0.0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20.x'
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run ESLint
+        run: pnpm run lint
+
+  format:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@fe02b34f77f8bc703788d5817da081398fad5dd2 # v4.0.0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20.x'
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Check code formatting
+        run: pnpm run format:check
+
+  test:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@fe02b34f77f8bc703788d5817da081398fad5dd2 # v4.0.0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20.x'
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run tests
+        run: pnpm test
+        env:
+          JWT_SECRET: test-secret-key-for-ci
+
+  renovate-verify:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20.x'
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@fe02b34f77f8bc703788d5817da081398fad5dd2 # v4.0.0
+
+      - name: Verify Renovate config
+        run: pnpm run renovate:verify
+
+  validate-skills:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Validate marketing skills
+        run: bash .agents/validate-skills.sh
+
   build:
     runs-on: ubuntu-latest
-    needs: lint-and-test
     permissions:
       contents: read
-    
     steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
-      
-    - name: Setup pnpm
-      uses: pnpm/action-setup@fe02b34f77f8bc703788d5817da081398fad5dd2 # v4.0.0
-      
-    - name: Setup Node.js
-      uses: actions/setup-node@v4
-      with:
-        node-version: '20.x'
-        cache: 'pnpm'
-    
-    - name: Install dependencies
-      run: pnpm install --frozen-lockfile
-    
-    - name: Build application
-      run: pnpm run build
-      env:
-        JWT_SECRET: test-secret-key-for-ci
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@fe02b34f77f8bc703788d5817da081398fad5dd2 # v4.0.0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20.x'
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build application
+        run: pnpm run build
+        env:
+          JWT_SECRET: test-secret-key-for-ci

--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,5 @@ e2e/.auth/
 
 # Retort ephemeral state
 .claude/state/
+.claude/worktrees/
+.serena/

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -12,6 +12,8 @@ export default [
       '**/dist/**',
       '**/build/**',
       '**/.git/**',
+      '**/.claude/worktrees/**',
+      '**/.serena/**',
       '**/coverage/**',
       '**/*.config.js',
       '**/*.config.ts',

--- a/jest.config.js
+++ b/jest.config.js
@@ -40,6 +40,8 @@ const customJestConfig = {
   testPathIgnorePatterns: [
     '<rootDir>/node_modules/',
     '<rootDir>/.next/',
+    '<rootDir>/.claude/worktrees/',
+    '<rootDir>/.serena/',
     '<rootDir>/e2e/',
     '<rootDir>/__tests__/a11y/a11y-setup.ts',
   ],
@@ -51,6 +53,8 @@ const customJestConfig = {
     'lib/**/*.{js,jsx,ts,tsx}',
     '!**/*.d.ts',
     '!**/node_modules/**',
+    '!**/.claude/worktrees/**',
+    '!**/.serena/**',
   ],
 
   // Verbose output

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "test": "jest",
     "test:watch": "jest --watch",
     "test:coverage": "jest --coverage",
+    "renovate:verify": "npx --yes --package renovate -- renovate-config-validator --strict",
     "db:generate": "prisma generate",
     "db:push": "prisma db push",
     "db:migrate": "prisma migrate dev",

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended",
+    "group:allNonMajor",
+    "helpers:pinGitHubActionDigests",
+    ":dependencyDashboard",
+    ":semanticCommits",
+    ":maintainLockFilesWeekly"
+  ],
+  "labels": ["dependencies"],
+  "packageRules": [
+    {
+      "description": "Group non-major development tooling updates.",
+      "matchManagers": ["npm"],
+      "matchDepTypes": ["devDependencies"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "dev tooling"
+    },
+    {
+      "description": "Group GitHub Actions digest and version maintenance.",
+      "matchManagers": ["github-actions"],
+      "groupName": "github actions"
+    }
+  ],
+  "rangeStrategy": "bump",
+  "prConcurrentLimit": 5,
+  "prHourlyLimit": 2,
+  "timezone": "Africa/Johannesburg"
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,7 @@
     "noEmit": true,
     "esModuleInterop": true,
     "module": "esnext",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "react-jsx",


### PR DESCRIPTION
## Summary
- add Renovate configuration with recommended presets, dependency dashboard, action digest pinning, and grouped non-major updates
- add a Renovate config validator script and CI job
- split CI checks into parallel jobs for type-check, lint, format, tests, Renovate validation, skills validation, and build
- ignore generated local agent worktrees in lint, Jest, and Git
- keep Next.js 16 required TypeScript module resolution setting

## Validation
- pnpm install --frozen-lockfile
- pnpm run type-check
- pnpm exec jest --runInBand
- pnpm run lint
- pnpm exec prettier --check .github/workflows/ci.yml package.json renovate.json eslint.config.mjs jest.config.js tsconfig.json
- pnpm run renovate:verify
- pnpm run build

## Notes
- Local skill validation via `bash .agents/validate-skills.sh` could not run on this Windows host because WSL has no installed distro; CI runs it on Ubuntu.
- Lint currently passes with existing warnings.