### PR TITLE
chore: enable Sluice PostgreSQL persistence

### DIFF
--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -23,7 +23,7 @@ Product runtime is owned by this repo:
 - Key Vault: `nl-dev-omnipost-kv`
 - Sluice gateway: `nl-dev-omnipost-sluice`
 - Sluice URL: `https://nl-dev-omnipost-sluice.jollyfield-e2805f37.westeurope.azurecontainerapps.io`
-- PostgreSQL: modeled but disabled by default
+- PostgreSQL: `nl-dev-omnipost-psql-swc` in Sweden Central, database `omnipost`
 
 Organization DNS is owned by `neuralliquid-org`:
 
@@ -61,7 +61,7 @@ the app package to the existing dev Web App.
 ```bash
 curl -I https://omnipost.neuralliquid.ai/api/health
 curl -I https://nl-dev-omnipost-web.azurewebsites.net/api/health
-curl https://nl-dev-omnipost-sluice.jollyfield-e2805f37.westeurope.azurecontainerapps.io/health/liveliness
+curl https://nl-dev-omnipost-sluice.jollyfield-e2805f37.westeurope.azurecontainerapps.io/health/readiness
 ```
 
-Expected result: HTTP `200 OK`.
+Expected result: HTTP `200 OK`; Sluice readiness should include `db: "connected"`.

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -27,7 +27,8 @@
 - Active runtime infrastructure validation now runs through Terraform. The
   legacy production Bicep workflow is retained but hard-disabled.
 - Key Vault and Sluice gateway are modeled as live Terraform resources.
-- PostgreSQL is modeled in Terraform with `enable_postgresql = false`.
+- PostgreSQL is live in Terraform for Sluice LiteLLM persistence:
+  `nl-dev-omnipost-psql-swc` in Sweden Central with database `omnipost`.
 - Sluice gateway is live at
   `https://nl-dev-omnipost-sluice.jollyfield-e2805f37.westeurope.azurecontainerapps.io`;
   Omnipost Web App settings include `SLUICE_GATEWAY_URL` and `SLUICE_API_KEY`.
@@ -61,9 +62,8 @@ Expected:
 ### Remaining Alpha Readiness Work
 
 - Configure required app secrets on `nl-dev-omnipost-web`. Current deployed settings include platform/runtime settings, but not `JWT_SECRET` or optional integration secrets.
-- Use `/health/liveliness` as the Sluice quick-iteration health signal while
-  PostgreSQL remains disabled. `/health/readiness` may report `db: "Not
-connected"` even when the LiteLLM gateway is serving traffic.
+- Use `/health/readiness` as the Sluice health signal; readiness should report
+  `db: "connected"` for the database-backed LiteLLM gateway.
 - Keep the existing managed certificate Azure-managed until a no-replacement
   Terraform import can be proven.
 - Follow up on non-blocking CI annotations:
@@ -89,7 +89,7 @@ connected"` even when the LiteLLM gateway is serving traffic.
 | Component                | Files                                                      | Purpose                                                                                                           |
 | ------------------------ | ---------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
 | **Sluice AI Gateway**    | `lib/clients/sluice-gateway.ts`, `infra/terraform/env/dev` | OpenAI-compatible proxy for centralized AI cost tracking, model routing, failover. Feature-flagged (`aiGateway`). |
-| **Azure PostgreSQL**     | `infra/terraform/env/dev`                                  | Modeled in Terraform with `enable_postgresql = false`.                                                            |
+| **Azure PostgreSQL**     | `infra/terraform/env/dev`                                  | Live Terraform-managed Sluice LiteLLM persistence in Sweden Central.                                              |
 | **Retort Orchestration** | `.agentkit/spec/*.yaml`                                    | Single-source YAML spec generating configs for 16+ AI tools.                                                      |
 | **Agent Rules**          | `.cursor/rules/` (10), `.windsurf/rules/` (10)             | Team-scoped coding rules for Claude, Cursor, Windsurf, Copilot.                                                   |
 | **Baton**                | `lib/integrations/baton.ts`                                | MCP client for task management + org context (proxies mcp-org). Feature-flagged (`baton`). Formerly phoenix-flow. |
