### PR TITLE
chore: ignore playwright verification artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,10 +67,12 @@ deploy/
 node-app.zip
 
 # Playwright
+.playwright-cli/
 test-results/
 playwright-report/
 blob-report/
 e2e/.auth/
+output/playwright/
 
 # Retort ephemeral state
 .claude/state/


### PR DESCRIPTION
## Summary
- ignore Playwright CLI session artifacts under `.playwright-cli/`
- ignore browser verification snapshots under `output/playwright/`

## Why
The dashboard/header verification pass generated local Playwright artifacts. These are useful transient diagnostics, but they should not appear as untracked source changes after future browser checks.

## Handoff
- PR #162 merged the dashboard/header UI controls.
- PR #163 merged the alpha Prisma SQLite packaging workflow fix.
- This PR only keeps the repo clean after verification runs.
- Existing local artifact directories can remain on disk; Git now ignores them.

## Validation
- `git status --short --branch` only showed `.gitignore` after the ignore rules were added.
