### PR TITLE
fix: use unique Azure Web App suffix

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -448,7 +448,7 @@ jobs:
           echo "## 🚀 Deployment Summary" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "### URLs" >> $GITHUB_STEP_SUMMARY
-          echo "- **Azure URL:** https://${{ env.ORG_CODE }}-prod-${{ env.PROJECT_NAME }}-app.azurewebsites.net" >> $GITHUB_STEP_SUMMARY
+          echo "- **Azure URL:** https://${{ env.APP_NAME }}.azurewebsites.net" >> $GITHUB_STEP_SUMMARY
 
           if [ "${ENABLE_CUSTOM_DOMAIN}" = "true" ]; then
             echo "- **Custom Domain:** https://${{ env.APP_SUBDOMAIN }}.${{ env.DNS_ZONE }}" >> $GITHUB_STEP_SUMMARY

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -6,7 +6,7 @@
 import type { MetadataRoute } from 'next';
 
 const BASE_URL =
-  process.env.NEXT_PUBLIC_SITE_URL || 'https://nl-dev-omnipost-app.azurewebsites.net';
+  process.env.NEXT_PUBLIC_SITE_URL || 'https://nl-dev-omnipost-web.azurewebsites.net';
 
 export default function robots(): MetadataRoute.Robots {
   const isProduction = process.env.NODE_ENV === 'production';

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -6,7 +6,7 @@
 import type { MetadataRoute } from 'next';
 
 const BASE_URL =
-  process.env.NEXT_PUBLIC_SITE_URL || 'https://nl-dev-omnipost-app.azurewebsites.net';
+  process.env.NEXT_PUBLIC_SITE_URL || 'https://nl-dev-omnipost-web.azurewebsites.net';
 const lastModified = new Date('2026-03-30');
 
 export default function sitemap(): MetadataRoute.Sitemap {

--- a/docs/AZURE_SECRETS.md
+++ b/docs/AZURE_SECRETS.md
@@ -22,7 +22,7 @@ The application requires several environment variables and secrets to function p
 - **How to Set:**
   ```bash
   az webapp config appsettings set \
-    --name nl-dev-omnipost-app \
+    --name nl-dev-omnipost-web \
     --resource-group nl-dev-omnipost-rg \
     --settings JWT_SECRET="your-generated-secret-here"
   ```
@@ -35,7 +35,7 @@ Configure these only if you're using the respective integrations:
 
 ```bash
 az webapp config appsettings set \
-  --name nl-dev-omnipost-app \
+  --name nl-dev-omnipost-web \
   --resource-group nl-dev-omnipost-rg \
   --settings \
     AIRTABLE_API_KEY="your-api-key" \
@@ -47,7 +47,7 @@ az webapp config appsettings set \
 
 ```bash
 az webapp config appsettings set \
-  --name nl-dev-omnipost-app \
+  --name nl-dev-omnipost-web \
   --resource-group nl-dev-omnipost-rg \
   --settings HUGGING_FACE_API_KEY="your-api-key"
 ```
@@ -56,7 +56,7 @@ az webapp config appsettings set \
 
 ```bash
 az webapp config appsettings set \
-  --name nl-dev-omnipost-app \
+  --name nl-dev-omnipost-web \
   --resource-group nl-dev-omnipost-rg \
   --settings \
     EMAIL_USER="your-email@gmail.com" \
@@ -69,7 +69,7 @@ az webapp config appsettings set \
 
 ```bash
 az webapp config appsettings set \
-  --name nl-dev-omnipost-app \
+  --name nl-dev-omnipost-web \
   --resource-group nl-dev-omnipost-rg \
   --settings SLACK_TOKEN="xoxb-your-slack-bot-token"
 ```
@@ -78,7 +78,7 @@ az webapp config appsettings set \
 
 ```bash
 az webapp config appsettings set \
-  --name nl-dev-omnipost-app \
+  --name nl-dev-omnipost-web \
   --resource-group nl-dev-omnipost-rg \
   --settings \
     TWILIO_ACCOUNT_SID="your-account-sid" \
@@ -91,7 +91,7 @@ az webapp config appsettings set \
 ```bash
 # Facebook
 az webapp config appsettings set \
-  --name nl-dev-omnipost-app \
+  --name nl-dev-omnipost-web \
   --resource-group nl-dev-omnipost-rg \
   --settings \
     FACEBOOK_API_URL="https://graph.facebook.com" \
@@ -99,7 +99,7 @@ az webapp config appsettings set \
 
 # Instagram
 az webapp config appsettings set \
-  --name nl-dev-omnipost-app \
+  --name nl-dev-omnipost-web \
   --resource-group nl-dev-omnipost-rg \
   --settings \
     INSTAGRAM_API_URL="https://graph.instagram.com" \
@@ -107,7 +107,7 @@ az webapp config appsettings set \
 
 # LinkedIn
 az webapp config appsettings set \
-  --name nl-dev-omnipost-app \
+  --name nl-dev-omnipost-web \
   --resource-group nl-dev-omnipost-rg \
   --settings \
     LINKEDIN_API_URL="https://api.linkedin.com" \
@@ -115,7 +115,7 @@ az webapp config appsettings set \
 
 # Twitter/X
 az webapp config appsettings set \
-  --name nl-dev-omnipost-app \
+  --name nl-dev-omnipost-web \
   --resource-group nl-dev-omnipost-rg \
   --settings \
     TWITTER_API_URL="https://api.twitter.com" \
@@ -137,7 +137,7 @@ SLUICE_GATEWAY_URL="https://$(az containerapp show \
 
 # Then apply it to the app settings
 az webapp config appsettings set \
-  --name nl-dev-omnipost-app \
+  --name nl-dev-omnipost-web \
   --resource-group nl-dev-omnipost-rg \
   --settings \
     SLUICE_GATEWAY_URL="$SLUICE_GATEWAY_URL" \
@@ -150,7 +150,7 @@ az webapp config appsettings set \
 
 Alternatively, you can configure these via the Azure Portal:
 
-1. Navigate to your App Service: `nl-dev-omnipost-app`
+1. Navigate to your App Service: `nl-dev-omnipost-web`
 2. Go to **Settings** → **Configuration**
 3. Click **+ New application setting**
 4. Add each setting with its value
@@ -173,7 +173,7 @@ For production environments, store secrets in Azure Key Vault and reference them
 
    ```bash
    az webapp config appsettings set \
-     --name nl-prod-omnipost-app \
+     --name nl-prod-omnipost-web \
      --resource-group nl-prod-omnipost-rg \
      --settings JWT_SECRET="@Microsoft.KeyVault(VaultName=nl-prod-omnipost-kv;SecretName=JWT-SECRET)"
    ```
@@ -183,12 +183,12 @@ For production environments, store secrets in Azure Key Vault and reference them
    ```bash
    # Enable managed identity
    az webapp identity assign \
-     --name nl-prod-omnipost-app \
+     --name nl-prod-omnipost-web \
      --resource-group nl-prod-omnipost-rg
 
    # Get the principal ID
    PRINCIPAL_ID=$(az webapp identity show \
-     --name nl-prod-omnipost-app \
+     --name nl-prod-omnipost-web \
      --resource-group nl-prod-omnipost-rg \
      --query principalId -o tsv)
 
@@ -206,13 +206,13 @@ After setting secrets, verify they're available:
 ```bash
 # List all app settings
 az webapp config appsettings list \
-  --name nl-dev-omnipost-app \
+  --name nl-dev-omnipost-web \
   --resource-group nl-dev-omnipost-rg \
   --query "[].{Name:name, Value:value}" \
   --output table
 
 # Test the health endpoint
-curl https://nl-dev-omnipost-app.azurewebsites.net/api/health
+curl https://nl-dev-omnipost-web.azurewebsites.net/api/health
 ```
 
 ## GitHub Secrets for CI/CD

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -48,7 +48,7 @@ param apiSubdomain string = 'api.omnipost'
 // Region suffix dropped per ADR-0027 (mystira) applied to omnipost: region is already
 // expressed by the resource group's location property; the suffix added noise without value.
 var base = '${org}-${env}-${project}'
-var appName = '${base}-app'
+var appName = '${base}-web'
 var appServicePlanName = '${base}-asp'
 
 // Generate tags
@@ -106,6 +106,10 @@ resource webApp 'Microsoft.Web/sites@2022-09-01' = {
         {
           name: 'NODE_ENV'
           value: 'production'
+        }
+        {
+          name: 'NEXT_PUBLIC_SITE_URL'
+          value: 'https://${appName}.azurewebsites.net'
         }
         // IMPORTANT: Application secrets (JWT_SECRET, API keys) must be configured separately
         // See docs/AZURE_SECRETS.md for configuration instructions

--- a/infra/naming.sh
+++ b/infra/naming.sh
@@ -50,8 +50,8 @@ generate_names() {
   # Resource Group: [org]-[env]-[project]-rg
   echo "RESOURCE_GROUP=${base}-rg"
 
-  # App Service: [org]-[env]-[project]-app
-  echo "APP_NAME=${base}-app"
+  # App Service: [org]-[env]-[project]-web
+  echo "APP_NAME=${base}-web"
 
   # App Service Plan: [org]-[env]-[project]-asp
   echo "ASP_NAME=${base}-asp"


### PR DESCRIPTION
## Summary

- change the Azure Web App resource suffix from `app` to `web`
- preserve the retired-region naming convention
- avoid the global App Service name collision on `nl-dev-omnipost-app`

## Validation

- `bash infra/naming.sh nl dev omnipost euw`
- `az bicep build --file infra/main.bicep --stdout --only-show-errors`
