### PR TITLE
feat: route queue approval through publisher

### DIFF
--- a/__tests__/api/queue-approve.test.ts
+++ b/__tests__/api/queue-approve.test.ts
@@ -1,0 +1,141 @@
+import { beforeEach, describe, expect, jest, test } from '@jest/globals';
+import '../setup';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const mockPublish = jest.fn<any>();
+
+jest.mock('../../lib/scheduler', () => ({
+  getPublisher: () => ({
+    publish: mockPublish,
+  }),
+}));
+
+jest.mock('../../lib/featureFlags', () => ({
+  __esModule: true,
+  default: {
+    platformConnectors: true,
+  },
+}));
+
+jest.mock('../../app/api/_utils/audit', () => ({
+  createLogEntry: jest.fn(() => ({})),
+  logToAuditTrail: jest.fn(),
+}));
+
+let POST: (req: Request) => Promise<Response>;
+
+function createRequest(body: Record<string, unknown>): Request {
+  return {
+    method: 'POST',
+    url: 'http://localhost:3000/api/queue/approve',
+    headers: {
+      get: (name: string) => {
+        if (name === 'content-type') return 'application/json';
+        return null;
+      },
+    },
+    json: async () => body,
+  } as unknown as Request;
+}
+
+describe('Queue approval API', () => {
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    jest.resetModules();
+
+    jest.doMock('../../lib/scheduler', () => ({
+      getPublisher: () => ({
+        publish: mockPublish,
+      }),
+    }));
+
+    const mod = await import('../../app/api/queue/approve/route');
+    POST = mod.POST;
+  });
+
+  test('publishes queue items through the scheduler publisher', async () => {
+    mockPublish.mockResolvedValueOnce({
+      success: true,
+      result: {
+        id: 'fb-post-1',
+        url: 'https://www.facebook.com/posts/fb-post-1',
+      },
+      duration: 42,
+      rateLimited: false,
+    });
+
+    const response = await POST(
+      createRequest({
+        queue: [
+          {
+            platform: { id: 1, name: 'Facebook' },
+            content: { id: 'content-1', title: 'Launch note' },
+          },
+        ],
+      })
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.message).toBe('Queue approved and published successfully');
+    expect(data.results.success[0]).toEqual(
+      expect.objectContaining({
+        platformPostId: 'fb-post-1',
+        publishedUrl: 'https://www.facebook.com/posts/fb-post-1',
+      })
+    );
+    expect(mockPublish).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'standalone',
+        contentId: 'content-1',
+        platformId: 'facebook',
+        content: { text: 'Launch note' },
+      })
+    );
+  });
+
+  test('returns failed results from scheduler publisher errors', async () => {
+    mockPublish.mockResolvedValueOnce({
+      success: false,
+      error: { message: 'Content validation failed: Instagram posts require at least one image' },
+      duration: 10,
+      rateLimited: false,
+    });
+
+    const response = await POST(
+      createRequest({
+        queue: [
+          {
+            platform: { id: 2, name: 'Instagram' },
+            content: { id: 'content-2', description: 'Caption without media' },
+          },
+        ],
+      })
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(500);
+    expect(data.message).toBe('All publishing attempts failed');
+    expect(data.results.failed[0].error).toBe(
+      'Content validation failed: Instagram posts require at least one image'
+    );
+  });
+
+  test('rejects items without publishable text', async () => {
+    const response = await POST(
+      createRequest({
+        queue: [
+          {
+            platform: { id: 1, name: 'Facebook' },
+            content: { id: 'content-3' },
+          },
+        ],
+      })
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(500);
+    expect(data.results.failed[0].error).toBe('Content text is required');
+    expect(mockPublish).not.toHaveBeenCalled();
+  });
+});

--- a/app/api/queue/approve/route.ts
+++ b/app/api/queue/approve/route.ts
@@ -1,7 +1,6 @@
 import { NextResponse } from 'next/server';
-import axios, { AxiosError } from 'axios';
-import pLimit from 'p-limit';
-import { getPlatformConfig, PlatformConfig } from '../../../../lib/config/platforms';
+import { getPublisher } from '../../../../lib/scheduler';
+import type { ScheduledJob } from '../../../../lib/scheduler';
 import { QueueItem, PublishResult } from '../../../../types';
 import featureFlags from '../../../../lib/featureFlags';
 import { withErrorHandling, Errors } from '../../_utils/errors';
