### PR TITLE
fix: package alpha prisma database

### DIFF
--- a/.github/workflows/azure-webapps-node.yml
+++ b/.github/workflows/azure-webapps-node.yml
@@ -54,12 +54,15 @@ jobs:
       - name: Install, build, and test
         run: |
           pnpm install --frozen-lockfile
+          pnpm exec prisma generate
           pnpm run type-check
           pnpm run lint
           pnpm run build
+          pnpm exec prisma db push --skip-generate
           pnpm test
         env:
           JWT_SECRET: test-secret-key-for-deployment-ci
+          DATABASE_URL: file:./prisma/omnipost.db
 
       - name: Prepare deployment package
         run: |
@@ -78,6 +81,10 @@ jobs:
 
           # Copy data directory (required for feature flags and configuration)
           cp -r data deploy/data || true
+
+          # Copy Prisma SQLite bootstrap database for alpha App Service auth persistence.
+          mkdir -p deploy/prisma
+          cp prisma/omnipost.db deploy/prisma/omnipost.db
 
           # Fix package.json start script for standalone mode
           # The standalone build includes a server.js that should be run directly


### PR DESCRIPTION
## Summary
- generate Prisma Client during the Azure Web App build workflow
- create the SQLite alpha database from the Prisma schema in CI
- package the generated database into the standalone deployment artifact

## Why
Alpha App Service auth persistence needs the SQLite database file present in the deployed package when using the current SQLite-backed Prisma setup.

## Validation
- reviewed against `prisma/schema.prisma`
- reviewed existing standalone package steps
- kept this separate from dashboard/header UI PR #162
