### PR TITLE
fix: restore dashboard app shell

### DIFF
--- a/app/(dashboard)/layout.tsx
+++ b/app/(dashboard)/layout.tsx
@@ -9,6 +9,7 @@ import { useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 import { useAuth } from '@/components/providers/AuthProvider';
 import { ErrorBoundary } from '@/components/ui';
+import Header from '@/components/ui/Header';
 import styles from '@/styles/shared.module.css';
 
 export default function DashboardLayout({ children }: { readonly children: React.ReactNode }) {
@@ -23,9 +24,12 @@ export default function DashboardLayout({ children }: { readonly children: React
 
   if (isLoading) {
     return (
-      <div className={styles.container}>
-        <div>Loading...</div>
-      </div>
+      <>
+        <Header />
+        <div className={styles.container}>
+          <div>Loading...</div>
+        </div>
+      </>
     );
   }
 
@@ -34,8 +38,11 @@ export default function DashboardLayout({ children }: { readonly children: React
   }
 
   return (
-    <div className={styles.container}>
-      <ErrorBoundary>{children}</ErrorBoundary>
-    </div>
+    <>
+      <Header />
+      <div className={styles.container}>
+        <ErrorBoundary>{children}</ErrorBoundary>
+      </div>
+    </>
   );
 }

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -27,7 +27,7 @@ export default function NotFound() {
             Go home
           </Link>
           <Link
-            href="/dashboard/dashboard"
+            href="/dashboard"
             className="inline-flex items-center justify-center rounded-md border border-input bg-background px-4 py-2 text-sm font-medium shadow-sm hover:bg-accent hover:text-accent-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
           >
             Dashboard
@@ -44,25 +44,22 @@ export default function NotFound() {
               </Link>
             </li>
             <li>
-              <Link href="/dashboard/dashboard" className="text-sm text-primary hover:underline">
+              <Link href="/dashboard" className="text-sm text-primary hover:underline">
                 Dashboard
               </Link>
             </li>
             <li>
-              <Link href="/dashboard/review" className="text-sm text-primary hover:underline">
+              <Link href="/review" className="text-sm text-primary hover:underline">
                 Content Review
               </Link>
             </li>
             <li>
-              <Link href="/dashboard/workflow" className="text-sm text-primary hover:underline">
+              <Link href="/workflow" className="text-sm text-primary hover:underline">
                 Workflow
               </Link>
             </li>
             <li>
-              <Link
-                href="/dashboard/platform-analysis"
-                className="text-sm text-primary hover:underline"
-              >
+              <Link href="/platform-analysis" className="text-sm text-primary hover:underline">
                 Platform Analysis
               </Link>
             </li>

--- a/styles/dashboard.module.css
+++ b/styles/dashboard.module.css
@@ -3,7 +3,23 @@
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
   gap: 1.5rem;
-  margin: 1.5rem 0;
+  margin: 0;
+}
+
+.metricsCard {
+  min-width: 0;
+}
+
+.cardHeader {
+  margin-bottom: 1rem;
+}
+
+.cardHeader h2 {
+  margin-top: 0;
+}
+
+.cardContent {
+  color: var(--color-text-body);
 }
 
 .metricItem {
@@ -11,7 +27,7 @@
   justify-content: space-between;
   align-items: center;
   padding: 0.75rem 0;
-  border-bottom: 1px solid #eaeaea;
+  border-bottom: 1px solid var(--color-border);
 }
 
 .metricItem:last-child {
@@ -20,14 +36,14 @@
 
 .platformName {
   font-weight: 500;
-  color: #333;
+  color: var(--color-text-primary);
 }
 
 .metricValue {
   font-weight: 600;
-  color: #4a6491;
+  color: var(--color-primary);
   padding: 0.25rem 0.75rem;
-  background-color: #f8f9fa;
+  background-color: var(--color-primary-100);
   border-radius: 4px;
 }
 
@@ -49,9 +65,9 @@
 
 .errorMessage {
   padding: 1rem;
-  background-color: #fff5f5;
-  border-left: 4px solid #f56565;
-  color: #c53030;
+  background-color: var(--color-error-bg);
+  border-left: 4px solid var(--color-error);
+  color: var(--color-error-text);
   margin: 1rem 0;
 }
 
@@ -69,15 +85,18 @@
 .metricsTable {
   width: 100%;
   border-collapse: collapse;
+  background-color: var(--color-bg-primary);
+  color: var(--color-text-primary);
 }
 
 .metricsTable th,
 .metricsTable td {
-  border: 1px solid #ddd;
+  border: 1px solid var(--color-border);
   padding: 8px;
   text-align: left;
 }
 
 .metricsTable th {
-  background-color: #f2f2f2;
+  background-color: var(--color-bg-tertiary);
+  color: var(--color-text-heading);
 }

--- a/styles/shared.module.css
+++ b/styles/shared.module.css
@@ -27,16 +27,17 @@
 }
 
 .section {
-  background-color: #f8f9fa;
+  background-color: var(--color-bg-primary);
   border-radius: 8px;
   padding: 1.5rem;
   box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+  color: var(--color-text-primary);
 }
 
 .section h2 {
   margin-top: 0;
-  color: #2c3e50;
-  border-bottom: 2px solid #4a6491;
+  color: var(--color-text-heading);
+  border-bottom: 2px solid var(--color-primary);
   padding-bottom: 0.5rem;
 }
 


### PR DESCRIPTION
## Summary
- render the shared header/navigation in authenticated dashboard routes
- restore readable dashboard metrics/table colors in dark mode by using design tokens
- add the missing dashboard card wrapper styles used by the page
- fix stale 404 helper links that pointed at /dashboard/dashboard and /dashboard/* route-group paths

## Validation
- pnpm exec eslint 'app/(dashboard)/layout.tsx' app/not-found.tsx
- pnpm exec prettier --check 'app/(dashboard)/layout.tsx' app/not-found.tsx styles/dashboard.module.css styles/shared.module.css
- pnpm run type-check
- pnpm run build