@@ -250,10 +250,10 @@ pnpm test:e2e               # Playwright E2E tests (needs running dev server)
 | -------------------- | ----------------- | ------------------------------------------------------------------- |
 | **Retort**           | Active            | `.agentkit/spec/` → generates agent configs                         |
 | **MarketingSkills**  | Active            | 34 skills in `.agents/skills/`, validated                           |
-| **Sluice**           | Ready (flag off)  | `lib/clients/sluice-gateway.ts` + `infra/terraform/env/dev`         |
+| **Sluice**           | Live              | `lib/clients/sluice-gateway.ts` + `infra/terraform/env/dev`         |
 | **Baton**            | Ready (flag off)  | `lib/integrations/baton.ts` + task board UI (formerly phoenix-flow) |
 | **mcp-org**          | Ready (via baton) | Org context proxied through baton MCP                               |
-| **Azure PostgreSQL** | Modeled, disabled | `infra/terraform/env/dev` with `enable_postgresql = false`          |
+| **Azure PostgreSQL** | Live              | `infra/terraform/env/dev`; Sluice LiteLLM persistence database      |
 
 ---
 

--- a/infra/README.md
+++ b/infra/README.md
@@ -23,8 +23,8 @@ Active workflow ownership:
 - Manual Terraform plan/apply: `.github/workflows/terraform-dev.yml`
 
 `deploy-prod.yml` is retained as a legacy Bicep workflow but hard-disabled.
-Key Vault and Sluice gateway are now modeled in Terraform. PostgreSQL is modeled
-with `enable_postgresql = false`.
+Key Vault, Sluice gateway, and the Sluice PostgreSQL persistence database are
+now modeled in Terraform.
 
 ## Recent Changes
 
@@ -41,7 +41,8 @@ The live dev runtime was imported into Terraform with no live Azure changes:
 - `omnipost.neuralliquid.ai` hostname binding
 - Key Vault
 - Sluice Container App Environment and internal gateway
-- PostgreSQL resources, disabled by default
+- PostgreSQL Flexible Server `nl-dev-omnipost-psql-swc` in Sweden Central with
+  database `omnipost`
 
 The existing App Service managed certificate remains live in Azure. Certificate
 lifecycle should remain Azure-managed until a no-replacement Terraform import

--- a/infra/terraform/env/dev/.terraform.lock.hcl
+++ b/infra/terraform/env/dev/.terraform.lock.hcl
@@ -20,3 +20,24 @@ provider "registry.terraform.io/hashicorp/azurerm" {
     "zh:facf68ea5bf0f2b8ba720e7fba5f86492e1d4c591100460bb91c3f79f391f4b6",
   ]
 }
+
+provider "registry.terraform.io/hashicorp/random" {
+  version     = "3.9.0"
+  constraints = "~> 3.7"
+  hashes = [
+    "h1:q/uaUTBdKgAmZESrwsoeDQff9uUA/cI/N5ZKNgVwa9c=",
+    "zh:161ad0bd9a75768c82f53fb6e7172a9d8be2d4889b012645a34795031aaf1bf1",
+    "zh:19dc9a5b17729725ccfc4f45b0500af0ee5bc6b6b160c7adb8f2bf617d2c80ea",
+    "zh:269eda8fe42daa7974d5a34d166c3ba9defe80cde86c01e4dadcfdf2e1f05e5f",
+    "zh:373f7c65566f8f2cc7f45d698654feb9d988996957e1266a69ca00c52d6d16d0",
+    "zh:5599d16804c41c83009ec621b6d6b6f74e102f5827678a4750f8809055546b61",
+    "zh:583be0440469a22bff70dcfa56593b01566860b29607437264adb51060cf46fc",
+    "zh:5f211d8ec3f2e1f414870d9584bfe26e6995560ef81c748f8447a48164767398",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:7b547fd16216761ef86efc3ed516ac5ac0c5c42b7c7eb24a08cef2d93f69ed5e",
+    "zh:7e7c0679daf2a382151d05068c8c3f0dae6b7b7dccf818827b73dd08638df2ef",
+    "zh:8089dec888a8038b9b4fb23b3df7e1057293dbc5b60b42cc47ff690d69d4b61b",
+    "zh:c51f15a031edfd6f23ce8ced3446ca7f8d8d647e2499890d7d5d10d5016d7257",
+    "zh:c94784f005708890dc6895afd53636ec00ec1e430b15d41e5aebfb1d4b39bd04",
+  ]
+}

