### PR TITLE
test: reduce alpha lint noise

### DIFF
--- a/__tests__/api/analytics-events.test.ts
+++ b/__tests__/api/analytics-events.test.ts
@@ -109,7 +109,7 @@ describe('Analytics Events API', () => {
       // Override headers mock to simulate unauthenticated request
       const { headers } = require('next/headers');
       (headers as jest.Mock).mockReturnValueOnce({
-        get: (name: string) => {
+        get: (_name: string) => {
           // No x-user-id header means unauthenticated
           return null;
         },

--- a/__tests__/api/scheduler-routes.test.ts
+++ b/__tests__/api/scheduler-routes.test.ts
@@ -104,7 +104,7 @@ describe('Scheduler API Routes', () => {
       // Override headers mock to simulate unauthenticated request
       const { headers } = require('next/headers');
       (headers as jest.Mock).mockReturnValueOnce({
-        get: (name: string) => null, // No x-user-id
+        get: (_name: string) => null, // No x-user-id
       });
 
       const request = createRequest('GET');
@@ -174,7 +174,7 @@ describe('Scheduler API Routes', () => {
     test('requires authentication for POST', async () => {
       const { headers } = require('next/headers');
       (headers as jest.Mock).mockReturnValueOnce({
-        get: (name: string) => null, // No x-user-id
+        get: (_name: string) => null, // No x-user-id
       });
 
       const validJob = {
@@ -187,7 +187,7 @@ describe('Scheduler API Routes', () => {
 
       const request = createRequest('POST', validJob);
       const response = await POST(request);
-      const data = await response.json();
+      await response.json();
 
       expect(response.status).toBe(401);
       expect(mockSchedule).not.toHaveBeenCalled();

--- a/__tests__/components/PageSkeleton.test.tsx
+++ b/__tests__/components/PageSkeleton.test.tsx
@@ -9,7 +9,6 @@ import PageSkeleton from '@/components/ui/PageSkeleton';
 describe('PageSkeleton', () => {
   it('renders correct number of rows', () => {
     const { container } = render(<PageSkeleton rows={5} />);
-    const rows = container.querySelectorAll('[class*="row"]');
     // Each row contains a row div with a rowLine div inside, so filter to direct row children
     const rowContainer = container.querySelector('[class*="rows"]');
     expect(rowContainer).toBeInTheDocument();

--- a/__tests__/lib/analytics-tracker.test.ts
+++ b/__tests__/lib/analytics-tracker.test.ts
@@ -13,9 +13,6 @@ import { beforeEach, afterEach, describe, expect, jest, test } from '@jest/globa
 const mockFetch = jest.fn<() => Promise<Response>>();
 global.fetch = mockFetch as unknown as typeof fetch;
 
-// Set up sessionStorage data
-const SESSION_KEY = 'omnipost_session_id';
-
 describe('Analytics Tracker', () => {
   let tracker: {
     track: (name: string, properties?: Record<string, unknown>) => void;

--- a/__tests__/lib/sluice-gateway.test.ts
+++ b/__tests__/lib/sluice-gateway.test.ts
@@ -31,9 +31,6 @@ jest.mock('../../lib/featureFlags', () => ({
 }));
 
 describe('Sluice Gateway Client', () => {
-  let isGatewayEnabled: () => boolean;
-  let gatewayPost: Function;
-
   beforeEach(() => {
     jest.clearAllMocks();
 
@@ -46,9 +43,6 @@ describe('Sluice Gateway Client', () => {
 
     // Re-import module to pick up new flag state
     jest.resetModules();
-    const mod = require('../../lib/clients/sluice-gateway');
-    isGatewayEnabled = mod.isGatewayEnabled;
-    gatewayPost = mod.gatewayPost;
   });
 
   describe('isGatewayEnabled()', () => {

--- a/app/signup/page.tsx
+++ b/app/signup/page.tsx
@@ -44,7 +44,7 @@ interface AuthProviderInfo {
 export default function SignupPage() {
   const router = useRouter();
   const { isAuthenticated, isLoading } = useAuth();
-  const { track, trackSignup, events } = useAnalytics({ trackPageView: true });
+  const { trackSignup } = useAnalytics({ trackPageView: true });
   const [username, setUsername] = useState('');
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');


### PR DESCRIPTION
## Summary
- remove unused analytics destructuring from signup
- remove unused test constants and setup variables
- mark intentionally unused mock header parameters with underscore names

## Validation
- pnpm exec eslint app/signup/page.tsx __tests__/api/analytics-events.test.ts __tests__/api/scheduler-routes.test.ts __tests__/components/PageSkeleton.test.tsx __tests__/lib/analytics-tracker.test.ts __tests__/lib/sluice-gateway.test.ts
- pnpm exec prettier --check app/signup/page.tsx __tests__/api/analytics-events.test.ts __tests__/api/scheduler-routes.test.ts __tests__/components/PageSkeleton.test.tsx __tests__/lib/analytics-tracker.test.ts __tests__/lib/sluice-gateway.test.ts
- pnpm test -- __tests__/api/analytics-events.test.ts __tests__/api/scheduler-routes.test.ts __tests__/components/PageSkeleton.test.tsx __tests__/lib/analytics-tracker.test.ts __tests__/lib/sluice-gateway.test.ts
- pnpm run type-check

## Notes
- No infra/Bicep/docs changes are included in this PR.