### PR TITLE
fix: tighten audit lint cleanup

### DIFF
--- a/app/api/_utils/audit.ts
+++ b/app/api/_utils/audit.ts
@@ -131,7 +131,7 @@ export async function logToAuditTrail(entry: LogEntry): Promise<void> {
   }
 
   // Fallback to console logging
-  console.log('[AUDIT]', JSON.stringify(entry));
+  console.warn('[AUDIT]', JSON.stringify(entry));
 }
 
 interface ResultWithStatus {

--- a/types/index.ts
+++ b/types/index.ts
@@ -59,7 +59,7 @@ export interface Feedback {
 
 // User types
 export interface UserPayload {
-  [key: string]: any;
+  [key: string]: unknown;
   isAdmin?: boolean;
 }
 


### PR DESCRIPTION
## Summary
- use console.warn for audit fallback logging so it follows the repo console policy
- replace the UserPayload any index signature with unknown

## Validation
- pnpm exec eslint app/api/_utils/audit.ts types/index.ts
- pnpm exec prettier --check app/api/_utils/audit.ts types/index.ts
- pnpm run type-check
- pnpm test -- __tests__/api/analytics-events.test.ts __tests__/api/auth.test.ts __tests__/api/feature-flags.test.ts

## Notes
- No infra, Bicep, or docs changes are included in this PR.