--- a/infra/terraform/env/dev/README.md
+++ b/infra/terraform/env/dev/README.md
@@ -24,9 +24,8 @@ DNS records for `omnipost.neuralliquid.ai` are owned by
 - `nl-dev-omnipost-kv`
 - `nl-dev-omnipost-cae`
 - `nl-dev-omnipost-sluice`
-
-PostgreSQL is modeled in Terraform but disabled by default with
-`enable_postgresql = false`.
+- `nl-dev-omnipost-psql-swc` in `swedencentral`
+- PostgreSQL database `omnipost`
 
 The existing App Service managed certificate remains live in Azure but is not
 managed by this first Terraform pass because importing it as

--- a/infra/terraform/env/dev/main.tf
+++ b/infra/terraform/env/dev/main.tf
@@ -38,6 +38,15 @@ locals {
       master_key = "os.environ/LITELLM_GATEWAY_KEY"
     }
   })
+
+  postgresql_password = var.enable_postgresql ? coalesce(var.postgresql_administrator_password, random_password.postgresql[0].result) : null
+  postgresql_url = var.enable_postgresql ? format(
+    "postgresql://%s:%s@%s:5432/%s?sslmode=require",
+    var.postgresql_administrator_login,
+    urlencode(local.postgresql_password),
+    azurerm_postgresql_flexible_server.this[0].fqdn,
+    var.postgresql_database_name
+  ) : null
 }
 
 data "azurerm_client_config" "current" {}
@@ -267,6 +276,14 @@ resource "azurerm_container_app" "sluice" {
     value = var.sluice_api_key
   }
 
