### PR TITLE
docs: add X-first campaign operating roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -1003,6 +1003,12 @@ This project builds upon these amazing open-source technologies:
 
 ### Roadmap
 
+The canonical campaign capability sequence, evidence gates, and platform
+expansion criteria are documented in the
+[Marketing and Campaign Operating-System Roadmap](./docs/roadmaps/MARKETING_CAMPAIGN_OPERATING_SYSTEM.md).
+The executable delivery sequence for the first campaign is in the
+[X-First Campaign Delivery Plan](./docs/plans/X_FIRST_CAMPAIGN_DELIVERY_PLAN.md).
+
 <details>
 <summary><b>🔮 Planned Features</b></summary>
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -22,6 +22,13 @@ Located in the repository root for easy access:
 
 - **[GETTING_STARTED.md](./GETTING_STARTED.md)** - Setup guide for alpha users (prerequisites, installation, first steps, configuration, troubleshooting)
 
+### Roadmaps and Plans
+
+- **[Marketing and Campaign Operating-System Roadmap](./roadmaps/MARKETING_CAMPAIGN_OPERATING_SYSTEM.md)** - Canonical X-first capability sequence, governance boundaries, evidence gates, and LinkedIn entry criteria
+- **[X-First Campaign Delivery Plan](./plans/X_FIRST_CAMPAIGN_DELIVERY_PLAN.md)** - Planned pull requests, workstreams, dependencies, verification, and campaign review cadence
+- **[Alpha Launch Plan](./ALPHA_LAUNCH_PLAN.md)** - Wider product alpha scope and launch checklist
+- **[X Campaign Go-Live Runbook](./runbooks/X_CAMPAIGN_GO_LIVE.md)** - Staffed operator procedure for the first controlled production X post
+
 ### Technical Documentation
 
 - **[ARCHITECTURE.md](./ARCHITECTURE.md)** - Comprehensive technical architecture guide
@@ -82,6 +89,8 @@ Historical documentation from previous development phases:
 - **Learn best practices** → [guides/next-best-practices/](./guides/next-best-practices/)
 - **Report a security issue** → [SECURITY.md](../SECURITY.md)
 - **Check migration status** → [api/api-migration-todo.md](./api/api-migration-todo.md)
+- **Review the campaign roadmap** → [roadmaps/MARKETING_CAMPAIGN_OPERATING_SYSTEM.md](./roadmaps/MARKETING_CAMPAIGN_OPERATING_SYSTEM.md)
+- **Plan the X-first delivery** → [plans/X_FIRST_CAMPAIGN_DELIVERY_PLAN.md](./plans/X_FIRST_CAMPAIGN_DELIVERY_PLAN.md)
 - **View project structure** → [PROJECT_STRUCTURE.md](../PROJECT_STRUCTURE.md)
 - **Explore program name suggestions** → [PROGRAM_NAME_SUGGESTIONS.md](./PROGRAM_NAME_SUGGESTIONS.md)
 
@@ -115,4 +124,4 @@ If you can't find what you're looking for:
 
 ---
 
-**Last Updated**: March 30, 2026
+**Last Updated**: July 24, 2026

--- a/docs/plans/X_FIRST_CAMPAIGN_DELIVERY_PLAN.md
+++ b/docs/plans/X_FIRST_CAMPAIGN_DELIVERY_PLAN.md
@@ -3,7 +3,8 @@
 - **Roadmap:** [Marketing and Campaign Operating-System Roadmap](../roadmaps/MARKETING_CAMPAIGN_OPERATING_SYSTEM.md)
 - **Operator runbook:** [X Campaign Go-Live Runbook](../runbooks/X_CAMPAIGN_GO_LIVE.md)
 - **Baton live-publish task:** `7e1feab6-a668-4c18-b54d-691eddcd243f`
-- **Starter campaign ID:** `omnipost-x-live-001`
+- **Starter campaign ID:** `campaign_omnipost_x_live_001`
+- **Starter campaign slug:** `omnipost-x-live-001`
 
 ## Outcome
 
