### PR TITLE
fix: align alpha login and public claims

### DIFF
--- a/__tests__/lib/auth-service.test.ts
+++ b/__tests__/lib/auth-service.test.ts
@@ -114,4 +114,25 @@ describe('AuthService', () => {
       expect(authService.isTokenBlacklisted(token)).toBe(false);
     });
   });
+
+  describe('development credential fallback', () => {
+    const originalNodeEnv = process.env.NODE_ENV;
+
+    afterEach(() => {
+      Object.defineProperty(process.env, 'NODE_ENV', {
+        value: originalNodeEnv,
+        configurable: true,
+      });
+    });
+
+    it('should reject hardcoded admin credentials in production', async () => {
+      Object.defineProperty(process.env, 'NODE_ENV', {
+        value: 'production',
+        configurable: true,
+      });
+
+      await expect(authService.findUserByUsername('admin')).resolves.toBeNull();
+      await expect(authService.verifyUserCredentials('admin', 'admin')).resolves.toBe(false);
+    });
+  });
 });

--- a/app/(marketing)/page.tsx
+++ b/app/(marketing)/page.tsx
@@ -169,10 +169,10 @@ export default function HomePage() {
         </div>
       </section>
 
-      {/* ---- Social Proof ---- */}
+      {/* ---- Project Status ---- */}
       <section className={`${styles.section} ${styles.socialProofSection}`}>
         <div className={styles.sectionInner}>
-          <h2 className={styles.sectionTitle}>Trusted by Content Creators Worldwide</h2>
+          <h2 className={styles.sectionTitle}>Early Access, Built in the Open</h2>
 
           <div className={styles.metrics}>
             <div className={styles.metric}>
@@ -180,43 +180,43 @@ export default function HomePage() {
               <span className={styles.metricLabel}>MIT Licensed</span>
             </div>
             <div className={styles.metric}>
-              <span className={styles.metricValue}>2M+</span>
-              <span className={styles.metricLabel}>Posts published</span>
+              <span className={styles.metricValue}>Alpha</span>
+              <span className={styles.metricLabel}>First tester cohort</span>
             </div>
             <div className={styles.metric}>
-              <span className={styles.metricValue}>4.8/5</span>
-              <span className={styles.metricLabel}>Average rating</span>
+              <span className={styles.metricValue}>WIP</span>
+              <span className={styles.metricLabel}>Publishing flow in progress</span>
             </div>
           </div>
 
           <div className={styles.testimonials}>
             <article className={styles.testimonialCard}>
               <blockquote>
-                &ldquo;OmniPost cut my publishing time in half. I used to spend an hour reformatting
-                posts — now it takes seconds.&rdquo;
+                &ldquo;OmniPost is currently being shaped with direct tester feedback before public
+                launch.&rdquo;
               </blockquote>
               <p className={styles.testimonialAuthor}>
-                <strong>Sarah K.</strong> — Social Media Manager
+                <strong>Alpha note</strong> — Product status
               </p>
             </article>
 
             <article className={styles.testimonialCard}>
               <blockquote>
-                &ldquo;The AI adaptation feature is a game-changer. Each platform gets perfectly
-                tailored content automatically.&rdquo;
+                &ldquo;The focus is a practical first posting flow with AI-assisted wording for each
+                platform.&rdquo;
               </blockquote>
               <p className={styles.testimonialAuthor}>
-                <strong>Marcus T.</strong> — Content Creator
+                <strong>Current scope</strong> — Platform adaptation
               </p>
             </article>
 
             <article className={styles.testimonialCard}>
               <blockquote>
-                &ldquo;Finally, one dashboard for all our analytics. Our team makes better decisions
-                faster.&rdquo;
+                &ldquo;Metrics, scheduling depth, and advanced platform workflows will grow after
+                the first live path is stable.&rdquo;
               </blockquote>
               <p className={styles.testimonialAuthor}>
-                <strong>Priya R.</strong> — Marketing Director
+                <strong>Roadmap</strong> — Alpha readiness
               </p>
             </article>
           </div>

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,6 +1,6 @@
 /**
  * Login Page
- * Simple login page with admin/admin credentials
+ * Login page with optional external identity providers and local credentials
  */
 
 'use client';
@@ -42,7 +42,7 @@ export default function LoginPage() {
           }
         }
       } catch {
-        // External providers unavailable — email/password still works
+        // External providers unavailable - email/password still works when provisioned
       } finally {
         if (!cancelled) {
           setProvidersLoading(false);
@@ -174,9 +174,12 @@ export default function LoginPage() {
             </button>
           </form>
 
-          <p className={pageStyles.hint}>
-            Use <strong>admin</strong> / <strong>admin</strong> to login
-          </p>
+          {!providersLoading && providers.length === 0 && (
+            <p className={pageStyles.hint}>
+              Mystira Identity sign-in is not configured for this environment yet. Use a provisioned
+              OmniPost account when one is available.
+            </p>
+          )}
         </div>
       </main>
     </>

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -27,7 +27,7 @@ export default function NotFound() {
             Go home
           </Link>
           <Link
-            href="/dashboard"
+            href="/dashboard/dashboard"
             className="inline-flex items-center justify-center rounded-md border border-input bg-background px-4 py-2 text-sm font-medium shadow-sm hover:bg-accent hover:text-accent-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
           >
             Dashboard
@@ -44,22 +44,25 @@ export default function NotFound() {
               </Link>
             </li>
             <li>
-              <Link href="/dashboard" className="text-sm text-primary hover:underline">
+              <Link href="/dashboard/dashboard" className="text-sm text-primary hover:underline">
                 Dashboard
               </Link>
             </li>
             <li>
-              <Link href="/review" className="text-sm text-primary hover:underline">
+              <Link href="/dashboard/review" className="text-sm text-primary hover:underline">
                 Content Review
               </Link>
             </li>
             <li>
-              <Link href="/workflow" className="text-sm text-primary hover:underline">
+              <Link href="/dashboard/workflow" className="text-sm text-primary hover:underline">
                 Workflow
               </Link>
             </li>
             <li>
-              <Link href="/platform-analysis" className="text-sm text-primary hover:underline">
+              <Link
+                href="/dashboard/platform-analysis"
+                className="text-sm text-primary hover:underline"
+              >
                 Platform Analysis
               </Link>
             </li>

--- a/components/StructuredData.tsx
+++ b/components/StructuredData.tsx
@@ -24,6 +24,7 @@ const DEFAULT_STRUCTURED_DATA = {
   applicationCategory: 'BusinessApplication',
   operatingSystem: 'Web',
   browserRequirements: 'Requires JavaScript. Requires HTML5.',
+  softwareVersion: 'alpha',
   offers: [
     {
       '@type': 'Offer',
@@ -49,13 +50,6 @@ const DEFAULT_STRUCTURED_DATA = {
       description: 'Everything in Pro plus team collaboration, client workspaces, shared calendars',
     },
   ],
-  aggregateRating: {
-    '@type': 'AggregateRating',
-    ratingValue: '4.8',
-    ratingCount: '256',
-    bestRating: '5',
-    worstRating: '1',
-  },
   creator: {
     '@type': 'Organization',
     name: 'OmniPost',

--- a/lib/auth/auth-service.ts
+++ b/lib/auth/auth-service.ts
@@ -218,8 +218,8 @@ export class AuthService {
       // Prisma not available, fall through to hardcoded user
     }
 
-    // Hardcoded admin user for development
-    if (username === 'admin') {
+    // Hardcoded admin user for local development and tests only
+    if (process.env.NODE_ENV !== 'production' && username === 'admin') {
       return {
         id: 'admin-1',
         username: 'admin',
@@ -299,8 +299,8 @@ export class AuthService {
       // Prisma not available, fall through to test credentials
     }
 
-    // Hardcoded admin/admin credentials for development
-    if (username === 'admin' && password === 'admin') {
+    // Hardcoded admin/admin credentials for local development and tests only
+    if (!isProduction && username === 'admin' && password === 'admin') {
       return true;
     }
 

--- a/lib/auth/identity-provider.ts
+++ b/lib/auth/identity-provider.ts
@@ -80,13 +80,13 @@ function getConfig(): IdentityProviderConfig | null {
   const flag = featureFlags.externalIdentityProvider as
     | { enabled: boolean; apiUrl?: string }
     | undefined;
+  const apiUrl = flag?.apiUrl || process.env.IDENTITY_API_URL;
+  const apiKey = process.env.IDENTITY_API_KEY;
+  const envEnabled = process.env.EXTERNAL_IDENTITY_PROVIDER_ENABLED === 'true';
 
-  if (!flag?.enabled) {
+  if (!flag?.enabled && !envEnabled) {
     return null;
   }
-
-  const apiUrl = flag.apiUrl || process.env.IDENTITY_API_URL;
-  const apiKey = process.env.IDENTITY_API_KEY;
 
   if (!apiUrl || !apiKey) {
     return null;


### PR DESCRIPTION
Summary:
- replace inflated landing-page social proof with alpha/early-access product status
- remove unearned aggregate rating JSON-LD from default structured data
- fix 404 helper links to point at existing dashboard routes
- stop advertising admin/admin on login and reject hardcoded admin fallback in production
- allow Mystira Identity provider config to be enabled via EXTERNAL_IDENTITY_PROVIDER_ENABLED with IDENTITY_API_URL and IDENTITY_API_KEY

Live finding:
- https://omnipost.neuralliquid.ai/api/auth/providers currently returns an empty provider list
- Azure app settings query found no JWT_SECRET, IDENTITY_API_URL, IDENTITY_API_KEY, TEST_USER_USERNAME, or TEST_USER_PASSWORD on nl-dev-omnipost-web

Validation:
- pnpm exec eslint app/(marketing)/page.tsx app/not-found.tsx components/StructuredData.tsx app/login/page.tsx lib/auth/auth-service.ts lib/auth/identity-provider.ts __tests__/lib/auth-service.test.ts
- pnpm exec prettier --check app/(marketing)/page.tsx app/not-found.tsx components/StructuredData.tsx app/login/page.tsx lib/auth/auth-service.ts lib/auth/identity-provider.ts __tests__/lib/auth-service.test.ts
- pnpm run type-check
- pnpm test -- __tests__/api/auth.test.ts __tests__/lib/auth-service.test.ts __tests__/components/StructuredData.test.tsx __tests__/api/health.test.ts

Notes:
- Runtime Mystira Identity still requires app settings: EXTERNAL_IDENTITY_PROVIDER_ENABLED=true, IDENTITY_API_URL, IDENTITY_API_KEY, and JWT_SECRET.