### PR TITLE
fix: type image fallback handlers

### DIFF
--- a/components/automation/ToolCard.tsx
+++ b/components/automation/ToolCard.tsx
@@ -23,8 +23,7 @@ const ToolCard: React.FC<ToolCardProps> = ({ tool, onSelect }) => {
           className="object-contain"
           // Fallback if images don't exist yet
           onError={e => {
-            // @ts-ignore
-            e.target.style.display = 'none';
+            e.currentTarget.style.display = 'none';
           }}
         />
       </div>

--- a/components/series/EmptyState.tsx
+++ b/components/series/EmptyState.tsx
@@ -20,8 +20,7 @@ const EmptyState: React.FC<EmptyStateProps> = ({ onCreateClick }) => {
           height={120}
           // Fallback if image doesn't exist
           onError={e => {
-            // @ts-ignore
-            e.target.style.display = 'none';
+            e.currentTarget.style.display = 'none';
           }}
         />
       </div>


### PR DESCRIPTION
Summary:
- remove ts-ignore suppressions from image fallback handlers
- use the typed currentTarget to hide missing fallback images

Validation:
- pnpm exec eslint components/series/EmptyState.tsx components/automation/ToolCard.tsx
- pnpm exec prettier --check components/series/EmptyState.tsx components/automation/ToolCard.tsx
- pnpm run type-check

Notes:
- No infra, Bicep, workflow, or docs changes included.