@@ -40,7 +41,8 @@ campaign brief
 Scope:
 
 - add the `marketing/` schema and campaign structure;
-- encode `omnipost-x-live-001`;
+- encode campaign ID `campaign_omnipost_x_live_001` with slug
+  `omnipost-x-live-001`;
 - document UTM and event naming;
 - validate platform length, required approvals, stable IDs, proof references,
   attribution fields, and prohibited telemetry; and
@@ -153,7 +155,7 @@ Verification:
 
 Entry criteria:
 
-- PRs A through D are deployed and verified;
+- PRs A through E are deployed and verified;
 - the X campaign has a recorded decision;
 - no unresolved duplicate, credential, approval, or attribution issue remains;
   and

--- a/docs/plans/X_FIRST_CAMPAIGN_DELIVERY_PLAN.md
+++ b/docs/plans/X_FIRST_CAMPAIGN_DELIVERY_PLAN.md
@@ -1,0 +1,225 @@
+# X-First Campaign Delivery Plan
+
+- **Roadmap:** [Marketing and Campaign Operating-System Roadmap](../roadmaps/MARKETING_CAMPAIGN_OPERATING_SYSTEM.md)
+- **Operator runbook:** [X Campaign Go-Live Runbook](../runbooks/X_CAMPAIGN_GO_LIVE.md)
+- **Baton live-publish task:** `7e1feab6-a668-4c18-b54d-691eddcd243f`
+- **Starter campaign ID:** `omnipost-x-live-001`
+
+## Outcome
+
+Prove and then productionize this chain:
+
+```text
+campaign brief
+  -> versioned source content
+  -> X-specific AI adaptation
+  -> human approval
+  -> immutable queued version
+  -> exactly-once X publish
+  -> provider reconciliation
+  -> attribution and workbook evidence
+  -> continue, revise, pause, or stop decision
+```
+
+## Workstreams
+
+| Workstream        | Primary ownership                  | Deliverable                                                        | Closeout evidence                                                                 |
+| ----------------- | ---------------------------------- | ------------------------------------------------------------------ | --------------------------------------------------------------------------------- |
+| Controlled smoke  | Marketing, backend, security       | One approved public X post                                         | Public URL, provider ID, UTC time, deployment SHA, scheduler result, no duplicate |
+| Contracts         | Marketing, backend, data, security | Campaign/content/AI schemas, X rules, event dictionary             | Clean validation, tests, linked Notion and Baton IDs                              |
+| Persistence       | Data, backend, frontend            | Versioned campaign, approval, attribution, AI, and publish records | Reload/restart persistence and audit reconstruction                               |
+| Account and queue | Backend, security, infra           | OAuth lifecycle, encrypted tokens, durable idempotent scheduler    | Restart, expiry, retry, revoke, and reconciliation tests                          |
+| Measurement       | Backend, data, infra, marketing    | Durable events, attribution capture, workbook                      | Runtime/workbook reconciliation and privacy tests                                 |
+| AI evidence       | Marketing, backend, data           | Prompt/model provenance and adjudication                           | Acceptance, edit, quality, cost, latency, and failure evidence                    |
+| LinkedIn reuse    | Backend, marketing, testing        | First governed second-platform pilot                               | Platform-specific adaptation and exactly-once evidence                            |
+
+## Planned Pull Requests
+
+### PR A — Campaign Contract Foundation
+
+Scope:
+
+- add the `marketing/` schema and campaign structure;
+- encode `omnipost-x-live-001`;
+- document UTM and event naming;
+- validate platform length, required approvals, stable IDs, proof references,
+  attribution fields, and prohibited telemetry; and
+- add repository documentation links.
+
+Verification:
+
+- schema validation tests;
+- campaign fixture tests;
+- prohibited-field tests;
+- `pnpm check-all`.
+
+No runtime migration is included.
+
+### PR B — Persist Campaign Versions and Approvals
+
+Scope:
+
+- add version, approval, attribution-link, AI-generation, publish-attempt, and
+  decision records;
+- import the approved Git campaign snapshot;
+- migrate the current starter campaign without replacing unrelated user data;
+- expose explicit approval and stale-version errors; and
+- remove browser-local state as campaign authority.
+
+Verification:
+
+- Prisma migration and data-access tests;
+- authorization and stale-version tests;
+- reload/restart smoke;
+- `pnpm check-all`;
+- deployed health and authenticated campaign smoke.
+
+### PR C1 — OAuth Account Lifecycle
+
+Scope:
+
+- X account connection and callback;
+- least-privilege scopes;
+- encrypted token storage;
+- refresh, expiry, revoke, and reconnect;
+- visible configuration status; and
+- secret-safe logging.
+
+Verification:
+
+- callback and state/PKCE tests;
+- token encryption/redaction tests;
+- expiry and revoke tests;
+- authenticated production configuration smoke.
+
+### PR C2 — Durable Exactly-Once Scheduler
+
+Scope:
+
+- persistent jobs;
+- job lease and idempotency key;
+- recurring Azure trigger;
+- retry classification and dead-letter state;
+- unknown-result reconciliation; and
+- provider rate-limit handling.
+
+Verification:
+
+- concurrent processor test;
+- duplicate-retry test;
+- restart recovery test;
+- provider timeout/unknown-result test;
+- controlled production scheduler smoke.
+
+### PR D — Attribution and Campaign Workbook
+
+Scope:
+
+- durable event ingestion;
+- `utm_*` and opaque `mtk` capture;
+- publish and conversion event contracts;
+- App Insights queries and workbook;
+- tagging-quality panel;
+- exact post/provider drill-down; and
+- documented decision-log procedure.
+
+Verification:
+
+- exact allow-list tests;
+- campaign-token propagation tests;
+- ingestion/retry tests;
+- workbook queries against known evidence;
+- runtime-to-workbook reconciliation.
+
+### PR E — AI Provenance and Quality
+
+Scope:
+
+- prompt-pack versioning;
+- provider/model/route and input/output hashes;
+- acceptance and edit reasons;
+- cost and latency;
+- brand, claim, policy, legal, and data gates; and
+- first-party adjudication views.
+
+Verification:
+
+- no prompt/output leakage into analytics;
+- accept/edit/reject workflow tests;
+- provider-gate tests;
+- cost/latency aggregation checks.
+
+### PR F — LinkedIn Pilot
+
+Entry criteria:
+
+- PRs A through D are deployed and verified;
+- the X campaign has a recorded decision;
+- no unresolved duplicate, credential, approval, or attribution issue remains;
+  and
+- current LinkedIn developer access is confirmed.
+
+Scope:
+
+- LinkedIn platform rules and adapter;
+- one governed platform-specific adaptation;
+- the existing version, approval, publish, attribution, and workbook contracts;
+  and
+- a cross-platform retrospective.
+
+## Immediate X Smoke Checklist
+
+The runbook remains authoritative. Planning status:
+
+- [x] X API v2 create-post contract deployed.
+- [x] Three-post X-only starter campaign seeded.
+- [x] Health checks and post-merge deployment verified.
+- [x] Operator runbook committed.
+- [ ] Account owner confirms the exact OmniPost X handle.
+- [ ] Account owner approves post 1 copy.
+- [ ] OAuth 2.0 PKCE app and user-context token are authorized.
+- [ ] X API credits are confirmed.
+- [ ] Key Vault reference resolves without exposing the value.
+- [ ] Staffed smoke window is agreed.
+- [ ] Exactly one post is queued and processed.
+- [ ] Public result and no-duplicate observation are captured.
+- [ ] Seven-day campaign observation and decision are recorded.
+
+## Dependencies and Stop Conditions
+
+| Dependency or risk          | Required action                                  | Stop condition                                    |
+| --------------------------- | ------------------------------------------------ | ------------------------------------------------- |
+| X account ownership         | Human account owner confirms handle and copy     | Ownership or approval is ambiguous                |
+| X API access and credits    | Confirm current developer access before smoke    | Access, scope, or spend is unknown                |
+| Credential handling         | Use Key Vault and redacted status only           | Secret value or secret URI appears in evidence    |
+| Current memory-backed queue | Staff one isolated job and invoke once           | App restart, timeout, or unknown state            |
+| Local campaign state        | Freeze exact approved copy before queueing       | Draft changes after approval cannot be reconciled |
+| Provider response           | Capture ID and URL immediately                   | Provider result cannot be determined              |
+| Duplicate protection        | Observe queue and public account after success   | More than one post or job appears                 |
+| Attribution baseline        | Use stable campaign/content IDs from PR A onward | IDs differ across Notion, Git, runtime, or Baton  |
+
+## Campaign Review Cadence
+
+- **Preflight:** owner, account, copy, scopes, spend, deployment, health, and
+  evidence destination.
+- **Smoke + 10 minutes:** exact post, correct account, one provider ID, one
+  public post, no delayed duplicate.
+- **24 hours:** operational failures, replies, impressions, profile visits, and
+  corrections.
+- **Seven days:** campaign metrics, attribution quality, AI/editorial notes,
+  incidents, and decision.
+- **Decision:** continue posts 2/3, revise the campaign, pause, or stop.
+
+## Definition of Done
+
+The X-first campaign initiative is complete only when:
+
+1. the first controlled post and evidence pass;
+2. campaign and approval state survive restart;
+3. OAuth and the scheduler no longer rely on manual static-token operation;
+4. one campaign item is traceable through durable publish and conversion
+   evidence;
+5. AI adaptations have first-party review and quality records;
+6. the campaign has a documented decision and retrospective; and
+7. LinkedIn has either passed its entry review or been explicitly deferred with
+   a reason.

