### PR TITLE
fix: complete mystira identity session handoff

### DIFF
--- a/__tests__/lib/identity-provider.test.ts
+++ b/__tests__/lib/identity-provider.test.ts
@@ -1,0 +1,105 @@
+function createUnsignedJwt(payload: Record<string, unknown>): string {
+  const header = Buffer.from(JSON.stringify({ alg: 'none', typ: 'JWT' })).toString('base64url');
+  const body = Buffer.from(JSON.stringify(payload)).toString('base64url');
+  return `${header}.${body}.`;
+}
+
+function createJsonResponse(body: Record<string, unknown>, status: number): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+  } as Response;
+}
+
+describe('Mystira Identity OIDC callback handling', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    jest.resetModules();
+    Object.defineProperty(globalThis.AbortSignal, 'timeout', {
+      configurable: true,
+      value: jest.fn(() => undefined),
+    });
+    process.env = {
+      ...originalEnv,
+      MYSTIRA_IDENTITY_ENABLED: 'true',
+      MYSTIRA_IDENTITY_ISSUER_URL: 'https://identity.example.test',
+      MYSTIRA_IDENTITY_CLIENT_ID: 'omnipost-client',
+      MYSTIRA_IDENTITY_CLIENT_SECRET: 'secret',
+      MYSTIRA_IDENTITY_PROVIDER_ID: 'mystira',
+    };
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    process.env = originalEnv;
+  });
+
+  it('falls back to id_token claims when userinfo rejects the access token', async () => {
+    const idToken = createUnsignedJwt({
+      sub: 'mystira-user-1',
+      email: 'user@mystira.app',
+      name: 'Mystira User',
+    });
+    const fetchMock = jest.fn(async input => {
+      const url = String(input);
+
+      if (url.endsWith('/.well-known/openid-configuration')) {
+        return createJsonResponse(
+          {
+            authorization_endpoint: 'https://identity.example.test/connect/authorize',
+            token_endpoint: 'https://identity.example.test/connect/token',
+            userinfo_endpoint: 'https://identity.example.test/connect/userinfo',
+          },
+          200
+        );
+      }
+
+      if (url.endsWith('/connect/token')) {
+        return createJsonResponse(
+          {
+            access_token: 'access-token-without-userinfo-sub',
+            id_token: idToken,
+          },
+          200
+        );
+      }
+
+      if (url.endsWith('/connect/userinfo')) {
+        return createJsonResponse({ error: 'invalid_token' }, 401);
+      }
+
+      return createJsonResponse({}, 404);
+    });
+    globalThis.fetch = fetchMock as typeof fetch;
+
+    const { clearProvidersCache, handleAuthCallback } =
+      await import('@/lib/auth/identity-provider');
+    clearProvidersCache();
+
+    const result = await handleAuthCallback(
+      'mystira',
+      'authorization-code',
+      'https://omnipost.neuralliquid.ai/api/auth/callback/mystira',
+      'pkce-verifier'
+    );
+
+    expect(result).toMatchObject({
+      success: true,
+      user: {
+        externalId: 'mystira-user-1',
+        email: 'user@mystira.app',
+        name: 'Mystira User',
+      },
+    });
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://identity.example.test/connect/userinfo',
+      expect.objectContaining({
+        headers: {
+          Authorization: 'Bearer access-token-without-userinfo-sub',
+        },
+      })
+    );
+  });
+});

--- a/app/api/auth/session/route.ts
+++ b/app/api/auth/session/route.ts
@@ -1,0 +1,20 @@
+import { NextResponse } from 'next/server';
+import { withErrorHandling } from '../../_utils/errors';
+import { authService } from '../../../../lib/auth/auth-service';
+
+export const GET = withErrorHandling(async (_req: Request) => {
+  const user = await authService.getCurrentUser();
+
+  if (!user) {
+    return NextResponse.json({ authenticated: false, user: null });
+  }
+
+  return NextResponse.json({
+    authenticated: true,
+    user: {
+      id: user.id,
+      username: user.username,
+      role: user.role,
+    },
+  });
+});

--- a/components/providers/AuthProvider.tsx
+++ b/components/providers/AuthProvider.tsx
@@ -15,6 +15,13 @@ export interface AuthUser {
   role: string;
 }
 
