### PR TITLE
fix: prevent auth provider cache staleness

### DIFF
--- a/app/api/auth/providers/route.ts
+++ b/app/api/auth/providers/route.ts
@@ -3,7 +3,8 @@
  *
  * Public endpoint that returns available authentication providers.
  * Calls the external identity API via the identity-provider abstraction
- * and caches results for 5 minutes.
+ * without HTTP caching so runtime identity configuration changes are reflected
+ * immediately on login/signup pages.
  *
  * Rate-limited to prevent abuse (public endpoint).
  */
@@ -25,7 +26,7 @@ async function handleGetProviders(): Promise<NextResponse> {
     { providers: publicProviders },
     {
       headers: {
-        'Cache-Control': 'public, max-age=300, s-maxage=300',
+        'Cache-Control': 'no-store, max-age=0',
       },
     }
   );

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -34,7 +34,7 @@ export default function LoginPage() {
     let cancelled = false;
     async function fetchProviders() {
       try {
-        const res = await fetch('/api/auth/providers');
+        const res = await fetch('/api/auth/providers', { cache: 'no-store' });
         if (res.ok) {
           const data = await res.json();
           if (!cancelled && Array.isArray(data.providers)) {

--- a/app/signup/page.tsx
+++ b/app/signup/page.tsx
@@ -77,7 +77,7 @@ export default function SignupPage() {
     let cancelled = false;
     async function fetchProviders() {
       try {
-        const res = await fetch('/api/auth/providers');
+        const res = await fetch('/api/auth/providers', { cache: 'no-store' });
         if (res.ok) {
           const data = await res.json();
           if (!cancelled && Array.isArray(data.providers)) {


### PR DESCRIPTION
## Summary
- stop HTTP caching /api/auth/providers so runtime Mystira Identity config changes show immediately
- fetch auth providers with cache: no-store on login and signup pages

## Live finding
The live providers endpoint currently returns Mystira Identity, but it was still serving Cache-Control: public, max-age=300. A prior empty provider response could make the login UI show the stale "Mystira Identity sign-in is not configured" hint even after the App Service config was corrected.

## Validation
- pnpm exec eslint app/api/auth/providers/route.ts app/login/page.tsx app/signup/page.tsx
- pnpm exec prettier --check app/api/auth/providers/route.ts app/login/page.tsx app/signup/page.tsx
- pnpm run build
- pnpm run type-check