+  dynamic "secret" {
+    for_each = var.enable_postgresql ? [1] : []
+    content {
+      name  = "litellm-db-url"
+      value = local.postgresql_url
+    }
+  }
+
   ingress {
     external_enabled = true
     target_port      = 4000
@@ -290,8 +307,8 @@ resource "azurerm_container_app" "sluice" {
     container {
       name   = "litellm"
       image  = var.sluice_image
-      cpu    = 0.5
-      memory = "1Gi"
+      cpu    = var.enable_postgresql ? 1.0 : 0.5
+      memory = var.enable_postgresql ? "2Gi" : "1Gi"
 
       command = [
         "/bin/sh",
@@ -319,6 +336,14 @@ resource "azurerm_container_app" "sluice" {
         value = "4000"
       }
 
+      dynamic "env" {
+        for_each = var.enable_postgresql ? [1] : []
+        content {
+          name        = "DATABASE_URL"
+          secret_name = "litellm-db-url"
+        }
+      }
+
       liveness_probe {
         transport        = "HTTP"
         path             = "/health/liveliness"
@@ -329,7 +354,7 @@ resource "azurerm_container_app" "sluice" {
 
       readiness_probe {
         transport        = "HTTP"
-        path             = "/health/liveliness"
+        path             = "/health/readiness"
         port             = 4000
         initial_delay    = 3
         interval_seconds = 5
@@ -338,20 +363,32 @@ resource "azurerm_container_app" "sluice" {
   }
 }
 
+resource "random_password" "postgresql" {
+  count = var.enable_postgresql ? 1 : 0
+
+  length           = 32
+  special          = true
+  override_special = "_%@"
+}
+
 resource "azurerm_postgresql_flexible_server" "this" {
   count = var.enable_postgresql ? 1 : 0
 
-  name                          = "${local.base}-psql"
+  name                          = "${local.base}-psql-swc"
   resource_group_name           = azurerm_resource_group.this.name
-  location                      = azurerm_resource_group.this.location
+  location                      = var.postgresql_location
   version                       = var.postgresql_version
   administrator_login           = var.postgresql_administrator_login
-  administrator_password        = var.postgresql_administrator_password
+  administrator_password        = local.postgresql_password
   sku_name                      = "B_Standard_B1ms"
   storage_mb                    = var.postgresql_storage_mb
   backup_retention_days         = var.postgresql_backup_retention_days
   public_network_access_enabled = true
   tags                          = merge(local.tags, { managedBy = "terraform", component = "postgresql" })
+
+  lifecycle {
+    ignore_changes = [zone]
+  }
 }
 
 resource "azurerm_postgresql_flexible_server_firewall_rule" "allow_azure_services" {

--- a/infra/terraform/env/dev/outputs.tf
+++ b/infra/terraform/env/dev/outputs.tf
@@ -30,3 +30,7 @@ output "sluice_gateway_url" {
 output "postgresql_server_name" {
   value = var.enable_postgresql ? azurerm_postgresql_flexible_server.this[0].name : null
 }
+
+output "postgresql_database_name" {
+  value = var.enable_postgresql ? azurerm_postgresql_flexible_server_database.app[0].name : null
+}

--- a/infra/terraform/env/dev/variables.tf
+++ b/infra/terraform/env/dev/variables.tf
@@ -37,7 +37,7 @@ variable "enable_sluice_gateway" {
 variable "sluice_image" {
   type        = string
   description = "Container image for the Sluice gateway."
-  default     = "litellm/litellm:v1.83.7-stable"
+  default     = "litellm/litellm-database:v1.83.7-stable@sha256:85e3d3ca43ff554b5731b00ef470ce7717f47505e56676afd46ec3a9f5a63466"
 }
 
 variable "sluice_azure_openai_endpoint" {
@@ -84,8 +84,8 @@ variable "sluice_azure_openai_embedding_api_version" {
 
 variable "enable_postgresql" {
   type        = bool
-  description = "Whether to manage Omnipost PostgreSQL. Kept false during quick iteration."
-  default     = false
+  description = "Whether to manage PostgreSQL for Sluice LiteLLM persistence."
+  default     = true
 }
 
 variable "postgresql_administrator_login" {
@@ -105,6 +105,12 @@ variable "postgresql_version" {
   type        = string
   description = "PostgreSQL major version."
   default     = "16"
+}
+
+variable "postgresql_location" {
+  type        = string
+  description = "Azure region for PostgreSQL Flexible Server. Separate from the Web App region because some subscriptions are restricted by offer in westeurope."
+  default     = "swedencentral"
 }
 
 variable "postgresql_database_name" {

--- a/infra/terraform/env/dev/versions.tf
+++ b/infra/terraform/env/dev/versions.tf
@@ -15,6 +15,10 @@ terraform {
       source  = "hashicorp/azurerm"
       version = "~> 4.0"
     }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.7"
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- enable Terraform-managed PostgreSQL persistence for the Sluice LiteLLM gateway
- switch Sluice to the database-capable pinned LiteLLM image and readiness probe
- document the live PostgreSQL-backed Sluice state

## Live verification
- Terraform apply completed for PostgreSQL Flexible Server \
l-dev-omnipost-psql-swc\ and database \omnipost\
- Sluice Container App latest revision has 100% traffic
- \/health/readiness\ returns HTTP 200 with \db: connected\

## Validation
- \	erraform -chdir=infra/terraform/env/dev fmt -check\
- \	erraform -chdir=infra/terraform/env/dev validate\
- \	erraform -chdir=infra/terraform/env/dev plan -input=false -refresh=false -lock-timeout=2m -no-color\ -> no changes