### PR TITLE
fix: add PKCE to Mystira OIDC login

### DIFF
--- a/app/api/auth/callback/[provider]/route.ts
+++ b/app/api/auth/callback/[provider]/route.ts
@@ -4,7 +4,7 @@
  * Starts and completes external identity provider callbacks.
  */
 
-import { randomBytes } from 'crypto';
+import { createHash, randomBytes } from 'crypto';
 import { cookies } from 'next/headers';
 import { NextResponse } from 'next/server';
 import { createLogEntry, logToAuditTrail } from '../../../_utils/audit';
@@ -30,6 +30,7 @@ interface ExternalUserRecord {
 interface StoredOAuthState {
   state: string;
   redirect: string;
+  codeVerifier: string;
 }
 
 /**
@@ -85,13 +86,25 @@ function parseStoredOAuthState(value: string | undefined): StoredOAuthState | nu
 
   try {
     const parsed = JSON.parse(value) as Partial<StoredOAuthState>;
-    if (typeof parsed.state !== 'string' || typeof parsed.redirect !== 'string') {
+    if (
+      typeof parsed.state !== 'string' ||
+      typeof parsed.redirect !== 'string' ||
+      typeof parsed.codeVerifier !== 'string'
+    ) {
       return null;
     }
-    return { state: parsed.state, redirect: parsed.redirect };
+    return {
+      state: parsed.state,
+      redirect: parsed.redirect,
+      codeVerifier: parsed.codeVerifier,
+    };
   } catch {
     return null;
   }
+}
+
+function createCodeChallenge(verifier: string): string {
+  return createHash('sha256').update(verifier).digest('base64url');
 }
 
 async function handleCallback(
@@ -116,8 +129,10 @@ async function handleCallback(
 
   if (!code) {
     const state = randomBytes(24).toString('base64url');
+    const codeVerifier = randomBytes(32).toString('base64url');
+    const codeChallenge = createCodeChallenge(codeVerifier);
     const requestedRedirect = url.searchParams.get('redirect') || '/dashboard';
-    const redirect = await initiateExternalAuth(provider, callbackUrl, state);
+    const redirect = await initiateExternalAuth(provider, callbackUrl, state, codeChallenge);
 
     if (!redirect) {
       const loginUrl = new URL('/login', publicOrigin);
@@ -130,6 +145,7 @@ async function handleCallback(
       value: JSON.stringify({
         state,
         redirect: parseSafeRedirect(requestedRedirect, publicOrigin),
+        codeVerifier,
       }),
       httpOnly: true,
       secure: process.env.NODE_ENV === 'production',
@@ -147,7 +163,12 @@ async function handleCallback(
     return Errors.badRequest('Invalid OAuth state');
   }
 
-  const authResult = await handleAuthCallback(provider, code, callbackUrl);
+  const authResult = await handleAuthCallback(
+    provider,
+    code,
+    callbackUrl,
+    storedState.codeVerifier
+  );
 
   if (!authResult.success || !authResult.user) {
     await logToAuditTrail(

--- a/lib/auth/identity-provider.ts
+++ b/lib/auth/identity-provider.ts
@@ -285,7 +285,8 @@ export async function getAvailableProviders(): Promise<AuthProvider[]> {
 export async function initiateExternalAuth(
   providerId: string,
   redirectUrl: string,
-  state?: string
+  state?: string,
+  codeChallenge?: string
 ): Promise<ExternalAuthRedirect | null> {
   const oidcConfig = getOidcConfig();
   if (oidcConfig && providerId === oidcConfig.providerId) {
@@ -301,6 +302,10 @@ export async function initiateExternalAuth(
     authUrl.searchParams.set('scope', oidcConfig.scope);
     if (state) {
       authUrl.searchParams.set('state', state);
+    }
+    if (codeChallenge) {
+      authUrl.searchParams.set('code_challenge', codeChallenge);
+      authUrl.searchParams.set('code_challenge_method', 'S256');
     }
 
     return { redirectUrl: authUrl.toString() };
@@ -355,12 +360,16 @@ export async function initiateExternalAuth(
 export async function handleAuthCallback(
   providerId: string,
   code: string,
-  redirectUrl?: string
+  redirectUrl?: string,
+  codeVerifier?: string
 ): Promise<ExternalAuthResult> {
   const oidcConfig = getOidcConfig();
   if (oidcConfig && providerId === oidcConfig.providerId) {
     if (!redirectUrl) {
       return { success: false, error: 'Missing redirect URL for OIDC callback' };
+    }
+    if (!codeVerifier) {
+      return { success: false, error: 'Missing PKCE verifier for OIDC callback' };
     }
 
     const discovery = await getOidcDiscovery(oidcConfig);
@@ -375,6 +384,7 @@ export async function handleAuthCallback(
         redirect_uri: redirectUrl,
         client_id: oidcConfig.clientId,
         client_secret: oidcConfig.clientSecret,
+        code_verifier: codeVerifier,
       });
 
       const tokenResponse = await fetch(discovery.token_endpoint, {


### PR DESCRIPTION
## Summary
- generate a PKCE code verifier/challenge when starting Mystira Identity auth
- include `code_challenge` and `code_challenge_method=S256` on the authorize redirect
- store the verifier in the short-lived OAuth state cookie and send `code_verifier` during token exchange

## Validation
- `pnpm exec eslint app/api/auth/callback/[provider]/route.ts lib/auth/identity-provider.ts`
- `pnpm run type-check`
- `pnpm exec prettier --check app/api/auth/callback/[provider]/route.ts lib/auth/identity-provider.ts`

## Live issue fixed
Mystira Identity rejected the authorize request with `invalid_request`: mandatory `code_challenge` parameter missing.