### PR TITLE
fix: remove unused monitoring region parameter

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -162,7 +162,6 @@ module monitoring 'monitoring.bicep' = if (enableMonitoring) {
     org: org
     env: env
     project: project
-    region: region
     location: location
     tags: tags
     webAppId: webApp.id

--- a/infra/monitoring.bicep
+++ b/infra/monitoring.bicep
@@ -10,9 +10,6 @@ param env string
 @description('Project name')
 param project string
 
-@description('Region code')
-param region string
-
 @description('The location to deploy Application Insights')
 param location string = resourceGroup().location
 
@@ -22,7 +19,7 @@ param tags object = {}
 @description('Web App resource ID for diagnostic settings')
 param webAppId string
 
-// Generate names (region suffix dropped per ADR-0027; region param retained for tags/future multi-region)
+// Generate names (region suffix dropped per ADR-0027)
 var base = '${org}-${env}-${project}'
 var appInsightsName = '${base}-ai'
 var logAnalyticsName = '${base}-law'


### PR DESCRIPTION
## Summary
- remove the unused monitoring module region parameter
- stop Bicep linter warning output from failing azure/arm-deploy with failOnStdErr

## Validation
- az bicep build --file infra/main.bicep --stdout --only-show-errors