### PR TITLE
fix: reduce rate limit console noise

### DIFF
--- a/app/api/_utils/rateLimit.ts
+++ b/app/api/_utils/rateLimit.ts
@@ -143,7 +143,6 @@ async function initUpstash(): Promise<Map<string, UpstashRatelimit> | null> {
       })
     );
 
-    console.log('[Rate Limit] Using Upstash Redis for distributed rate limiting');
     return upstashLimiters;
   } catch (error) {
     // Use safe error message to prevent sensitive data leaks
@@ -255,12 +254,6 @@ function safeEvict(now: number, targetSize: number): number {
         removed++;
       }
     }
-  }
-
-  if (removed > 0 && process.env.NODE_ENV !== 'production') {
-    console.debug(
-      `[Rate Limit] Safe-evicted ${removed} entries (store size: ${rateLimitStore.size})`
-    );
   }
 
   return removed;


### PR DESCRIPTION
Summary:
- remove informational Upstash success console log from rate limit initialization
- remove development-only safe-eviction debug console output

Validation:
- pnpm exec eslint app/api/_utils/rateLimit.ts
- pnpm exec prettier --check app/api/_utils/rateLimit.ts
- pnpm run type-check
- pnpm test -- __tests__/api/rateLimit.test.ts

Notes:
- No infra, Bicep, or docs changes included.