### PR TITLE
feat: add live platform publish constraints

### DIFF
--- a/__tests__/api/platforms.test.ts
+++ b/__tests__/api/platforms.test.ts
@@ -111,11 +111,12 @@ describe('Platforms API', () => {
       // Assertions
       expect(response.status).toBe(200);
       expect(Array.isArray(data)).toBe(true);
-      expect(data).toHaveLength(5); // Updated: now has 5 platforms
+      expect(data).toHaveLength(6); // Includes TikTok plus custom channel
       expect(data[0]).toHaveProperty('id', 1);
       expect(data[0]).toHaveProperty('name', 'Facebook');
       expect(data[1]).toHaveProperty('name', 'Instagram'); // Updated order
       expect(data[2]).toHaveProperty('name', 'LinkedIn');
+      expect(data[4]).toHaveProperty('name', 'TikTok');
     });
 
     test('should require authentication', async () => {

--- a/__tests__/api/queue-approve.test.ts
+++ b/__tests__/api/queue-approve.test.ts
@@ -69,7 +69,12 @@ describe('Queue approval API', () => {
         queue: [
           {
             platform: { id: 1, name: 'Facebook' },
-            content: { id: 'content-1', title: 'Launch note' },
+            content: {
+              id: 'content-1',
+              title: 'Launch note',
+              mediaUrls: ['https://cdn.example.com/post.png'],
+              hashtags: ['launch'],
+            },
           },
         ],
       })
@@ -89,7 +94,11 @@ describe('Queue approval API', () => {
         type: 'standalone',
         contentId: 'content-1',
         platformId: 'facebook',
-        content: { text: 'Launch note' },
+        content: {
+          text: 'Launch note',
+          mediaUrls: ['https://cdn.example.com/post.png'],
+          hashtags: ['launch'],
+        },
       })
     );
   });

--- a/__tests__/lib/scheduler-adapters.test.ts
+++ b/__tests__/lib/scheduler-adapters.test.ts
@@ -1,0 +1,125 @@
+import { afterEach, describe, expect, jest, test } from '@jest/globals';
+import { getAdapter } from '../../lib/scheduler/adapters';
+import { platformConfigurations, platforms } from '../../lib/config/platforms';
+
+const originalNodeEnv = process.env.NODE_ENV;
+const originalTikTokApiKey = platformConfigurations.tiktok.apiKey;
+const originalTikTokPrivacyLevel = process.env.TIKTOK_PRIVACY_LEVEL;
+const originalFetch = global.fetch;
+
+function setNodeEnv(value: typeof process.env.NODE_ENV): void {
+  Object.defineProperty(process.env, 'NODE_ENV', {
+    value,
+    configurable: true,
+    writable: true,
+  });
+}
+
+describe('Scheduler platform adapters', () => {
+  afterEach(() => {
+    setNodeEnv(originalNodeEnv);
+    platformConfigurations.tiktok.apiKey = originalTikTokApiKey;
+    if (originalTikTokPrivacyLevel === undefined) {
+      delete process.env.TIKTOK_PRIVACY_LEVEL;
+    } else {
+      process.env.TIKTOK_PRIVACY_LEVEL = originalTikTokPrivacyLevel;
+    }
+    global.fetch = originalFetch;
+    jest.restoreAllMocks();
+  });
+
+  test('registers TikTok with video-only publish constraints', () => {
+    const adapter = getAdapter('tiktok');
+
+    expect(adapter).toBeDefined();
+    expect(adapter?.getMaxLength()).toBe(2200);
+    expect(
+      adapter?.validateContent({
+        text: 'Short video caption',
+      })
+    ).toEqual(
+      expect.objectContaining({
+        valid: false,
+        errors: expect.arrayContaining(['TikTok posts require a video URL']),
+      })
+    );
+    expect(
+      adapter?.validateContent({
+        text: 'Short video caption',
+        mediaUrls: ['https://cdn.example.com/video.mp4'],
+      })
+    ).toEqual(
+      expect.objectContaining({
+        valid: true,
+      })
+    );
+  });
+
+  test('production adapters fail closed when provider credentials are missing', async () => {
+    setNodeEnv('production');
+    delete process.env.FACEBOOK_API_KEY;
+
+    await expect(
+      getAdapter('facebook')?.publish({
+        text: 'Production publish should not simulate without credentials',
+      })
+    ).rejects.toThrow('facebook API key is not configured');
+  });
+
+  test('TikTok is excluded from the default text-only content flow', () => {
+    const tiktok = platforms.find(platform => platform.slug === 'tiktok');
+
+    expect(tiktok).toEqual(
+      expect.objectContaining({
+        defaultContentFlow: false,
+        requiresMedia: true,
+      })
+    );
+  });
+
+  test('TikTok direct post sends privacy level and returns nested publish ID', async () => {
+    setNodeEnv('production');
+    process.env.TIKTOK_PRIVACY_LEVEL = 'SELF_ONLY';
+    platformConfigurations.tiktok.apiKey = 'tiktok-token';
+    const fetchMock = jest.fn<typeof fetch>().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        data: {
+          publish_id: 'publish-123',
+        },
+        error: {
+          code: 'ok',
+          message: '',
+        },
+      }),
+    } as Response);
+    global.fetch = fetchMock;
+
+    const result = await getAdapter('tiktok')?.publish({
+      text: 'Video caption',
+      mediaUrls: ['https://cdn.example.com/video.mp4'],
+    });
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        id: 'publish-123',
+        url: 'https://www.tiktok.com/upload?publish_id=publish-123',
+      })
+    );
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        body: JSON.stringify({
+          post_info: {
+            title: 'Video caption',
+            privacy_level: 'SELF_ONLY',
+          },
+          source_info: {
+            source: 'PULL_FROM_URL',
+            video_url: 'https://cdn.example.com/video.mp4',
+          },
+        }),
+      })
+    );
+  });
+});

