### PR TITLE
fix: remove unsupported prisma db push flag

### DIFF
--- a/.github/workflows/azure-webapps-node.yml
+++ b/.github/workflows/azure-webapps-node.yml
@@ -58,7 +58,7 @@ jobs:
           pnpm run type-check
           pnpm run lint
           pnpm run build
-          pnpm exec prisma db push --skip-generate
+          pnpm exec prisma db push
           pnpm test
         env:
           JWT_SECRET: test-secret-key-for-deployment-ci


### PR DESCRIPTION
Summary: remove the unsupported --skip-generate flag from the Azure Web App deploy workflow prisma db push step. This keeps the workflow aligned with the repo db:push script, which runs prisma db push. Validation: git diff --check passed, with only the existing LF-to-CRLF working-copy warning. Local pnpm command validation could not run because this shell invokes pnpm 11.15.1 while the repo requires pnpm 9.0.0. No application code changed.