@@ -12,6 +11,37 @@ import { validateArray } from '../../_utils/validation';
 // Configure concurrency limit - could be moved to config
 const MAX_CONCURRENT_REQUESTS = 5;
 
+async function mapWithConcurrency<T, TResult>(
+  items: T[],
+  concurrency: number,
+  mapper: (item: T, index: number) => Promise<TResult>
+): Promise<PromiseSettledResult<TResult>[]> {
+  const results = new Array<PromiseSettledResult<TResult>>(items.length);
+  let nextIndex = 0;
+
+  async function worker(): Promise<void> {
+    while (nextIndex < items.length) {
+      const currentIndex = nextIndex++;
+      try {
+        results[currentIndex] = {
+          status: 'fulfilled',
+          value: await mapper(items[currentIndex], currentIndex),
+        };
+      } catch (reason) {
+        results[currentIndex] = {
+          status: 'rejected',
+          reason,
+        };
+      }
+    }
+  }
+
+  const workerCount = Math.min(concurrency, items.length);
+  await Promise.all(Array.from({ length: workerCount }, () => worker()));
+
+  return results;
+}
+
 /**
  * Validates a queue item structure
  */
@@ -19,30 +49,43 @@ function validateQueueItem(item: QueueItem): { valid: boolean; error?: string } 
   if (!item.platform || !item.platform.name || !item.content) {
     return { valid: false, error: 'Invalid item structure' };
   }
+  if (!getContentText(item)) {
+    return { valid: false, error: 'Content text is required' };
+  }
   return { valid: true };
 }
 
 /**
- * Validates platform configuration
+ * Gets publishable text from legacy queue content.
  */
