### PR TITLE
feat: mark gated platforms coming soon

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,10 +1,4 @@
-# pnpm configuration for Azure deployment compatibility
-# Use hoisted node_modules structure instead of isolated .pnpm structure
-# This ensures proper module resolution in Azure App Service
-node-linker=hoisted
-
-# Automatically install peer dependencies
-auto-install-peers=true
-
-# Use strict peer dependencies (recommended for production)
-strict-peer-dependencies=false
+# npm configuration
+#
+# Keep pnpm-specific project settings in pnpm-workspace.yaml. npm 11 warns on
+# pnpm-only project keys in .npmrc.

--- a/AZURE_DEPLOYMENT_FIX.md
+++ b/AZURE_DEPLOYMENT_FIX.md
@@ -19,13 +19,12 @@
 pnpm's default isolated module structure (`.pnpm` directory) is not compatible with Azure App Service's Node.js module resolution. When Next.js tries to resolve dependencies like `styled-jsx/package.json`, it fails because Azure's runtime doesn't understand pnpm's hoisted structure.
 
 **Solution:**
-Added `.npmrc` configuration to use hoisted node_modules structure:
+Added `pnpm-workspace.yaml` configuration to use hoisted node_modules structure:
 
-```ini
-# .npmrc
-node-linker=hoisted
-auto-install-peers=true
-strict-peer-dependencies=false
+```yaml
+nodeLinker: hoisted
+autoInstallPeers: true
+strictPeerDependencies: false
 ```
 
 This ensures all dependencies are placed in a flat `node_modules` directory that Azure can resolve.
@@ -46,12 +45,12 @@ Explicitly set `appCommandLine: 'node server.js'` in the Bicep template (`infra/
 
 ### Changes Made
 
-1. **.npmrc** (NEW):
+1. **pnpm-workspace.yaml**:
 
-   ```ini
-   node-linker=hoisted
-   auto-install-peers=true
-   strict-peer-dependencies=false
+   ```yaml
+   nodeLinker: hoisted
+   autoInstallPeers: true
+   strictPeerDependencies: false
    ```
 
 2. **infra/main.bicep** (Lines 88, 182):
@@ -70,7 +69,7 @@ Explicitly set `appCommandLine: 'node server.js'` in the Bicep template (`infra/
 
 - pnpm's default `.pnpm` structure uses symlinks and a complex nested layout
 - Azure's Node.js runtime expects a flat `node_modules` directory
-- `node-linker=hoisted` creates a traditional flat structure compatible with Azure
+- `nodeLinker: hoisted` creates a traditional flat structure compatible with Azure
 - All dependencies (including `styled-jsx`) are now directly resolvable
 
 **Explicit startup command:**

--- a/README.md
+++ b/README.md
@@ -826,9 +826,9 @@ This has been fixed in the repository. Ensure you have the latest code:
 # Pull latest changes
 git pull origin main
 
-# Verify .npmrc exists
-cat .npmrc
-# Should contain: node-linker=hoisted
+# Verify pnpm-workspace.yaml contains Azure-compatible pnpm settings
+cat pnpm-workspace.yaml
+# Should contain: nodeLinker: hoisted
 
 # Rebuild and redeploy
 pnpm install

--- a/__tests__/api/scheduler-routes.test.ts
+++ b/__tests__/api/scheduler-routes.test.ts
@@ -171,6 +171,24 @@ describe('Scheduler API Routes', () => {
       expect(mockSchedule).not.toHaveBeenCalled();
     });
 