--- a/app/(dashboard)/content/new/page.tsx
+++ b/app/(dashboard)/content/new/page.tsx
@@ -110,7 +110,7 @@ export function ContentCreatePage() {
   // Step 2: Platform Adaptation
   const [platformStates, setPlatformStates] = useState<PlatformState[]>(() =>
     platforms
-      .filter(p => p.slug !== 'custom-channel')
+      .filter(p => p.slug !== 'custom-channel' && p.defaultContentFlow !== false)
       .map(p => ({
         slug: p.slug,
         name: p.name,

--- a/app/api/queue/approve/route.ts
+++ b/app/api/queue/approve/route.ts
@@ -77,6 +77,9 @@ function toPublishJob(item: QueueItem): ScheduledJob {
     platformId,
     content: {
       text: getContentText(item),
+      mediaUrls: item.content.mediaUrls,
+      hashtags: item.content.hashtags,
+      tiktokPrivacyLevel: item.content.tiktokPrivacyLevel,
     },
     scheduledTime: now,
     timezone: 'UTC',

--- a/lib/config/platforms.ts
+++ b/lib/config/platforms.ts
@@ -9,6 +9,8 @@ export interface Platform {
   name: string;
   slug: string;
   description?: string;
+  defaultContentFlow?: boolean;
+  requiresMedia?: boolean;
 }
 
 export interface PlatformConfig {
@@ -27,6 +29,14 @@ export const platforms: Platform[] = [
   { id: 4, name: 'Twitter', slug: 'twitter', description: 'Twitter microblogging platform' },
   {
     id: 5,
+    name: 'TikTok',
+    slug: 'tiktok',
+    description: 'TikTok short-form video platform',
+    defaultContentFlow: false,
+    requiresMedia: true,
+  },
+  {
+    id: 6,
     name: 'Custom Channel',
     slug: 'custom-channel',
     description: 'Custom publishing channel',
@@ -38,13 +48,13 @@ export const platforms: Platform[] = [
  */
 export const platformConfigurations: Record<string, PlatformConfig> = {
   facebook: {
-    apiUrl: 'https://api.facebook.com/publish',
+    apiUrl: process.env.FACEBOOK_API_URL || 'https://graph.facebook.com/v23.0/me/feed',
     apiKey: process.env.FACEBOOK_API_KEY || '',
     required: true,
     capabilities: ['text', 'image', 'video'],
   },
   instagram: {
-    apiUrl: 'https://api.instagram.com/publish',
+    apiUrl: process.env.INSTAGRAM_API_URL || 'https://graph.instagram.com/v23.0/me/media',
     apiKey: process.env.INSTAGRAM_API_KEY || '',
     required: true,
     capabilities: ['image', 'video'],
@@ -60,6 +70,12 @@ export const platformConfigurations: Record<string, PlatformConfig> = {
     apiKey: process.env.TWITTER_API_KEY || '',
     required: true,
     capabilities: ['text', 'image', 'video'],
+  },
+  tiktok: {
+    apiUrl: process.env.TIKTOK_API_URL || 'https://open.tiktokapis.com/v2/post/publish/video/init/',
+    apiKey: process.env.TIKTOK_API_KEY || '',
+    required: true,
+    capabilities: ['video'],
   },
   'custom-channel': {
     apiUrl: 'https://api.customchannel.com/publish',

--- a/lib/scheduler/adapters.ts
+++ b/lib/scheduler/adapters.ts
@@ -141,6 +141,12 @@ abstract class BasePlatformAdapter implements PlatformAdapter {
   }
 
   protected abstract getMockUrl(postId: string): string;
+
+  protected assertProductionCredentials(config: { apiKey?: string } | undefined): void {
+    if (process.env.NODE_ENV === 'production' && !config?.apiKey) {
+      throw new Error(`${this.platformId} API key is not configured`);
+    }
+  }
 }
 
 /**
@@ -160,6 +166,7 @@ export class TwitterAdapter extends BasePlatformAdapter {
     if (config?.apiKey && process.env.NODE_ENV === 'production') {
       return this.publishToTwitter(content, config);
     }
+    this.assertProductionCredentials(config);
 
     // Development: simulate
     return this.simulatePublish(content, 'Twitter');
@@ -313,6 +320,7 @@ export class LinkedInAdapter extends BasePlatformAdapter {
     if (config?.apiKey && process.env.NODE_ENV === 'production') {
       return this.publishToLinkedIn(content, config);
     }
+    this.assertProductionCredentials(config);
 
     return this.simulatePublish(content, 'LinkedIn');
   }
@@ -379,6 +387,7 @@ export class FacebookAdapter extends BasePlatformAdapter {
     if (config?.apiKey && process.env.NODE_ENV === 'production') {
       return this.publishToFacebook(content, config);
     }
+    this.assertProductionCredentials(config);
 
     return this.simulatePublish(content, 'Facebook');
   }
@@ -429,6 +438,7 @@ export class InstagramAdapter extends BasePlatformAdapter {
     if (config?.apiKey && process.env.NODE_ENV === 'production') {
       return this.publishToInstagram(content, config);
     }
+    this.assertProductionCredentials(config);
 
     return this.simulatePublish(content, 'Instagram');
   }
@@ -496,6 +506,97 @@ export class InstagramAdapter extends BasePlatformAdapter {
 }
 
 /**
+ * TikTok Adapter
+ */
+export class TikTokAdapter extends BasePlatformAdapter {
+  platformId = 'tiktok';
+
+  getMaxLength(): number {
+    return 2200;
+  }
+
+  async publish(content: ScheduledJob['content']): Promise<PlatformPublishResult> {
+    const config = getPlatformConfig('tiktok');
+
+    if (config?.apiKey && process.env.NODE_ENV === 'production') {
+      return this.publishToTikTok(content, config);
+    }
+    this.assertProductionCredentials(config);
+
+    return this.simulatePublish(content, 'TikTok');
+  }
+
+  private async publishToTikTok(
+    content: ScheduledJob['content'],
+    config: { apiUrl: string; apiKey: string; timeoutMs?: number }
+  ): Promise<PlatformPublishResult> {
+    if (!content.mediaUrls || content.mediaUrls.length === 0) {
+      throw new Error('TikTok posts require a video URL');
+    }
+
+    const privacyLevel = content.tiktokPrivacyLevel || process.env.TIKTOK_PRIVACY_LEVEL;
+    if (!privacyLevel) {
+      throw new Error('TikTok privacy level is required for direct posts');
+    }
+
+    const data = await fetchWithTimeout<{
+      data?: { publish_id?: string };
+      error?: { code?: string; message?: string };
+    }>({
+      url: config.apiUrl,
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${config.apiKey}`,
+        'Content-Type': 'application/json',
+      },
+      body: {
+        post_info: {
+          title: content.text,
+          privacy_level: privacyLevel,
+        },
+        source_info: {
+          source: 'PULL_FROM_URL',
+          video_url: content.mediaUrls[0],
+        },
+      },
+      timeoutMs: config.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+      platformName: 'TikTok',
+    });
+
+    if (data.error?.code && data.error.code !== 'ok') {
+      const message = data.error.message ? ` - ${data.error.message}` : '';
+      throw new Error(`TikTok API error: ${data.error.code}${message}`);
+    }
+
+    const id = data.data?.publish_id;
+    if (!id) {
+      throw new Error('TikTok publish response did not include a publish ID');
+    }
+
+    return {
+      id,
+      url: `https://www.tiktok.com/upload?publish_id=${id}`,
+      platformData: data,
+    };
+  }
+
+  protected getMockUrl(postId: string): string {
+    return `https://www.tiktok.com/@user/video/${postId}`;
+  }
+
+  validateContent(content: ScheduledJob['content']): ValidationResult {
+    const result = super.validateContent(content);
+
+    if (!content.mediaUrls || content.mediaUrls.length === 0) {
+      result.errors.push('TikTok posts require a video URL');
+      result.valid = false;
+    }
+
+    return result;
+  }
+}
+
+/**
  * Adapter registry
  */
 const adapters = new Map<string, PlatformAdapter>();
@@ -503,6 +604,7 @@ adapters.set('twitter', new TwitterAdapter());
 adapters.set('linkedin', new LinkedInAdapter());
 adapters.set('facebook', new FacebookAdapter());
 adapters.set('instagram', new InstagramAdapter());
+adapters.set('tiktok', new TikTokAdapter());
 
 /**
  * Get adapter for a platform

--- a/lib/scheduler/index.ts
+++ b/lib/scheduler/index.ts
@@ -42,6 +42,7 @@ export {
   LinkedInAdapter,
   FacebookAdapter,
   InstagramAdapter,
+  TikTokAdapter,
 } from './adapters';
 
 // Publisher

--- a/lib/scheduler/types.ts
+++ b/lib/scheduler/types.ts
@@ -38,6 +38,7 @@ export interface ScheduledJob {
     mediaUrls?: string[];
     hashtags?: string[];
     mentions?: string[];
+    tiktokPrivacyLevel?: string;
     isThread?: boolean;
     threadParts?: { order: number; text: string; mediaUrls?: string[] }[];
   };

--- a/types/index.ts
+++ b/types/index.ts
@@ -18,6 +18,9 @@ export interface ContentType {
   id?: string;
   title?: string;
   description?: string;
+  mediaUrls?: string[];
+  hashtags?: string[];
+  tiktokPrivacyLevel?: string;
   // Add other relevant fields
 }
 


### PR DESCRIPTION
## Summary
- add TikTok as an explicit platform and scheduler publisher adapter
- make production platform adapters fail closed when provider API keys are missing instead of silently simulating a publish
- pass media URLs and hashtags from queue approval payloads into scheduler publisher jobs
- add tests for TikTok video constraints, production missing-credential behavior, and queue media/hashtag propagation

## Validation
- npx -y pnpm@9.0.0 --dir C:\Users\smitj\repos\omnipost test -- queue-approve.test.ts scheduler-adapters.test.ts
- npx -y pnpm@9.0.0 --dir C:\Users\smitj\repos\omnipost run type-check
- npx -y pnpm@9.0.0 --dir C:\Users\smitj\repos\omnipost run lint (passes with existing warnings)

## Live readiness note
Azure app settings for nl-dev-omnipost-web currently include identity and Sluice settings, but no FACEBOOK_API_KEY, INSTAGRAM_API_KEY, or TIKTOK_API_KEY. This PR makes that explicit at runtime; live publish smoke remains blocked until the intended provider credentials/endpoints are configured.