--- a/docs/roadmaps/MARKETING_CAMPAIGN_OPERATING_SYSTEM.md
+++ b/docs/roadmaps/MARKETING_CAMPAIGN_OPERATING_SYSTEM.md
@@ -1,0 +1,399 @@
+# OmniPost Marketing and Campaign Operating-System Roadmap
+
+- **Status:** Approved direction
+- **Last updated:** 2026-07-24
+- **Horizon:** Controlled X evidence pilot through first LinkedIn expansion
+- **Canonical MVP constraint:** One reliable workflow from content input
+  through AI adaptation, human approval, verified publishing, visible result,
+  and audit evidence.
+
+## Purpose
+
+This roadmap defines how OmniPost will turn campaign strategy into traceable
+execution and evidence. It does not replace:
+
+- [the alpha launch plan](../ALPHA_LAUNCH_PLAN.md), which describes the wider
+  product launch;
+- [the X campaign go-live runbook](../runbooks/X_CAMPAIGN_GO_LIVE.md), which is
+  the operator procedure for the first controlled X post; or
+- Baton, which owns delivery status, dependencies, and closeout evidence.
+
+The roadmap is the canonical sequencing and governance document for marketing
+campaign capabilities.
+
+## Product Decision
+
+OmniPost will not pursue feature-for-feature parity with broad social suites
+before the launch gate passes. The initial product wedge is:
+
+> AI-assisted, platform-specific publishing with human approval and verifiable
+> campaign evidence for creators and small teams.
+
+The order is:
+
+1. prove exactly one controlled X publish;
+2. establish versioned campaign and telemetry contracts;
+3. persist campaign, approval, account, queue, and result state;
+4. make campaign attribution and operational evidence durable;
+5. evaluate AI routes using first-party acceptance and quality evidence; and
+6. reuse the proven contracts for a LinkedIn pilot.
+
+Facebook, Instagram, TikTok, broad listening, a unified inbox, autonomous
+posting, and CRM-grade revenue attribution remain deferred until these gates
+pass.
+
+## Source-of-Truth Boundaries
+
+| System                          | Owns                                                                                                                                    | Must not own                                                  |
+| ------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
+| Notion                          | Brand, audiences, message matrix, claims, campaign briefs, approvals, decisions, retrospectives                                         | Live queue state, provider credentials, mutable runtime truth |
+| Git                             | Schemas, validation, prompt packs, channel rules, telemetry contracts, workbook definitions, approved campaign snapshots                | Secrets, live provider state, mutable performance data        |
+| OmniPost database and telemetry | Campaign versions, content versions, adaptations, approvals, accounts, publish attempts, provider IDs, attribution events, measurements | Informal strategy discussion or secret values in analytics    |
+| Baton                           | Delivery owner, dependency graph, blockers, evidence requirements, closeout, residual risk                                              | Campaign content or credentials                               |
+
+All four systems must use the same stable `campaignId`, `contentId`,
+`variantId`, and opaque `campaignToken`. A queued or published item must also
+reference the immutable campaign/content version and content hash that was
+approved.
+
+## Operating Principles
+
+1. **Human approval is server-authoritative.** UI state alone cannot authorize
+   a publish.
+2. **Queued content is immutable.** Later Notion or draft edits cannot alter
+   already-approved work.
+3. **Publishing is idempotent.** Retrying an unknown result must not create a
+   duplicate post.
+4. **Evidence is captured at the source.** Provider IDs, URLs, attempt state,
+   timestamps, errors, and deployment version are persisted when known.
+5. **Telemetry is allow-listed.** Store bounded identifiers and classifications
+   in telemetry, not secrets, full copy, prompts, raw tokens, or unnecessary
+   personal data.
+6. **Attribution uses standard fields.** Use stable lowercase values for
+   `utm_id`, `utm_source`, `utm_medium`, `utm_campaign`, and `utm_content`, plus
+   an opaque OmniPost `mtk` token.
+7. **AI evidence is first-party.** External model reputation is only a prior;
+   production choices depend on OmniPost acceptance, edit, quality, cost,
+   latency, legal, and policy evidence.
+8. **One platform earns the next.** LinkedIn work begins only after the X gate
+   named below passes.
+
+## Current Baseline
+
+As of 2026-07-24:
+
+- PR #172 is deployed and the X adapter uses `POST /2/tweets`.
+- The draft **OmniPost on X - First Live Campaign** contains three X-only posts.
+- The live service is fail-closed because no X user-context credential is
+  configured.
+- Baton task `7e1feab6-a668-4c18-b54d-691eddcd243f` tracks the controlled X
+  smoke.
+- Campaign state is still local to the browser.
+- The queue is memory-backed and has no recurring Azure trigger.
+- The current analytics event store is memory-backed.
+- The first path does not yet provide multi-account OAuth refresh and
+  revocation handling.
+
+These constraints allow a staffed evidence pilot. They do not constitute a
+production-grade multi-account publishing service.
+
+## Roadmap
+
+### Gate 0 — Controlled X Evidence Pilot
+
+- **Horizon:** Now
+- **Launch class:** Tier 3 controlled evidence launch
+- **Owner:** Campaign owner plus technical operator
+- **Operator procedure:** [X campaign go-live runbook](../runbooks/X_CAMPAIGN_GO_LIVE.md)
+
+Deliver:
+
+- account owner confirms the OmniPost X account and approves post 1;
+- an X OAuth 2.0 user-context token has only the required scopes;
+- the credential is stored through Key Vault and resolves in App Service;
+- one job is queued and the protected processor is invoked once;
+- the public post, provider ID, URL, deployment SHA, publish time, and scheduler
+  result are captured in Baton; and
+- the operator watches for delayed duplicates and errors.
+
+Exit gate:
+
+- exactly one approved post is public on the correct X account;
+- the returned provider ID and public URL reconcile;
+- there are zero duplicates;
+- the scheduler result is successful;
+- evidence is complete; and
+- no credential or secret URI appears in evidence.
+
+Stop on a wrong-account post, 401/403 response, duplicate, altered copy,
+unresolved secret reference, unknown job state, or incomplete audit evidence.
+
+Posts 2 and 3 remain gated until post 1 passes. They are then reviewed and
+scheduled at least 24 hours apart, with a seven-day observation window.
+
+### Gate 1 — Campaign and Evidence Contracts
+
+- **Horizon:** Now
+- **Primary teams:** Marketing, backend, data, security, docs
+
+Deliver:
+
+- `marketing/schemas/campaign.schema.json`;
+- `marketing/schemas/content.schema.json`;
+- `marketing/schemas/ai-generation.schema.json`;
+- `marketing/channels/x.yaml`;
+- `marketing/campaigns/omnipost-x-live-001.yaml`;
+- a versioned event and attribution dictionary;
+- claim, asset-provenance, approval, and privacy rules; and
+- CI validation for required fields, stable IDs, platform limits, attribution
+  naming, approvals, and referenced proof.
+
+Exit gate:
+
+- the X campaign validates from a clean checkout;
+- every content item has an owner, reviewer, audience, objective, CTA,
+  platform, version, and approval state;
+- attribution IDs are unique and consistently named;
+- prohibited telemetry fields are documented and tested; and
+- the Notion, Git, and Baton records reference the same campaign ID.
+
+### Gate 2 — Durable Campaign and Approval State
+
+- **Horizon:** Next
+- **Primary teams:** Data, backend, security, frontend
+
+Deliver:
+
+- campaign and content version records;
+- immutable approval records;
+- attribution-link records;
+- AI-generation records;
+- publish-attempt records;
+- campaign-decision records;
+- import/reconciliation for the approved Git campaign snapshot; and
+- migration from browser-local campaign truth.
+
+Exit gate:
+
+- a reload or app restart preserves campaign and approval state;
+- queued work references the approved version and content hash;
+- unauthorized or stale versions fail closed;
+- changes create a new version instead of rewriting the approved record; and
+- audit queries can reconstruct who approved what and what was queued.
+
+### Gate 3 — Production-Grade X Account and Scheduler Path
+
+- **Horizon:** Next
+- **Primary teams:** Backend, security, infra, devops
+
+Deliver:
+
+- encrypted per-account token storage;
+- OAuth connection, refresh, expiry, revoke, and reconnect handling;
+- a durable queue with leases and idempotency keys;
+- a recurring Azure processor trigger;
+- classified retry and dead-letter behavior;
+- account/platform rate-limit enforcement; and
+- provider reconciliation for unknown results.
+
+Exit gate:
+
+- app restarts do not lose or duplicate work;
+- expired and revoked credentials fail safely with visible recovery actions;
+- a retry cannot create a second provider post;
+- operators can reconcile a provider result without inspecting secrets; and
+- controlled X publishing no longer requires a manually provisioned static
+  token or one-off processor invocation.
+
+### Gate 4 — Attribution and Campaign Workbook
+
+- **Horizon:** Next
+- **Primary teams:** Backend, data, infra, marketing
+
+Deliver the durable event family:
+
+- `campaign_created`;
+- `content_approved`;
+- `publish_job_queued`;
+- `publish_attempted`;
+- `publish_succeeded`;
+- `publish_failed`;
+- `landing_view`;
+- `cta_clicked`;
+- `signup_started`;
+- `signup_completed`; and
+- `platform_connected`.
+
+Common bounded dimensions:
+
+- `campaignId`;
+- `campaignVersion`;
+- `contentId`;
+- `variantId`;
+- `platform`;
+- `publishAttemptId`;
+- `providerPostId`;
+- `campaignToken`;
+- `utmSource`;
+- `utmMedium`;
+- `utmCampaign`;
+- `utmContent`; and
+- `landingPage`.
+
+Deliver a workbook with:
+
+1. campaign preflight completeness;
+2. approval and scheduling funnel;
+3. publish success, failure, retry, and latency;
+4. exact post/provider drill-down;
+5. attribution by campaign, content, variant, and platform;
+6. landing-to-signup-to-first-publish conversion;
+7. tagging and missing-data cleanup;
+8. credential, rate-limit, and platform health; and
+9. experiment gate and decision history.
+
+Exit gate:
+
+- an operator can trace one approved campaign item through publish and available
+  conversion events;
+- workbook totals reconcile with runtime records;
+- missing or malformed campaign tags are visible;
+- telemetry contains only approved fields; and
+- campaign decisions cite the workbook evidence used.
+
+### Gate 5 — AI Generation Provenance and Adjudication
+
+- **Horizon:** Later
+- **Primary teams:** Marketing, backend, data, security
+
+Deliver:
+
+- versioned prompt packs;
+- provider, model, and route capture;
+- input/output hashes;
+- token usage, cost, and latency;
+- human accept, edit, reject, and reason capture;
+- brand, claim, platform-policy, legal, and data-use gates;
+- first-party quality scorecards by task and platform; and
+- drift and incident monitoring.
+
+Exit gate:
+
+- a reviewer can reproduce the context and version used for an adaptation
+  without exposing hidden reasoning;
+- an AI route cannot graduate on reputation alone;
+- provider decisions use first-party acceptance and quality evidence;
+- costs remain visible but do not override legal or policy gates; and
+- generated assets retain provenance metadata, with C2PA support evaluated for
+  image/video work.
+
+### Gate 6 — LinkedIn Pilot
+
+- **Horizon:** Later
+- **Primary teams:** Backend, marketing, security, testing
+
+Entry criteria:
+
+- Gates 1 through 4 are complete;
+- the X observation window has a documented decision;
+- no unresolved duplicate, approval, credential, or attribution defect remains;
+  and
+- LinkedIn application access and current API constraints are verified.
+
+Deliver:
+
+- LinkedIn channel rules and platform-specific content validation;
+- one campaign adapted from the approved source rather than copied verbatim;
+- the same approval, version, idempotency, attribution, and workbook evidence
+  used for X; and
+- an X-versus-LinkedIn adaptation and outcome comparison.
+
+Exit gate:
+
+- one approved LinkedIn post publishes exactly once;
+- platform-specific copy and CTA choices are visible;
+- provider and attribution evidence reconcile; and
+- the retrospective decides whether to expand, revise, or stop.
+
+## Success Measures
+
+### Operational measures
+
+- exactly-once publish rate;
+- duplicate-post count;
+- publish success/failure rate;
+- queue-to-provider latency;
+- reconciliation completeness;
+- approval-to-publish trace completeness; and
+- credential-expiry recovery rate.
+
+### Campaign measures
+
+- impressions and reach where the provider supplies them;
+- engagement rate;
+- profile visits;
+- landing views and CTA clicks;
+- attributed signup starts and completions; and
+- first-platform connection and first-publish conversion.
+
+The first campaign establishes a baseline. Do not invent acquisition or
+engagement targets before baseline evidence exists.
+
+### AI measures
+
+- accepted without edit;
+- accepted after edit;
+- rejected;
+- edit distance or classified edit reason;
+- brand/claim/policy failure rate;
+- cost per approved adaptation; and
+- latency per approved adaptation.
+
+## Delivery Slices
+
+Keep changes reviewable and independently verifiable:
+
+1. documentation, schemas, X campaign specification, and validation;
+2. persisted versions, approvals, attribution links, and import;
+3. durable account/OAuth and scheduler infrastructure;
+4. durable event ingestion, attribution, queries, and workbook;
+5. AI provenance and quality adjudication; and
+6. LinkedIn pilot.
+
+Each slice requires `pnpm check-all`, a separate PR, deployment verification
+when runtime behavior changes, and a Baton closeout containing changed files,
+tests, deployment evidence, residual risk, and next action.
+
+## Notion Operating Cadence
+
+- **Before work:** verify the current campaign brief, claims, owner, reviewer,
+  channel rules, and decision gate.
+- **Before publish:** freeze the approved snapshot and reference its Git version
+  and content hash.
+- **During the campaign:** runtime systems own state; do not edit Notion to
+  rewrite what was published.
+- **Weekly:** reconcile campaign links, tagging quality, publish outcomes,
+  attribution, and open incidents.
+- **At the decision gate:** record continue, revise, pause, or stop with cited
+  evidence.
+- **Quarterly:** re-check competitor capability and pricing claims before using
+  them externally.
+
+## Decision Log
+
+| Date       | Decision                                                                              | Reason                                                                                                                 |
+| ---------- | ------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| 2026-07-24 | Use X as the first controlled live path                                               | The adapter, starter campaign, deployment, and operator runbook already exist; changing platforms would delay evidence |
+| 2026-07-24 | Separate the smoke gate from production readiness                                     | The current local campaign and memory-backed queue can prove one staffed publish but cannot support broad rollout      |
+| 2026-07-24 | Use Notion, Git, runtime, and Baton as distinct sources of truth joined by stable IDs | This preserves human governance, versioned contracts, live execution truth, and accountable delivery                   |
+| 2026-07-24 | Defer LinkedIn until durable campaign and measurement gates pass                      | The second platform should validate reuse of the operating system rather than add another one-off integration          |
+
+## Immediate Next Actions
+
+1. Complete the external account-authorization steps in the X runbook and run
+   Gate 0 when the account owner is present.
+2. Deliver Gate 1 as the next repository PR.
+3. Use the approved `omnipost-x-live-001` campaign ID in Notion, Git, runtime
+   migration, telemetry, and Baton.
+4. Start Gate 2 only after the Gate 1 schemas and validation are reviewed.
+5. Do not un-gate another provider until its named entry criteria pass.