+    test('rejects coming-soon platforms before scheduling', async () => {
+      const comingSoonJob = {
+        type: 'standalone',
+        contentId: 'content-1',
+        platformId: 'facebook',
+        content: { text: 'Hello world' },
+        scheduledTime: '2026-04-01T12:00:00Z',
+      };
+
+      const request = createRequest('POST', comingSoonJob);
+      const response = await POST(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(data.message).toContain('Facebook publishing is coming soon');
+      expect(mockSchedule).not.toHaveBeenCalled();
+    });
+
     test('requires authentication for POST', async () => {
       const { headers } = require('next/headers');
       (headers as jest.Mock).mockReturnValueOnce({

--- a/__tests__/lib/scheduler-adapters.test.ts
+++ b/__tests__/lib/scheduler-adapters.test.ts
@@ -66,11 +66,21 @@ describe('Scheduler platform adapters', () => {
     ).rejects.toThrow('facebook API key is not configured');
   });
 
+  test('provider-gated platforms are marked as coming soon', () => {
+    const comingSoonSlugs = platforms
+      .filter(platform => platform.comingSoon)
+      .map(platform => platform.slug)
+      .sort();
+
+    expect(comingSoonSlugs).toEqual(['facebook', 'instagram', 'tiktok']);
+  });
+
   test('TikTok is excluded from the default text-only content flow', () => {
     const tiktok = platforms.find(platform => platform.slug === 'tiktok');
 
     expect(tiktok).toEqual(
       expect.objectContaining({
+        comingSoon: true,
         defaultContentFlow: false,
         requiresMedia: true,
       })

--- a/app/(dashboard)/content/new/page.tsx
+++ b/app/(dashboard)/content/new/page.tsx
@@ -27,6 +27,7 @@ const PLATFORM_CHAR_LIMITS: Record<string, number> = {
   linkedin: 3000,
   facebook: 63206,
   instagram: 2200,
+  tiktok: 2200,
   'custom-channel': 5000,
 };
 
@@ -37,6 +38,7 @@ interface PlatformState {
   name: string;
   enabled: boolean;
   hashtags: string;
+  comingSoon?: boolean;
 }
 
 interface ContentDraft {
@@ -110,12 +112,13 @@ export function ContentCreatePage() {
   // Step 2: Platform Adaptation
   const [platformStates, setPlatformStates] = useState<PlatformState[]>(() =>
     platforms
-      .filter(p => p.slug !== 'custom-channel' && p.defaultContentFlow !== false)
+      .filter(p => p.slug !== 'custom-channel')
       .map(p => ({
         slug: p.slug,
         name: p.name,
-        enabled: true,
+        enabled: p.defaultContentFlow !== false && !p.comingSoon,
         hashtags: (DEFAULT_PLATFORM_CONFIGS[p.slug]?.defaultHashtags ?? []).join(', '),
+        comingSoon: p.comingSoon,
       }))
   );
 
@@ -159,7 +162,9 @@ export function ContentCreatePage() {
   }, [body, track, events]);
 
   const togglePlatform = useCallback((slug: string) => {
-    setPlatformStates(prev => prev.map(p => (p.slug === slug ? { ...p, enabled: !p.enabled } : p)));
+    setPlatformStates(prev =>
+      prev.map(p => (p.slug === slug && !p.comingSoon ? { ...p, enabled: !p.enabled } : p))
+    );
   }, []);
 
   const updateHashtags = useCallback((slug: string, value: string) => {
@@ -370,25 +375,36 @@ export function ContentCreatePage() {
             const charUsed = Math.min(body.length, charLimit);
             const color = getCharColor(body.length, charLimit);
             const fillPercent = Math.min((body.length / charLimit) * 100, 100);
+            const isComingSoon = platform.comingSoon;
 
             return (
               <div
                 key={platform.slug}
-                className={`${styles.platformCard} ${!platform.enabled ? styles.excluded : ''}`}
+                className={`${styles.platformCard} ${!platform.enabled ? styles.excluded : ''} ${
+                  isComingSoon ? styles.comingSoonCard : ''
+                }`}
               >
                 <div className={styles.platformCardHeader}>
-                  <span className={styles.platformName}>{platform.name}</span>
+                  <div className={styles.platformTitle}>
+                    <span className={styles.platformName}>{platform.name}</span>
+                    {isComingSoon && <span className={styles.comingSoonBadge}>Coming Soon</span>}
+                  </div>
                   <div className={styles.platformToggle}>
                     <span className={styles.toggleLabel}>
-                      {platform.enabled ? 'Included' : 'Excluded'}
+                      {isComingSoon ? 'Unavailable' : platform.enabled ? 'Included' : 'Excluded'}
                     </span>
                     <button
                       type="button"
                       className={`${styles.toggle} ${platform.enabled ? styles.toggleOn : ''}`}
                       onClick={() => togglePlatform(platform.slug)}
-                      aria-label={`${platform.enabled ? 'Exclude' : 'Include'} ${platform.name}`}
+                      aria-label={
+                        isComingSoon
+                          ? `${platform.name} is coming soon`
+                          : `${platform.enabled ? 'Exclude' : 'Include'} ${platform.name}`
+                      }
                       role="switch"
                       aria-checked={platform.enabled}
+                      disabled={isComingSoon}
                     >
                       <span className={styles.toggleKnob} />
                     </button>

--- a/app/(dashboard)/settings/platforms/page.tsx
+++ b/app/(dashboard)/settings/platforms/page.tsx
@@ -147,11 +147,14 @@ export function PlatformSettingsPage() {
           const connection = connections[platform.slug];
           const isConnected = Boolean(connection);
           const config = platformConfigurations[platform.slug];
+          const isComingSoon = platform.comingSoon;
 
           return (
             <div
               key={platform.slug}
-              className={`${styles.platformCard} ${isConnected ? styles.platformCardConnected : ''}`}
+              className={`${styles.platformCard} ${isConnected ? styles.platformCardConnected : ''} ${
+                isComingSoon ? styles.platformCardComingSoon : ''
+              }`}
             >
               <div className={styles.cardTop}>
                 <div className={`${styles.platformIcon} ${getIconColorClass(platform.slug)}`}>
@@ -167,12 +170,24 @@ export function PlatformSettingsPage() {
 
               <div>
                 <span
-                  className={`${styles.statusBadge} ${isConnected ? styles.statusConnected : styles.statusDisconnected}`}
+                  className={`${styles.statusBadge} ${
+                    isComingSoon
+                      ? styles.statusComingSoon
+                      : isConnected
+                        ? styles.statusConnected
+                        : styles.statusDisconnected
+                  }`}
                 >
                   <span
-                    className={`${styles.statusDot} ${isConnected ? styles.statusDotConnected : styles.statusDotDisconnected}`}
+                    className={`${styles.statusDot} ${
+                      isComingSoon
+                        ? styles.statusDotComingSoon
+                        : isConnected
+                          ? styles.statusDotConnected
+                          : styles.statusDotDisconnected
+                    }`}
                   />
-                  {isConnected ? 'Connected' : 'Not Connected'}
+                  {isComingSoon ? 'Coming Soon' : isConnected ? 'Connected' : 'Not Connected'}
                 </span>
               </div>
 
@@ -204,8 +219,9 @@ export function PlatformSettingsPage() {
                   <button
                     className={`${styles.connectButton} ${styles.connectButtonPrimary}`}
                     onClick={() => openConnectModal(platform.slug)}
+                    disabled={isComingSoon}
                   >
-                    Connect
+                    {isComingSoon ? 'Coming Soon' : 'Connect'}
                   </button>
                 )}
               </div>

--- a/app/api/scheduler/route.ts
+++ b/app/api/scheduler/route.ts
@@ -12,6 +12,7 @@ import { isAuthenticated, getCurrentUserId } from '@/app/api/_utils/auth';
 import { Errors, withErrorHandling } from '@/app/api/_utils/errors';
 import { withRateLimit, RateLimitPresets } from '@/app/api/_utils/rateLimit';
 import { sanitizeText, validateAndSanitize } from '@/app/api/_utils/sanitize';
+import { platforms } from '@/lib/config/platforms';
 
 // ── Zod Schemas ──────────────────────────────────────────────────────────
 
@@ -60,6 +61,13 @@ const createJobSchema = z.object({
   timezone: z.string().optional(),
   maxAttempts: z.number().int().min(1).max(20).optional(),
 });
+
+function getComingSoonPlatformName(platformId: string): string | undefined {
+  const normalizedPlatformId = platformId.toLowerCase();
+  const platform = platforms.find(p => p.slug === normalizedPlatformId);
+
+  return platform?.comingSoon ? platform.name : undefined;
+}
 
 // ── Route Handlers ───────────────────────────────────────────────────────
 
@@ -142,6 +150,10 @@ export const POST = withRateLimit(
     }
 
     const data = validation.data;
+    const comingSoonPlatformName = getComingSoonPlatformName(data.platformId);
+    if (comingSoonPlatformName) {
+      return Errors.badRequest(`${comingSoonPlatformName} publishing is coming soon`);
+    }
 
     const scheduler = getScheduler();
     const job = await scheduler.schedule({

--- a/lib/config/platforms.ts
+++ b/lib/config/platforms.ts
@@ -11,6 +11,7 @@ export interface Platform {
   description?: string;
   defaultContentFlow?: boolean;
   requiresMedia?: boolean;
+  comingSoon?: boolean;
 }
 
 export interface PlatformConfig {
@@ -23,8 +24,20 @@ export interface PlatformConfig {
 
 // List of available platforms
 export const platforms: Platform[] = [
-  { id: 1, name: 'Facebook', slug: 'facebook', description: 'Facebook social media platform' },
-  { id: 2, name: 'Instagram', slug: 'instagram', description: 'Instagram photo sharing platform' },
+  {
+    id: 1,
+    name: 'Facebook',
+    slug: 'facebook',
+    description: 'Facebook social media platform',
+    comingSoon: true,
+  },
+  {
+    id: 2,
+    name: 'Instagram',
+    slug: 'instagram',
+    description: 'Instagram photo sharing platform',
+    comingSoon: true,
+  },
   { id: 3, name: 'LinkedIn', slug: 'linkedin', description: 'LinkedIn professional network' },
   { id: 4, name: 'Twitter', slug: 'twitter', description: 'Twitter microblogging platform' },
   {
@@ -34,6 +47,7 @@ export const platforms: Platform[] = [
     description: 'TikTok short-form video platform',
     defaultContentFlow: false,
     requiresMedia: true,
+    comingSoon: true,
   },
   {
     id: 6,

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "AI-powered multi-platform content publishing. Publish everywhere, manage anywhere. Built with React and Next.js.",
   "main": "index.js",
-  "packageManager": "pnpm@9.0.0",
+  "packageManager": "pnpm@10.34.5",
   "scripts": {
     "dev": "next dev",
     "build": "next build",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,10 @@
 packages:
   - '.'
 
+nodeLinker: hoisted
+autoInstallPeers: true
+strictPeerDependencies: false
+
 onlyBuiltDependencies:
   - sharp
   - unrs-resolver

--- a/styles/ContentCreate.module.css
+++ b/styles/ContentCreate.module.css
@@ -244,6 +244,11 @@
   border-color: var(--color-border-light);
 }
 
+.platformCard.comingSoonCard {
+  opacity: 1;
+  background-color: var(--color-bg-secondary);
+}
+
 .platformCardHeader {
   display: flex;
   align-items: center;
@@ -253,10 +258,27 @@
   border-bottom: 1px solid var(--color-border-light);
 }
 
+.platformTitle {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+  min-width: 0;
+}
+
 .platformName {
   font-size: var(--font-size-base);
   font-weight: var(--font-weight-semibold);
   color: var(--color-text-heading);
+}
+
+.comingSoonBadge {
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-full);
+  color: var(--color-text-secondary);
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-medium);
+  padding: 2px 8px;
+  white-space: nowrap;
 }
 
 .platformToggle {
@@ -280,6 +302,10 @@
   transition: background-color var(--transition-fast);
   border: none;
   padding: 0;
+}
+
+.toggle:disabled {
+  cursor: not-allowed;
 }
 
 .toggle.toggleOn {

--- a/styles/PlatformSettings.module.css
+++ b/styles/PlatformSettings.module.css
@@ -42,6 +42,10 @@
   border-color: #38a169;
 }
 
+.platformCardComingSoon {
+  background-color: #f7fafc;
+}
+
 .cardTop {
   display: flex;
   align-items: center;
@@ -113,6 +117,11 @@
   color: #9b2c2c;
 }
 
+.statusComingSoon {
+  background-color: #edf2f7;
+  color: #4a5568;
+}
+
 .statusDot {
   width: 8px;
   height: 8px;
@@ -125,6 +134,10 @@
 
 .statusDotDisconnected {
   background-color: #e53e3e;
+}
+
+.statusDotComingSoon {
+  background-color: #718096;
 }
 
 .connectedInfo {
@@ -175,6 +188,16 @@
 
 .connectButtonPrimary:hover {
   background-color: #3a5280;
+}
+
+.connectButton:disabled {
+  cursor: not-allowed;
+  opacity: 0.65;
+}
+
+.connectButtonPrimary:disabled,
+.connectButtonPrimary:disabled:hover {
+  background-color: #a0aec0;
 }
 
 .connectButtonDanger {


### PR DESCRIPTION
## Summary
- mark Facebook, Instagram, and TikTok as coming soon in shared platform metadata
- keep coming-soon platforms visible but disabled in content creation and platform settings
- prevent coming-soon platforms from being toggled into publish jobs while provider credentials are skipped
- move pnpm-only settings out of .npmrc into pnpm-workspace.yaml and pin packageManager to pnpm 10.34.5

## Validation
- corepack pnpm test -- scheduler-adapters.test.ts platforms.test.ts
- corepack pnpm run type-check
- corepack pnpm run lint
- npx -y pnpm@9.0.0 --dir C:\Users\smitj\repos\omnipost exec prettier --version from the Mystira cwd no longer emits npm unknown project config warnings after moving the caller workspace pnpm-only .npmrc settings

## Notes
- Local pnpm 10 frozen install hung while migrating the existing node_modules tree, so CI is the fresh-install validation for the pnpm 10 pin.
- Lint still reports existing repo warnings but exits successfully.