### PR TITLE
Use Sluice liveliness health probe

### DIFF
--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -61,7 +61,7 @@ the app package to the existing dev Web App.
 ```bash
 curl -I https://omnipost.neuralliquid.ai/api/health
 curl -I https://nl-dev-omnipost-web.azurewebsites.net/api/health
-curl https://nl-dev-omnipost-sluice.jollyfield-e2805f37.westeurope.azurecontainerapps.io/health/readiness
+curl https://nl-dev-omnipost-sluice.jollyfield-e2805f37.westeurope.azurecontainerapps.io/health/liveliness
 ```
 
 Expected result: HTTP `200 OK`.

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -61,8 +61,9 @@ Expected:
 ### Remaining Alpha Readiness Work
 
 - Configure required app secrets on `nl-dev-omnipost-web`. Current deployed settings include platform/runtime settings, but not `JWT_SECRET` or optional integration secrets.
-- Monitor first Sluice-routed calls and adjust model aliases if Omnipost needs
-  names beyond `gpt-4o` and `text-embedding-3-large`.
+- Use `/health/liveliness` as the Sluice quick-iteration health signal while
+  PostgreSQL remains disabled. `/health/readiness` may report `db: "Not
+connected"` even when the LiteLLM gateway is serving traffic.
 - Keep the existing managed certificate Azure-managed until a no-replacement
   Terraform import can be proven.
 - Follow up on non-blocking CI annotations:

--- a/infra/terraform/env/dev/main.tf
+++ b/infra/terraform/env/dev/main.tf
@@ -329,7 +329,7 @@ resource "azurerm_container_app" "sluice" {
 
       readiness_probe {
         transport        = "HTTP"
-        path             = "/health/readiness"
+        path             = "/health/liveliness"
         port             = 4000
         initial_delay    = 3
         interval_seconds = 5


### PR DESCRIPTION
## Summary
- switch Sluice Container App readiness probe to /health/liveliness
- update deployment and handoff docs to use liveliness as the quick-iteration health signal
- keep PostgreSQL modeled but disabled

## Validation
- terraform validate: success
- Sluice Container App state: Succeeded / Running
- GET /health/liveliness returned alive