+interface StoredTokenPayload {
+  id?: string;
+  username?: string;
+  role?: string;
+  exp?: number;
+}
+
 interface AuthContextType {
   user: AuthUser | null;
   isAuthenticated: boolean;
@@ -33,45 +40,61 @@ export function AuthProvider({ children }: AuthProviderProps) {
   const [user, setUser] = useState<AuthUser | null>(null);
   const [isLoading, setIsLoading] = useState(true);
 
-  // Check for existing token on mount
+  // Check for existing token or cookie-backed session on mount
   useEffect(() => {
+    const restoreAuthState = async () => {
+      try {
+        const token = tokenStorage.getToken();
+        if (token) {
+          // Try to decode the token to get user info
+          try {
+            const parts = token.split('.');
+            if (parts.length !== 3) {
+              throw new Error('Malformed JWT: expected 3 parts');
+            }
+            const payload = JSON.parse(atob(parts[1])) as StoredTokenPayload;
+            if (
+              payload?.exp &&
+              payload.exp * 1000 > Date.now() &&
+              payload.id &&
+              payload.username &&
+              payload.role
+            ) {
+              setUser({
+                id: payload.id,
+                username: payload.username,
+                role: payload.role,
+              });
+              return;
+            }
+
+            // Token expired, remove it
+            tokenStorage.removeToken();
+          } catch {
+            // Invalid token, remove it
+            console.warn('[AuthProvider] Removed invalid auth token from storage');
+            tokenStorage.removeToken();
+          }
+        }
+
+        const session = await apiClient.getSession();
+        if (session.authenticated && session.user) {
+          setUser(session.user);
+        }
+      } catch (error) {
+        // localStorage/session restoration can fail. Log and continue - the user simply won't be authenticated.
+        console.error('[AuthProvider] Failed to restore auth state:', error);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
     if (globalThis.window === undefined) {
       setIsLoading(false);
       return;
     }
 
-    try {
-      const token = tokenStorage.getToken();
-      if (token) {
-        // Try to decode the token to get user info
-        try {
-          const parts = token.split('.');
-          if (parts.length !== 3) {
-            throw new Error('Malformed JWT: expected 3 parts');
-          }
-          const payload = JSON.parse(atob(parts[1]));
-          if (payload && payload.exp * 1000 > Date.now()) {
-            setUser({
-              id: payload.id,
-              username: payload.username,
-              role: payload.role,
-            });
-          } else {
-            // Token expired, remove it
-            tokenStorage.removeToken();
-          }
-        } catch {
-          // Invalid token, remove it
-          console.warn('[AuthProvider] Removed invalid auth token from storage');
-          tokenStorage.removeToken();
-        }
-      }
-    } catch (error) {
-      // localStorage access can fail (e.g., corrupted storage, security restrictions).
-      // Log and continue - the user simply won't be authenticated.
-      console.error('[AuthProvider] Failed to restore auth state:', error);
-    }
-    setIsLoading(false);
+    void restoreAuthState();
   }, []);
 
   const login = useCallback(async (username: string, password: string) => {

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -269,9 +269,9 @@ Different endpoints have different rate limits based on resource consumption:
 
 The application sets the following security headers:
 
-- `X-Frame-Options`: DENY
+- `X-Frame-Options`: SAMEORIGIN
 - `X-Content-Type-Options`: nosniff
-- `Referrer-Policy`: strict-origin-when-cross-origin
+- `Referrer-Policy`: origin-when-cross-origin
 - `Permissions-Policy`: Restrictive permissions
 - `Content-Security-Policy`: Comprehensive CSP
 - `Strict-Transport-Security`: HSTS enabled

--- a/lib/api-client.ts
+++ b/lib/api-client.ts
@@ -17,6 +17,17 @@ export interface ApiError {
   code?: string;
 }
 
+export interface AuthSessionUser {
+  id: string;
+  username: string;
+  role: string;
+}
+
+export interface AuthSessionResponse {
+  authenticated: boolean;
+  user: AuthSessionUser | null;
+}
+
 /**
  * API Client for making requests to the backend API
  */
@@ -159,6 +170,13 @@ class ApiClient {
     tokenStorage.removeToken();
 
     return response;
+  }
+
+  /**
+   * Get the current cookie-backed auth session, if one exists.
+   */
+  public async getSession(): Promise<AuthSessionResponse> {
+    return this.get<AuthSessionResponse>('/api/auth/session');
   }
 
   /**

--- a/lib/auth/identity-provider.ts
+++ b/lib/auth/identity-provider.ts
@@ -405,10 +405,11 @@ export async function handleAuthCallback(
         typeof tokenData.access_token === 'string' ? tokenData.access_token : null;
       const idToken = typeof tokenData.id_token === 'string' ? tokenData.id_token : null;
 
-      const claims =
+      const userInfoClaims =
         accessToken && discovery.userinfo_endpoint
           ? await fetchUserInfo(discovery.userinfo_endpoint, accessToken)
-          : decodeJwtPayload(idToken);
+          : null;
+      const claims = userInfoClaims ?? decodeJwtPayload(idToken);
 
       if (!claims) {
         return { success: false, error: 'Mystira Identity did not return user claims' };

--- a/next.config.ts
+++ b/next.config.ts
@@ -76,16 +76,6 @@ const nextConfig: NextConfig = {
               "form-action 'self'",
             ].join('; '),
           },
-          {
-            key: 'Content-Security-Policy-Report-Only',
-            value: [
-              "default-src 'self'",
-              "script-src 'self'",
-              "style-src 'self' 'unsafe-inline'",
-              "img-src 'self' data: https:",
-              "connect-src 'self' https://*.huggingface.co https://*.openai.com https://*.azure.com",
-            ].join('; '),
-          },
         ],
       },
     ];


### PR DESCRIPTION
## Summary
- remove the stale CSP report-only header that generated console-only inline script warnings with no report endpoint
- let Mystira OIDC callback fall back to id_token claims when userinfo rejects the access token
- add a cookie-backed /api/auth/session endpoint and hydrate the client AuthProvider from it after OIDC redirects
- align security-header docs with shipped headers

## Live finding
Identity logs confirm OmniPost attempts landed on Mystira Identity: authorization and token requests for client `neuralliquid-omnipost-web` were validated around 2026-07-18T22:01:55Z and 22:02:07Z. Identity returned id_token/access_token, then rejected the userinfo access token with `invalid_token` / missing `sub`. OmniPost previously did not fall back to id_token claims, and even a successful callback only set an HTTP-only cookie that the client auth guard did not hydrate from.

## Validation
- pnpm exec jest __tests__/lib/identity-provider.test.ts --runInBand
- pnpm exec eslint components/providers/AuthProvider.tsx lib/api-client.ts lib/auth/identity-provider.ts app/api/auth/session/route.ts __tests__/lib/identity-provider.test.ts
- pnpm exec prettier --check next.config.ts components/providers/AuthProvider.tsx lib/api-client.ts lib/auth/identity-provider.ts app/api/auth/session/route.ts __tests__/lib/identity-provider.test.ts docs/ARCHITECTURE.md
- pnpm run type-check
- pnpm run build