-function validatePlatformConfig(
-  platformName: string
-): { valid: true; config: PlatformConfig } | { valid: false; error: string } {
-  const platformConfig = getPlatformConfig(platformName);
+function getContentText(item: QueueItem): string {
+  return (item.content.description || item.content.title || '').trim();
+}
 
-  if (!platformConfig) {
-    return { valid: false, error: `Platform configuration not found for ${platformName}` };
-  }
+/**
+ * Converts legacy queue items into scheduler publisher jobs.
+ */
+function toPublishJob(item: QueueItem): ScheduledJob {
+  const now = new Date().toISOString();
+  const platformId = item.platform.name.toLowerCase().replaceAll(/\s+/g, '-');
+  const contentId = item.content.id || `queue-${platformId}-${Date.now()}`;
 
-  // Check if API key is missing for a required platform
-  if (platformConfig.required && !platformConfig.apiKey) {
-    return {
-      valid: false,
-      error: `API key for ${platformName} is not configured. Please set the ${platformName.toUpperCase().replaceAll(/\s+/g, '_')}_API_KEY environment variable.`,
-    };
-  }
-
-  return { valid: true, config: platformConfig };
+  return {
+    id: `queue-${platformId}-${contentId}`,
+    type: 'standalone',
+    contentId,
+    platformId,
+    content: {
+      text: getContentText(item),
+    },
+    scheduledTime: now,
+    timezone: 'UTC',
+    status: 'processing',
+    attempts: 0,
+    maxAttempts: 1,
+    createdAt: now,
+    updatedAt: now,
+  };
 }
 
 /**
@@ -59,14 +102,6 @@ async function publishItem(item: QueueItem): Promise<PublishResult> {
   const platformName = item.platform.name.toLowerCase();
   const contentId = item.content.id || 'unknown';
 
-  // Validate platform configuration
-  const configValidation = validatePlatformConfig(platformName);
-  if (!configValidation.valid) {
-    return { item, error: configValidation.error };
-  }
-
-  const platformConfig = configValidation.config;
-
   try {
     // Log individual publishing attempt
     const publishLogEntry = await createLogEntry('PUBLISH_TO_PLATFORM', {
@@ -75,41 +110,28 @@ async function publishItem(item: QueueItem): Promise<PublishResult> {
     });
     await logToAuditTrail(publishLogEntry);
 
-    // Publish to platform
-    await axios.post(
-      platformConfig.apiUrl,
-      {
-        content: item.content,
-      },
-      {
-        headers: {
-          ...platformConfig.headers,
-          ...(platformConfig.headers?.Authorization
-            ? { Authorization: platformConfig.headers.Authorization }
-            : platformConfig.apiKey
-              ? { Authorization: `Bearer ${platformConfig.apiKey}` }
-              : {}),
-        },
-      }
-    );
+    const publishResult = await getPublisher().publish(toPublishJob(item));
 
-    // Return successful result without error property
-    return { item };
+    if (!publishResult.success) {
+      return {
+        item,
+        error: publishResult.error?.message || 'Publishing failed',
+      };
+    }
+
+    return {
+      item,
+      platformPostId: publishResult.result?.id,
+      publishedUrl: publishResult.result?.url,
+    };
   } catch (err) {
-    // Enhanced error handling with AxiosError details
-    const axiosError = err as AxiosError;
-    const statusCode = axiosError.response?.status;
-    const errorMessage = platformConfig.apiKey
-      ? axiosError.message
-      : `${axiosError.message} (This may be due to missing API key)`;
+    const errorMessage = err instanceof Error ? err.message : 'Unknown publishing error';
 
     // Enhanced error logging with HTTP status
     const errorLogEntry = await createLogEntry('PUBLISH_FAILURE', {
       platformName,
       contentId,
       error: errorMessage,
-      statusCode: statusCode,
-      responseData: axiosError.response?.data,
     });
     await logToAuditTrail(errorLogEntry);
 
@@ -151,24 +173,21 @@ export const POST = withErrorHandling(async (request: Request) => {
   const approvalLogEntry = await createLogEntry('APPROVE_QUEUE', { queueSize: queue.length });
   await logToAuditTrail(approvalLogEntry);
 
-  // Create a concurrency limiter
-  const limit = pLimit(MAX_CONCURRENT_REQUESTS);
-
   // Process all items concurrently with throttling
-  const publishPromises: Promise<PublishResult>[] = queue.map((item: QueueItem) =>
-    limit(() => publishItem(item))
-  );
-  const publishResults = await Promise.allSettled(publishPromises);
+  const publishResults = await mapWithConcurrency(queue, MAX_CONCURRENT_REQUESTS, publishItem);
 
   // Process results
-  const results: { success: QueueItem[]; failed: PublishResult[] } = { success: [], failed: [] };
+  const results: { success: PublishResult[]; failed: PublishResult[] } = {
+    success: [],
+    failed: [],
+  };
 
   publishResults.forEach((result, index) => {
     if (result.status === 'fulfilled') {
       const publishResult = result.value;
       if (!publishResult.error) {
         // No error means success
-        results.success.push(publishResult.item);
+        results.success.push(publishResult);
       } else {
         // Has error property means failure
         results.failed.push(publishResult);

--- a/types/index.ts
+++ b/types/index.ts
@@ -29,6 +29,8 @@ export interface QueueItem {
 export interface PublishResult {
   item: QueueItem;
   error?: string;
+  platformPostId?: string;
+  publishedUrl?: string;
 }
 
 // Feature flag types


### PR DESCRIPTION
## Summary
- route /api/queue/approve through the existing scheduler Publisher service instead of direct placeholder Axios posts
- return platform post IDs and published URLs in successful queue approval results
- replace p-limit in this route with a local bounded-concurrency helper to avoid ESM runtime/test friction
- add focused Jest coverage for queue approval success, publisher failure, and missing publishable text

## Validation
- npx -y pnpm@9.0.0 --dir C:\Users\smitj\repos\omnipost test -- queue-approve.test.ts
- npx -y pnpm@9.0.0 --dir C:\Users\smitj\repos\omnipost run type-check
- npx -y pnpm@9.0.0 --dir C:\Users\smitj\repos\omnipost run lint (passes with existing warnings)

## R13 note
This is the first live-posting baseline cut: approval now uses the shared publisher path with adapter validation/rate-limit/retry handling. Remaining platform-specific work should focus on real provider endpoint shapes and configured credentials for the intended first live platform(s).