### PR TITLE
feat: improve dashboard header controls

### DIFF
--- a/app/(dashboard)/dashboard/AirtableSection.tsx
+++ b/app/(dashboard)/dashboard/AirtableSection.tsx
@@ -7,10 +7,50 @@
 
 import AirtableIntegration from '@/components/content/AirtableIntegration';
 import dashboardStyles from '@/styles/dashboard.module.css';
+import { useEffect, useState } from 'react';
+
+const AIRTABLE_STORAGE_KEY = 'omnipost.airtableEnabled';
 
 export function AirtableSection() {
+  const [enabled, setEnabled] = useState(true);
+
+  useEffect(() => {
+    const stored = localStorage.getItem(AIRTABLE_STORAGE_KEY);
+    if (stored !== null) {
+      setEnabled(stored === 'true');
+    }
+
+    const handleToggle = (event: Event) => {
+      const customEvent = event as CustomEvent<{ enabled: boolean }>;
+      setEnabled(customEvent.detail.enabled);
+    };
+
+    window.addEventListener('omnipost:airtable-toggle', handleToggle);
+    return () => window.removeEventListener('omnipost:airtable-toggle', handleToggle);
+  }, []);
+
+  if (!enabled) {
+    return (
+      <div className={`${dashboardStyles.metricsCard} ${dashboardStyles.integrationPausedCard}`}>
+        <div className={dashboardStyles.cardHeader}>
+          <span className={dashboardStyles.cardKicker}>Integration</span>
+          <h2>Airtable paused</h2>
+        </div>
+        <div className={dashboardStyles.cardContent}>
+          <p>
+            Airtable dashboard records are hidden. Use the header Airtable toggle to bring the
+            integration panel back.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
   return (
     <div className={dashboardStyles.metricsCard}>
+      <div className={dashboardStyles.cardHeader}>
+        <span className={dashboardStyles.cardKicker}>Integration</span>
+      </div>
       <div className={dashboardStyles.cardContent}>
         <AirtableIntegration />
       </div>

--- a/app/(dashboard)/dashboard/DashboardMetrics.tsx
+++ b/app/(dashboard)/dashboard/DashboardMetrics.tsx
@@ -44,7 +44,7 @@ function MetricsContent({
   }
 
   if (metrics.length === 0) {
-    return <p>No metrics available</p>;
+    return <p className={dashboardStyles.emptyMessage}>No metrics available</p>;
   }
 
   return (
@@ -101,7 +101,9 @@ export function DashboardMetrics({ initialMetrics }: Readonly<DashboardMetricsPr
   return (
     <div className={dashboardStyles.metricsCard}>
       <div className={dashboardStyles.cardHeader}>
+        <span className={dashboardStyles.cardKicker}>Analytics</span>
         <h2>Engagement Metrics</h2>
+        <p>Current engagement by platform with manual refresh support.</p>
       </div>
       <div className={dashboardStyles.cardContent}>
         <MetricsContent

--- a/app/(dashboard)/dashboard/page.tsx
+++ b/app/(dashboard)/dashboard/page.tsx
@@ -24,16 +24,58 @@ async function getEngagementMetrics() {
   return engagementMetrics;
 }
 
+function getNumericMetricValue(value: number | string): number {
+  if (typeof value === 'number') return value;
+  const parsed = Number.parseFloat(value.replace(/[^0-9.-]/g, ''));
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
 export default async function PerformanceDashboardPage() {
   const metrics = await getEngagementMetrics();
+  const metricValues = metrics.map(metric => getNumericMetricValue(metric.value));
+  const totalEngagement = metricValues.reduce((total, value) => total + value, 0);
+  const topMetric = metrics.reduce<(typeof metrics)[number] | null>((top, metric) => {
+    if (!top) return metric;
+    return getNumericMetricValue(metric.value) > getNumericMetricValue(top.value) ? metric : top;
+  }, null);
 
   return (
     <>
-      <div className={styles.header}>
-        <h1>Performance Dashboard</h1>
-        <p>Monitor and analyze your content performance across platforms</p>
+      <div className={dashboardStyles.dashboardHero}>
+        <div>
+          <p className={dashboardStyles.eyebrow}>Publishing intelligence</p>
+          <h1>Performance Dashboard</h1>
+          <p>Monitor engagement, integrations, and platform momentum from one workspace.</p>
+        </div>
+        <div className={dashboardStyles.heroMeta}>
+          <span>{metrics.length} platforms tracked</span>
+          <span>{topMetric ? `${topMetric.platform} leads` : 'No leader yet'}</span>
+        </div>
       </div>
-      <div className={styles.section}>
+
+      <div className={dashboardStyles.summaryGrid} aria-label="Dashboard summary">
+        <div className={dashboardStyles.summaryCard}>
+          <span className={dashboardStyles.summaryLabel}>Total engagement</span>
+          <strong>{totalEngagement.toLocaleString()}</strong>
+          <span className={dashboardStyles.summaryHint}>Across tracked platforms</span>
+        </div>
+        <div className={dashboardStyles.summaryCard}>
+          <span className={dashboardStyles.summaryLabel}>Top platform</span>
+          <strong>{topMetric?.platform ?? 'None'}</strong>
+          <span className={dashboardStyles.summaryHint}>
+            {topMetric ? `${topMetric.value} engagement` : 'Waiting for activity'}
+          </span>
+        </div>
+        <div className={dashboardStyles.summaryCard}>
+          <span className={dashboardStyles.summaryLabel}>Airtable sync</span>
+          <strong>Header controlled</strong>
+          <span className={dashboardStyles.summaryHint}>
+            Toggle visibility without leaving the page
+          </span>
+        </div>
+      </div>
+
+      <div className={`${styles.section} ${dashboardStyles.dashboardSection}`}>
         <div className={dashboardStyles.dashboardGrid}>
           {/* Engagement Metrics - Server rendered with client refresh */}
           <Suspense

--- a/components/content/AirtableIntegration.tsx
+++ b/components/content/AirtableIntegration.tsx
@@ -1,5 +1,6 @@
 import Airtable, { FieldSet, Records } from 'airtable';
 import React, { useEffect, useState } from 'react';
+import dashboardStyles from '@/styles/dashboard.module.css';
 
 interface Record {
   id: string;
@@ -18,10 +19,20 @@ const AirtableIntegration: React.FC = () => {
     const fetchRecords = async () => {
       setLoading(true);
       try {
+        const apiKey = process.env.NEXT_PUBLIC_AIRTABLE_API_KEY || '';
+        const baseId = process.env.NEXT_PUBLIC_AIRTABLE_BASE_ID || '';
+        const tableName = process.env.NEXT_PUBLIC_AIRTABLE_TABLE_NAME || '';
+
+        if (!apiKey || !baseId || !tableName) {
+          setRecords([]);
+          setError('Airtable browser configuration is incomplete.');
+          return;
+        }
+
         const base = new Airtable({
-          apiKey: process.env.NEXT_PUBLIC_AIRTABLE_API_KEY || '',
-        }).base(process.env.NEXT_PUBLIC_AIRTABLE_BASE_ID || '');
-        const table = base(process.env.NEXT_PUBLIC_AIRTABLE_TABLE_NAME || '');
+          apiKey,
+        }).base(baseId);
+        const table = base(tableName);
 
         const records: Records<FieldSet> = await table.select().all();
         setRecords([...records] as Record[]);
@@ -36,12 +47,17 @@ const AirtableIntegration: React.FC = () => {
   }, []);
 
   return (
-    <div>
+    <div className={dashboardStyles.integrationPanel}>
       <h2>Airtable Integration</h2>
-      {error && <p>Error: {error}</p>}
-      {loading && <p>Loading records...</p>}
-      {!loading && records.length === 0 && !error && <p>No records found</p>}
-      <ul>
+      <p className={dashboardStyles.integrationIntro}>
+        Review synced content records from the configured Airtable base.
+      </p>
+      {error && <p className={dashboardStyles.errorMessage}>Error: {error}</p>}
+      {loading && <p className={dashboardStyles.loadingIndicator}>Loading records...</p>}
+      {!loading && records.length === 0 && !error && (
+        <p className={dashboardStyles.emptyMessage}>No records found</p>
+      )}
+      <ul className={dashboardStyles.recordList}>
         {records.map(record => (
           <li key={record.id}>{record.fields?.Name || record.id || 'Unnamed record'}</li>
         ))}

--- a/components/ui/Header.tsx
+++ b/components/ui/Header.tsx
@@ -4,11 +4,18 @@ import React, { useState, useEffect, useRef, useCallback } from 'react';
 import Link from 'next/link';
 import { usePathname, useRouter } from 'next/navigation';
 import styles from '@/styles/Header.module.css';
-import { siteConfig } from '../../data/siteConfig';
+import { NavigationItem, siteConfig } from '../../data/siteConfig';
 import { useAuth } from '../providers/AuthProvider';
+
+type ThemeMode = 'light' | 'dark';
+
+const THEME_STORAGE_KEY = 'omnipost.theme';
+const AIRTABLE_STORAGE_KEY = 'omnipost.airtableEnabled';
 
 const Header: React.FC = () => {
   const [menuOpen, setMenuOpen] = useState(false);
+  const [themeMode, setThemeMode] = useState<ThemeMode>('light');
+  const [airtableEnabled, setAirtableEnabled] = useState(true);
   const pathname = usePathname();
   const router = useRouter();
   const menuRef = useRef<HTMLElement>(null);
@@ -28,6 +35,45 @@ const Header: React.FC = () => {
   const toggleMenu = () => {
     setMenuOpen(!menuOpen);
   };
+
+  const isNavItemActive = (item: NavigationItem): boolean => {
+    if (pathname === item.path) return true;
+    return item.children?.some(child => pathname === child.path) ?? false;
+  };
+
+  const toggleTheme = () => {
+    const nextTheme = themeMode === 'dark' ? 'light' : 'dark';
+    setThemeMode(nextTheme);
+    document.documentElement.dataset.theme = nextTheme;
+    localStorage.setItem(THEME_STORAGE_KEY, nextTheme);
+  };
+
+  const toggleAirtable = () => {
+    const nextValue = !airtableEnabled;
+    setAirtableEnabled(nextValue);
+    localStorage.setItem(AIRTABLE_STORAGE_KEY, String(nextValue));
+    window.dispatchEvent(
+      new CustomEvent('omnipost:airtable-toggle', { detail: { enabled: nextValue } })
+    );
+  };
+
+  useEffect(() => {
+    const storedTheme = localStorage.getItem(THEME_STORAGE_KEY);
+    const preferredTheme =
+      storedTheme === 'dark' || storedTheme === 'light'
+        ? storedTheme
+        : window.matchMedia('(prefers-color-scheme: dark)').matches
+          ? 'dark'
+          : 'light';
+
+    setThemeMode(preferredTheme);
+    document.documentElement.dataset.theme = preferredTheme;
+
+    const storedAirtable = localStorage.getItem(AIRTABLE_STORAGE_KEY);
+    if (storedAirtable !== null) {
+      setAirtableEnabled(storedAirtable === 'true');
+    }
+  }, []);
 
   // Handle escape key to close menu
   useEffect(() => {
@@ -81,17 +127,72 @@ const Header: React.FC = () => {
         >
           <ul className={styles.navList}>
             {navigationItems.map(item => (
-              <li key={`nav-${item.path}`} className={styles.navItem}>
-                <Link
-                  href={item.path}
-                  className={`${styles.navLink} ${pathname === item.path ? styles.activeLink : ''}`}
-                  onClick={() => setMenuOpen(false)}
-                >
-                  {item.name}
-                </Link>
+              <li
+                key={`nav-${item.path}`}
+                className={`${styles.navItem} ${item.children ? styles.hasDropdown : ''}`}
+              >
+                {item.children ? (
+                  <>
+                    <Link
+                      href={item.path}
+                      className={`${styles.navLink} ${styles.dropdownTrigger} ${
+                        isNavItemActive(item) ? styles.activeLink : ''
+                      }`}
+                      onClick={() => setMenuOpen(false)}
+                    >
+                      {item.name}
+                      <span className={styles.dropdownChevron} aria-hidden="true">
+                        v
+                      </span>
+                    </Link>
+                    <ul className={styles.dropdownMenu} aria-label={`${item.name} navigation`}>
+                      {item.children.map(child => (
+                        <li key={`nav-${item.path}-${child.path}`}>
+                          <Link
+                            href={child.path}
+                            className={`${styles.dropdownLink} ${
+                              pathname === child.path ? styles.activeDropdownLink : ''
+                            }`}
+                            onClick={() => setMenuOpen(false)}
+                          >
+                            {child.name}
+                          </Link>
+                        </li>
+                      ))}
+                    </ul>
+                  </>
+                ) : (
+                  <Link
+                    href={item.path}
+                    className={`${styles.navLink} ${pathname === item.path ? styles.activeLink : ''}`}
+                    onClick={() => setMenuOpen(false)}
+                  >
+                    {item.name}
+                  </Link>
+                )}
               </li>
             ))}
-            <li className={styles.navItem}>
+            <li className={`${styles.navItem} ${styles.utilityGroup}`} aria-label="Header controls">
+              <button
+                type="button"
+                className={`${styles.toggleButton} ${airtableEnabled ? styles.toggleActive : ''}`}
+                onClick={toggleAirtable}
+                aria-pressed={airtableEnabled}
+              >
+                <span className={styles.toggleTrack} aria-hidden="true">
+                  <span className={styles.toggleThumb}></span>
+                </span>
+                Airtable
+              </button>
+              <button
+                type="button"
+                className={styles.iconToggleButton}
+                onClick={toggleTheme}
+                aria-label={`Switch to ${themeMode === 'dark' ? 'light' : 'dark'} mode`}
+                title={`Switch to ${themeMode === 'dark' ? 'light' : 'dark'} mode`}
+              >
+                {themeMode === 'dark' ? 'Light' : 'Dark'}
+              </button>
               {isAuthenticated ? (
                 <button onClick={handleLogout} className={styles.authButton}>
                   Logout ({user?.username})

--- a/styles/Header.module.css
+++ b/styles/Header.module.css
@@ -4,19 +4,22 @@
    ========================================================================== */
 
 .header {
-  background-color: var(--color-bg-primary, #ffffff);
+  background-color: color-mix(in srgb, var(--color-bg-primary, #ffffff) 94%, transparent);
+  border-bottom: 1px solid var(--color-border, #e2e8f0);
   box-shadow: var(--shadow-header, 0 2px 8px rgba(0, 0, 0, 0.08));
   position: sticky;
   top: 0;
   z-index: var(--z-sticky, 100);
+  backdrop-filter: blur(16px);
 }
 
 .headerContainer {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: var(--spacing-md, 1rem);
-  max-width: var(--max-width-content, 1200px);
+  gap: var(--spacing-lg, 1.5rem);
+  padding: 0.75rem var(--spacing-md, 1rem);
+  max-width: 1320px;
   margin: 0 auto;
 }
 
@@ -41,14 +44,18 @@
 .logoText {
   font-size: var(--font-size-xl, 1.25rem);
   font-weight: var(--font-weight-bold, 700);
+  letter-spacing: 0;
 }
 
 .navigation {
   display: flex;
+  align-items: center;
+  min-width: 0;
 }
 
 .navList {
   display: flex;
+  align-items: center;
   list-style: none;
   margin: 0;
   padding: 0;
@@ -57,14 +64,19 @@
 
 .navItem {
   display: flex;
+  align-items: center;
+  position: relative;
 }
 
 .navLink {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
   color: var(--color-text-secondary, #4a5568);
   text-decoration: none;
   font-size: var(--font-size-sm, 0.875rem);
   font-weight: var(--font-weight-medium, 500);
-  padding: var(--spacing-sm, 0.5rem) var(--spacing-md, 1rem);
+  padding: 0.55rem 0.75rem;
   border-radius: var(--radius-md, 8px);
   transition:
     color var(--transition-base, 200ms ease),
@@ -92,6 +104,137 @@
   height: 3px;
   background-color: var(--color-primary, #4a6491);
   border-radius: var(--radius-full, 9999px);
+}
+
+.dropdownChevron {
+  color: var(--color-text-muted, #94a3b8);
+  font-size: 0.75rem;
+  line-height: 1;
+}
+
+.dropdownMenu {
+  position: absolute;
+  top: calc(100% + 0.45rem);
+  left: 0;
+  min-width: 190px;
+  list-style: none;
+  margin: 0;
+  padding: 0.4rem;
+  background-color: var(--color-bg-primary, #ffffff);
+  border: 1px solid var(--color-border, #e2e8f0);
+  border-radius: var(--radius-md, 8px);
+  box-shadow: var(--shadow-lg, 0 10px 15px rgba(0, 0, 0, 0.1));
+  opacity: 0;
+  transform: translateY(-4px);
+  pointer-events: none;
+  transition:
+    opacity var(--transition-base, 200ms ease),
+    transform var(--transition-base, 200ms ease);
+  z-index: var(--z-dropdown, 50);
+}
+
+.hasDropdown:hover .dropdownMenu,
+.hasDropdown:focus-within .dropdownMenu {
+  opacity: 1;
+  transform: translateY(0);
+  pointer-events: auto;
+}
+
+.dropdownLink {
+  display: block;
+  padding: 0.55rem 0.65rem;
+  color: var(--color-text-secondary, #4a5568);
+  text-decoration: none;
+  border-radius: var(--radius-sm, 4px);
+  font-size: var(--font-size-sm, 0.875rem);
+  line-height: 1.25;
+  transition:
+    color var(--transition-base, 200ms ease),
+    background-color var(--transition-base, 200ms ease);
+}
+
+.dropdownLink:hover,
+.activeDropdownLink {
+  color: var(--color-primary, #4a6491);
+  background-color: var(--color-primary-50, rgba(74, 100, 145, 0.05));
+}
+
+.utilityGroup {
+  gap: 0.5rem;
+  margin-left: 0.5rem;
+  padding-left: 0.75rem;
+  border-left: 1px solid var(--color-border, #e2e8f0);
+}
+
+.toggleButton,
+.iconToggleButton {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.45rem;
+  min-height: 36px;
+  border: 1px solid var(--color-border, #e2e8f0);
+  background-color: var(--color-bg-primary, #ffffff);
+  color: var(--color-text-secondary, #4a5568);
+  border-radius: var(--radius-md, 8px);
+  cursor: pointer;
+  font-size: var(--font-size-sm, 0.875rem);
+  font-weight: var(--font-weight-medium, 500);
+  transition:
+    color var(--transition-base, 200ms ease),
+    background-color var(--transition-base, 200ms ease),
+    border-color var(--transition-base, 200ms ease);
+}
+
+.toggleButton {
+  padding: 0.45rem 0.65rem;
+}
+
+.iconToggleButton {
+  min-width: 48px;
+  padding: 0.45rem 0.6rem;
+}
+
+.toggleButton:hover,
+.iconToggleButton:hover {
+  color: var(--color-primary, #4a6491);
+  background-color: var(--color-primary-50, rgba(74, 100, 145, 0.05));
+  border-color: var(--color-primary, #4a6491);
+}
+
+.toggleTrack {
+  position: relative;
+  width: 30px;
+  height: 16px;
+  flex: 0 0 auto;
+  border-radius: var(--radius-full, 9999px);
+  background-color: var(--color-border-dark, #cbd5e0);
+  transition: background-color var(--transition-base, 200ms ease);
+}
+
+.toggleThumb {
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 12px;
+  height: 12px;
+  border-radius: var(--radius-full, 9999px);
+  background-color: var(--color-bg-primary, #ffffff);
+  box-shadow: var(--shadow-sm, 0 1px 2px rgba(0, 0, 0, 0.05));
+  transition: transform var(--transition-base, 200ms ease);
+}
+
+.toggleActive {
+  color: var(--color-primary, #4a6491);
+  border-color: var(--color-primary, #4a6491);
+}
+
+.toggleActive .toggleTrack {
+  background-color: var(--color-primary, #4a6491);
+}
+
+.toggleActive .toggleThumb {
+  transform: translateX(14px);
 }
 
 .mobileMenuButton {
@@ -148,16 +291,20 @@
 
   .navList {
     flex-direction: column;
+    align-items: stretch;
     width: 100%;
     gap: var(--spacing-xs, 0.25rem);
   }
 
   .navItem {
     width: 100%;
+    align-items: stretch;
+    flex-direction: column;
   }
 
   .navLink {
-    display: block;
+    display: flex;
+    justify-content: space-between;
     padding: var(--spacing-md, 1rem) var(--spacing-lg, 1.5rem);
     width: 100%;
     font-size: var(--font-size-base, 1rem);
@@ -171,6 +318,38 @@
   .authButton {
     width: 100%;
     text-align: left;
+  }
+
+  .dropdownMenu {
+    position: static;
+    min-width: 0;
+    width: 100%;
+    margin: 0.1rem 0 0.35rem;
+    padding: 0.25rem 0 0.25rem 0.75rem;
+    background-color: transparent;
+    border: 0;
+    box-shadow: none;
+    opacity: 1;
+    transform: none;
+    pointer-events: auto;
+  }
+
+  .dropdownLink {
+    padding: 0.6rem 1rem;
+  }
+
+  .utilityGroup {
+    gap: 0.5rem;
+    margin-left: 0;
+    padding-left: 0;
+    border-left: 0;
+  }
+
+  .toggleButton,
+  .iconToggleButton {
+    width: 100%;
+    justify-content: flex-start;
+    padding: 0.65rem 1rem;
   }
 }
 

--- a/styles/dashboard.module.css
+++ b/styles/dashboard.module.css
@@ -1,24 +1,137 @@
 /* Dashboard-specific styles */
+.dashboardHero {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 1.5rem;
+  margin-bottom: 1.5rem;
+  padding: 2rem;
+  color: var(--color-text-inverse);
+  background: linear-gradient(135deg, var(--color-secondary), var(--color-primary));
+  border-radius: var(--radius-md, 8px);
+  box-shadow: var(--shadow-md);
+}
+
+.dashboardHero h1 {
+  margin: 0;
+  font-size: clamp(2rem, 4vw, 3rem);
+  line-height: 1.1;
+  letter-spacing: 0;
+}
+
+.dashboardHero p {
+  max-width: 680px;
+  margin: 0.65rem 0 0;
+  font-size: var(--font-size-lg, 1.125rem);
+  opacity: 0.92;
+}
+
+.eyebrow,
+.cardKicker,
+.summaryLabel {
+  display: block;
+  margin: 0 0 0.35rem;
+  color: var(--color-text-muted);
+  font-size: var(--font-size-xs, 0.75rem);
+  font-weight: var(--font-weight-bold, 700);
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+
+.dashboardHero .eyebrow {
+  color: rgba(255, 255, 255, 0.72);
+}
+
+.heroMeta {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  min-width: 220px;
+}
+
+.heroMeta span {
+  display: inline-flex;
+  justify-content: center;
+  padding: 0.45rem 0.7rem;
+  color: var(--color-text-inverse);
+  background-color: rgba(255, 255, 255, 0.14);
+  border: 1px solid rgba(255, 255, 255, 0.22);
+  border-radius: var(--radius-md, 8px);
+  font-size: var(--font-size-sm, 0.875rem);
+  font-weight: var(--font-weight-medium, 500);
+}
+
+.summaryGrid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 1rem;
+  margin-bottom: 1.5rem;
+}
+
+.summaryCard,
+.metricsCard {
+  min-width: 0;
+  color: var(--color-text-primary);
+  background-color: var(--color-bg-primary);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md, 8px);
+  box-shadow: var(--shadow-sm);
+}
+
+.summaryCard {
+  padding: 1rem;
+}
+
+.summaryCard strong {
+  display: block;
+  color: var(--color-text-heading);
+  font-size: var(--font-size-xl, 1.25rem);
+  line-height: 1.2;
+}
+
+.summaryHint {
+  display: block;
+  margin-top: 0.35rem;
+  color: var(--color-text-secondary);
+  font-size: var(--font-size-sm, 0.875rem);
+}
+
+.dashboardSection {
+  border: 1px solid var(--color-border);
+  box-shadow: var(--shadow-sm);
+}
+
 .dashboardGrid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
-  gap: 1.5rem;
+  grid-template-columns: minmax(0, 1.15fr) minmax(320px, 0.85fr);
+  gap: 1.25rem;
   margin: 0;
 }
 
 .metricsCard {
-  min-width: 0;
+  overflow: hidden;
 }
 
 .cardHeader {
+  padding: 1.25rem 1.25rem 0;
   margin-bottom: 1rem;
 }
 
 .cardHeader h2 {
-  margin-top: 0;
+  margin: 0;
+  color: var(--color-text-heading);
+  font-size: var(--font-size-2xl, 1.5rem);
+  line-height: 1.2;
+}
+
+.cardHeader p {
+  margin: 0.4rem 0 0;
+  color: var(--color-text-secondary);
+  font-size: var(--font-size-sm, 0.875rem);
 }
 
 .cardContent {
+  padding: 0 1.25rem 1.25rem;
   color: var(--color-text-body);
 }
 
@@ -44,23 +157,33 @@
   color: var(--color-primary);
   padding: 0.25rem 0.75rem;
   background-color: var(--color-primary-100);
-  border-radius: 4px;
+  border-radius: var(--radius-sm, 4px);
 }
 
 .refreshButton {
   margin-top: 1rem;
-  padding: 0.5rem 1rem;
-  background-color: #4a6491;
-  color: white;
+  padding: 0.6rem 0.95rem;
+  background-color: var(--color-primary);
+  color: var(--color-text-inverse);
   border: none;
-  border-radius: 4px;
+  border-radius: var(--radius-sm, 4px);
   cursor: pointer;
   font-size: 0.9rem;
-  transition: background-color 0.2s;
+  font-weight: var(--font-weight-semibold, 600);
+  transition:
+    background-color 0.2s,
+    transform 0.2s;
 }
 
 .refreshButton:hover {
-  background-color: #3a5481;
+  background-color: var(--color-primary-dark);
+  transform: translateY(-1px);
+}
+
+.refreshButton:disabled {
+  cursor: wait;
+  opacity: 0.7;
+  transform: none;
 }
 
 .errorMessage {
@@ -71,32 +194,104 @@
   margin: 1rem 0;
 }
 
+.emptyMessage,
 .loadingIndicator {
   display: flex;
   justify-content: center;
   align-items: center;
+  min-height: 140px;
   padding: 2rem;
-  color: #718096;
+  color: var(--color-text-secondary);
 }
+
 .tableContainer {
   width: 100%;
+  overflow-x: auto;
 }
 
 .metricsTable {
   width: 100%;
-  border-collapse: collapse;
+  border-collapse: separate;
+  border-spacing: 0;
+  overflow: hidden;
   background-color: var(--color-bg-primary);
   color: var(--color-text-primary);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md, 8px);
 }
 
 .metricsTable th,
 .metricsTable td {
-  border: 1px solid var(--color-border);
-  padding: 8px;
+  padding: 0.85rem 1rem;
   text-align: left;
+  border-bottom: 1px solid var(--color-border);
 }
 
 .metricsTable th {
   background-color: var(--color-bg-tertiary);
   color: var(--color-text-heading);
+  font-size: var(--font-size-xs, 0.75rem);
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+
+.metricsTable tr:last-child td {
+  border-bottom: 0;
+}
+
+.metricsTable td:last-child {
+  color: var(--color-primary);
+  font-weight: var(--font-weight-semibold, 600);
+}
+
+.integrationPausedCard {
+  border-style: dashed;
+  background-color: var(--color-bg-tertiary);
+}
+
+.integrationPanel h2 {
+  margin: 0;
+  color: var(--color-text-heading);
+  font-size: var(--font-size-2xl, 1.5rem);
+  line-height: 1.2;
+}
+
+.integrationIntro {
+  margin: 0.4rem 0 1rem;
+  color: var(--color-text-secondary);
+  font-size: var(--font-size-sm, 0.875rem);
+}
+
+.recordList {
+  display: grid;
+  gap: 0.5rem;
+  margin: 1rem 0 0;
+  padding: 0;
+  list-style: none;
+}
+
+.recordList li {
+  padding: 0.65rem 0.75rem;
+  color: var(--color-text-primary);
+  background-color: var(--color-bg-tertiary);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm, 4px);
+  font-size: var(--font-size-sm, 0.875rem);
+}
+
+@media (max-width: 900px) {
+  .dashboardHero {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .heroMeta {
+    width: 100%;
+    min-width: 0;
+  }
+
+  .summaryGrid,
+  .dashboardGrid {
+    grid-template-columns: 1fr;
+  }
 }

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -554,6 +554,110 @@ textarea:focus-visible {
   }
 }
 
+:root[data-theme='light'] {
+  color-scheme: light;
+  --color-primary: #4a6491;
+  --color-primary-dark: #3a5481;
+  --color-primary-light: #5a7db3;
+  --color-primary-50: rgba(74, 100, 145, 0.05);
+  --color-primary-100: rgba(74, 100, 145, 0.1);
+  --color-primary-200: rgba(74, 100, 145, 0.2);
+  --color-secondary: #2c3e50;
+  --color-secondary-dark: #1a252f;
+  --color-secondary-light: #3d566e;
+  --color-accent: #3498db;
+  --color-accent-dark: #2980b9;
+  --color-accent-light: #5dade2;
+  --color-success: #16a34a;
+  --color-success-dark: #059669;
+  --color-success-light: #d1fae5;
+  --color-success-bg: #dcfce7;
+  --color-success-bg-subtle: #f0fdf4;
+  --color-warning: #f59e0b;
+  --color-warning-light: #fef3c7;
+  --color-error: #dc2626;
+  --color-error-light: #fee2e2;
+  --color-error-bg: #fee2e2;
+  --color-error-border: #fecaca;
+  --color-error-text: #991b1b;
+  --color-info: #3b82f6;
+  --color-info-light: #dbeafe;
+  --color-text-primary: #1a1a2e;
+  --color-text-secondary: #64748b;
+  --color-text-muted: #94a3b8;
+  --color-text-body: #475569;
+  --color-text-heading: #1e293b;
+  --color-text-label: #374151;
+  --color-text-placeholder: #9ca3af;
+  --color-text-inverse: #ffffff;
+  --color-bg-primary: #ffffff;
+  --color-bg-secondary: #f9fafb;
+  --color-bg-tertiary: #f1f5f9;
+  --color-bg-card: #ffffff;
+  --color-bg-dark: #2c3e50;
+  --color-bg-disabled: #f3f4f6;
+  --color-border: #e2e8f0;
+  --color-border-light: #edf2f7;
+  --color-border-dark: #cbd5e0;
+  --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.05);
+  --shadow-md: 0 4px 6px rgba(0, 0, 0, 0.07);
+  --shadow-lg: 0 10px 15px rgba(0, 0, 0, 0.1);
+  --shadow-xl: 0 20px 25px rgba(0, 0, 0, 0.1);
+  --shadow-header: 0 2px 8px rgba(0, 0, 0, 0.08);
+}
+
+:root[data-theme='dark'] {
+  color-scheme: dark;
+  --color-primary: #6b8cbe;
+  --color-primary-dark: #5a7baa;
+  --color-primary-light: #7d9ece;
+  --color-primary-50: rgba(107, 140, 190, 0.05);
+  --color-primary-100: rgba(107, 140, 190, 0.1);
+  --color-primary-200: rgba(107, 140, 190, 0.2);
+  --color-secondary: #94a3b8;
+  --color-secondary-dark: #cbd5e1;
+  --color-secondary-light: #64748b;
+  --color-accent: #5dade2;
+  --color-accent-dark: #3498db;
+  --color-accent-light: #85c1e9;
+  --color-success: #22c55e;
+  --color-success-dark: #16a34a;
+  --color-success-light: #064e3b;
+  --color-success-bg: #064e3b;
+  --color-success-bg-subtle: #052e23;
+  --color-warning: #fbbf24;
+  --color-warning-light: #78350f;
+  --color-error: #f87171;
+  --color-error-light: #7f1d1d;
+  --color-error-bg: #450a0a;
+  --color-error-border: #7f1d1d;
+  --color-error-text: #fca5a5;
+  --color-info: #60a5fa;
+  --color-info-light: #1e3a5f;
+  --color-text-primary: #f1f5f9;
+  --color-text-secondary: #94a3b8;
+  --color-text-muted: #64748b;
+  --color-text-body: #cbd5e1;
+  --color-text-heading: #e2e8f0;
+  --color-text-label: #d1d5db;
+  --color-text-placeholder: #6b7280;
+  --color-text-inverse: #1a1a2e;
+  --color-bg-primary: #1e293b;
+  --color-bg-secondary: #0f172a;
+  --color-bg-tertiary: #1e293b;
+  --color-bg-card: #1e293b;
+  --color-bg-dark: #0f172a;
+  --color-bg-disabled: #334155;
+  --color-border: #334155;
+  --color-border-light: #1e293b;
+  --color-border-dark: #475569;
+  --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.3);
+  --shadow-md: 0 4px 6px rgba(0, 0, 0, 0.4);
+  --shadow-lg: 0 10px 15px rgba(0, 0, 0, 0.5);
+  --shadow-xl: 0 20px 25px rgba(0, 0, 0, 0.5);
+  --shadow-header: 0 2px 8px rgba(0, 0, 0, 0.4);
+}
+
 /* ==========================================================================
    Responsive Breakpoints
    ========================================================================== */


### PR DESCRIPTION
## Summary
- reorganize the primary header into grouped dropdown navigation
- add persisted Airtable and dark/light controls to the header
- refresh the dashboard hero, summary cards, metrics table, and Airtable panel states

## Validation
- pnpm run type-check
- pnpm run lint
- pnpm run build
- git diff --check
- Playwright browser verification of header controls and dashboard rendering with local auth seeding

## Notes
- Excludes the unrelated Azure workflow change currently present in the local worktree.
- Excludes generated Playwright/output artifacts.