--- a/docs/roadmaps/MARKETING_CAMPAIGN_OPERATING_SYSTEM.md
+++ b/docs/roadmaps/MARKETING_CAMPAIGN_OPERATING_SYSTEM.md
@@ -294,7 +294,7 @@ Exit gate:
 
 Entry criteria:
 
-- Gates 1 through 4 are complete;
+- Gates 1 through 5 are complete;
 - the X observation window has a documented decision;
 - no unresolved duplicate, approval, credential, or attribution defect remains;
   and
@@ -393,7 +393,8 @@ tests, deployment evidence, residual risk, and next action.
 1. Complete the external account-authorization steps in the X runbook and run
    Gate 0 when the account owner is present.
 2. Deliver Gate 1 as the next repository PR.
-3. Use the approved `omnipost-x-live-001` campaign ID in Notion, Git, runtime
-   migration, telemetry, and Baton.
+3. Use the approved `campaign_omnipost_x_live_001` campaign ID in Notion, Git,
+   runtime migration, telemetry, and Baton; use `omnipost-x-live-001` only as
+   its human-readable slug.
 4. Start Gate 2 only after the Gate 1 schemas and validation are reviewed.
 5. Do not un-gate another provider until its named entry criteria pass.


### PR DESCRIPTION
## What changed

- add the canonical marketing and campaign operating-system roadmap
- separate the controlled X evidence pilot from production-grade campaign readiness
- document Gates 0-6 covering contracts, persistence, OAuth/scheduling, attribution, AI provenance, and the LinkedIn entry gate
- add the X-first delivery plan with planned PR slices, dependencies, verification, and definition of done
- link both documents from the root and documentation indexes

## Why

OmniPost planning was split across the alpha plan, the X operator runbook, Notion, and Baton. This PR creates one versioned sequencing and governance record while preserving those systems' distinct responsibilities.

## Impact

The team now has explicit source-of-truth boundaries, stable cross-system IDs, stop/go gates, success measures, and a delivery sequence that prevents one successful smoke post from being mistaken for broad production readiness.

## Validation

- `git diff --check`
- targeted Prettier check for all four changed files
- TypeScript type-check passed
- ESLint completed with existing warnings and no errors
- Jest: 29 suites, 223 tests passed
- `pnpm check-all` reaches `format:check` and stops on the pre-existing repository-wide Prettier baseline affecting 166 unrelated files; all files changed by this PR pass targeted formatting