### PR TITLE
docs: add defensibility roadmap gates

### DIFF
--- a/.agents/context/product-marketing-context.md
+++ b/.agents/context/product-marketing-context.md
@@ -105,6 +105,9 @@ Additional models to evaluate:
 
 **Differentiation**:
 
+- Evidence-grade campaign operations: exact approved version, provider-confirmed
+  delivery, attribution, decision history, and exportable audit lineage
+- Human-governed AI with recorded accept/edit/reject evidence and policy gates
 - AI-native content optimization (auto-reformats for each platform's constraints)
 - Open-source (MIT license) with self-hosting option — no vendor lock-in
 - Built-in CRM, lead management, and outreach sequences
@@ -113,6 +116,32 @@ Additional models to evaluate:
 - Unified analytics across all platforms in one dashboard
 - Multi-agent orchestration for development (Retort + 10 team-scoped agents)
 - Sluice AI gateway for centralized cost tracking across AI providers
+
+## Strategic Positioning and Moat Thesis
+
+**Positioning direction**:
+
+> For agencies and accountable marketing teams that cannot treat a green
+> “scheduled” badge as proof, OmniPost is an evidence-grade campaign operating
+> system that binds human approval to provider-confirmed delivery and measurable
+> outcomes. Unlike generic social schedulers, OmniPost preserves the exact
+> version, decision, attribution, and audit lineage while using AI only inside
+> explicit governance boundaries.
+
+**Moat thesis**:
+
+- Gates 0–6 create the reliable product and evidence foundation; they do not by
+  themselves establish a moat.
+- Defensibility must compound from consented proprietary outcome evidence,
+  measurable recommendation lift, embedded customer policies and integrations,
+  retained paid workflows, and a repeatable vertical distribution or extension
+  channel.
+- Open-source code is not treated as secret IP. The protected advantage is the
+  hosted trust, evidence network, customer-specific learning, operational
+  history, certified ecosystem, and distribution relationships.
+- OmniPost must preserve deletion, export, and migration rights. Switching cost
+  should be earned through accumulated value, not data hostage-taking.
+- “AI-powered,” feature count, or raw data volume are not acceptable moat claims.
 
 ## Brand Voice
 
@@ -127,3 +156,7 @@ Additional models to evaluate:
 2. **Secondary**: Convert free users to paid plans (pricing TBD)
 3. **Metric**: Monthly active publishers, content published per user
 4. **Conversion Action**: Sign up → connect first platform → publish first content
+5. **Beachhead Validation**: Five design-partner organizations complete two
+   governed campaigns with at least 90% evidence completeness
+6. **Defensibility Proof**: Reproducible outcome lift, 90-day retained recurring
+   use, paid intent, and one compounding acquisition or extension channel

--- a/docs/plans/X_FIRST_CAMPAIGN_DELIVERY_PLAN.md
+++ b/docs/plans/X_FIRST_CAMPAIGN_DELIVERY_PLAN.md
@@ -169,6 +169,85 @@ Scope:
   and
 - a cross-platform retrospective.
 
+### PR G — Design-Partner Evidence Network
+
+Scope:
+
+- consented design-partner cohort and beachhead selection;
+- tenant-isolated evidence completeness and retention controls;
+- deletion/export workflows; and
+- repeat-campaign and evidence-quality reporting.
+
+Verification:
+
+- tenant-boundary and deletion tests;
+- five organizations complete two governed campaigns;
+- at least 90% evidence completeness; and
+- customer interviews and willingness-to-pay evidence.
+
+### PR H — Outcome Intelligence
+
+Scope:
+
+- tenant-private brand and approval memory;
+- consented privacy-safe aggregate benchmarks;
+- evidence-backed recommendations and route evaluation; and
+- holdouts, explanations, rollback, and guardrails.
+
+Verification:
+
+- at least 10% relative lift in a predeclared primary measure;
+- no quality, policy, privacy, or reliability regression;
+- reproducibility across at least three organizations; and
+- baseline behavior returns when the learned signal is disabled.
+
+### PR I — Workflow Embeddedness
+
+Scope:
+
+- organization/client policy packs and escalation;
+- beachhead integrations and API contracts;
+- lineage-preserving import; and
+- complete portable campaign and audit export.
+
+Verification:
+
+- 90-day cohort retention and third-campaign reuse;
+- recurring policy-pack plus integration usage; and
+- export/re-import audit reconstruction.
+
+### PR J — Vertical Distribution and Extensions
+
+Scope:
+
+- segment positioning, onboarding, proof, and pricing;
+- customer-approved case studies;
+- certified adapter/integration SDK; and
+- partner and contributor acquisition attribution.
+
+Verification:
+
+- repeatable channel share over two measurement periods;
+- three externally owned live certified integrations; and
+- predeclared paid-pilot conversion threshold.
+
+### PR K — Defensibility Review
+
+Scope:
+
+- 3/6/12-month counterfactual clone review;
+- protected-asset inventory;
+- replacement-cost and switching interviews;
+- unit economics and concentration risk; and
+- evidence-backed continue, narrow, partner, open-source, or stop decision.
+
+Verification:
+
+- Gate 11 criteria are evaluated without waivers;
+- every moat claim cites retained usage, lift, workflow, or distribution
+  evidence; and
+- failed criteria produce an owned remediation or stop decision.
+
 ## Immediate X Smoke Checklist
 
 The runbook remains authoritative. Planning status:
@@ -224,4 +303,10 @@ The X-first campaign initiative is complete only when:
 5. AI adaptations have first-party review and quality records;
 6. the campaign has a documented decision and retrospective; and
 7. LinkedIn has either passed its entry review or been explicitly deferred with
-   a reason.
+   a reason;
+8. design partners produce a consented, evidence-complete corpus;
+9. outcome intelligence demonstrates reproducible guarded lift;
+10. retained customers repeatedly use embedded policies and integrations;
+11. one vertical acquisition or extension channel compounds; and
+12. the defensibility review either substantiates a specific moat or records a
+    remediation/stop decision.

--- a/docs/roadmaps/MARKETING_CAMPAIGN_OPERATING_SYSTEM.md
+++ b/docs/roadmaps/MARKETING_CAMPAIGN_OPERATING_SYSTEM.md
@@ -2,7 +2,7 @@
 
 - **Status:** Approved direction
 - **Last updated:** 2026-07-24
-- **Horizon:** Controlled X evidence pilot through first LinkedIn expansion
+- **Horizon:** Controlled X evidence pilot through measured defensibility proof
 - **Canonical MVP constraint:** One reliable workflow from content input
   through AI adaptation, human approval, verified publishing, visible result,
   and audit evidence.
@@ -36,7 +36,13 @@ The order is:
 3. persist campaign, approval, account, queue, and result state;
 4. make campaign attribution and operational evidence durable;
 5. evaluate AI routes using first-party acceptance and quality evidence; and
-6. reuse the proven contracts for a LinkedIn pilot.
+6. reuse the proven contracts for a LinkedIn pilot;
+7. accumulate a consented, privacy-safe outcome corpus;
+8. turn that corpus into measurably better decisions;
+9. embed evidence-grade workflows deeply enough to create earned switching
+   costs;
+10. establish a repeatable vertical distribution and extension ecosystem; and
+11. pass a counterfactual clone-and-retention review before claiming a moat.
 
 Facebook, Instagram, TikTok, broad listening, a unified inbox, autonomous
 posting, and CRM-grade revenue attribution remain deferred until these gates
@@ -315,6 +321,159 @@ Exit gate:
 - provider and attribution evidence reconcile; and
 - the retrospective decides whether to expand, revise, or stop.
 
+### Gate 7 — Design-Partner Evidence Network
+
+- **Horizon:** Post-pilot
+- **Primary teams:** Product, marketing, data, security, customer success
+
+Entry criteria:
+
+- Gates 1 through 6 are complete;
+- evidence collection, retention, consent, export, and deletion rules are
+  documented; and
+- design partners agree to the exact data-use boundary.
+
+Deliver:
+
+- a focused design-partner program for one beachhead segment;
+- tenant-isolated records for approvals, edits, publish outcomes, attribution,
+  incidents, and campaign decisions;
+- explicit consent and purpose metadata for any aggregate learning signal;
+- data-quality, deletion, export, and tenant-boundary controls; and
+- a cohort dashboard that separates usage volume from evidence completeness.
+
+Exit gate:
+
+- at least five active design-partner organizations complete two governed
+  campaigns each;
+- at least 90% of their published adaptations have complete approval,
+  provider, attribution, and decision evidence;
+- deletion/export and cross-tenant isolation tests pass; and
+- interviews confirm one beachhead problem worth paying to solve.
+
+### Gate 8 — Compounding Outcome Intelligence
+
+- **Horizon:** Post-pilot
+- **Primary teams:** Data, AI, backend, security, marketing
+
+Entry criteria:
+
+- Gate 7 evidence quality passes;
+- no raw customer content, credentials, or personal data is required for
+  aggregate learning; and
+- each recommendation can cite its evidence class and confidence.
+
+Deliver:
+
+- tenant-private brand and approval memory;
+- privacy-safe aggregate benchmarks where consent permits;
+- recommendation and routing evaluations using acceptance, edit, quality,
+  outcome, cost, and latency evidence;
+- holdouts and rollback controls; and
+- explanations that distinguish observed evidence from model inference.
+
+Exit gate:
+
+- a prospective holdout shows at least a 10% relative improvement in one
+  declared primary measure such as first-pass acceptance or edit effort;
+- brand, claim, policy, privacy, and publish-reliability guardrails do not
+  regress;
+- the result reproduces across at least three design-partner organizations; and
+- disabling the learned signal returns behavior to the documented baseline.
+
+### Gate 9 — Evidence-Grade Workflow Embeddedness
+
+- **Horizon:** Post-pilot
+- **Primary teams:** Product, frontend, backend, security, integrations
+
+Entry criteria:
+
+- Gate 8 produces a repeatable benefit;
+- customers identify existing approval, reporting, and audit systems that
+  OmniPost must complement; and
+- portability remains a product requirement rather than artificial lock-in.
+
+Deliver:
+
+- reusable brand, approval, claim, and channel policy packs;
+- organization roles, client workspaces, review escalation, and evidence
+  retention controls;
+- durable integrations and APIs for the beachhead workflow;
+- complete campaign-history, evidence, and policy export; and
+- migration tools that preserve lineage when customers import existing work.
+
+Exit gate:
+
+- at least 60% of the Gate 7 cohort remains active after 90 days;
+- at least 70% of retained organizations run a third governed campaign;
+- at least three organizations use a policy pack plus one external integration
+  in recurring operation; and
+- export/re-import reconstructs the approval and publish audit trail without
+  vendor-only fields.
+
+### Gate 10 — Vertical Distribution and Extension Flywheel
+
+- **Horizon:** Post-pilot
+- **Primary teams:** Product marketing, partnerships, developer experience,
+  security
+
+Entry criteria:
+
+- Gate 9 identifies one retained beachhead segment;
+- external claims are backed by customer-approved evidence; and
+- adapter and integration security boundaries are documented.
+
+Deliver:
+
+- segment-specific positioning, onboarding, templates, proof, and pricing;
+- customer-approved case studies tied to measured operational or campaign
+  outcomes;
+- a versioned adapter/integration SDK with certification tests;
+- a partner and contributor motion that brings qualified organizations into the
+  evidence network; and
+- attribution from partner or ecosystem entry through retained usage.
+
+Exit gate:
+
+- one repeatable channel produces at least 30% of qualified design-partner or
+  pilot opportunities for two consecutive measurement periods;
+- at least three external integrations or adapters pass certification and are
+  used in live governed workflows;
+- the beachhead cohort converts to paid or signed paid-pilot commitments at a
+  predeclared threshold; and
+- acquisition claims reconcile with CRM and product evidence.
+
+### Gate 11 — Defensibility Review
+
+- **Horizon:** Decision gate
+- **Primary teams:** Product, strategy, finance, security, data
+
+Entry criteria:
+
+- Gates 7 through 10 have completed measurement windows; and
+- retention, willingness-to-pay, recommendation lift, evidence quality, and
+  distribution data are available.
+
+Deliver:
+
+- a counterfactual review of what a funded competitor could copy in 3, 6, and
+  12 months;
+- an asset inventory separating open-source code from customer trust, data,
+  integrations, workflow history, and distribution advantages;
+- customer interviews testing replacement cost and willingness to switch;
+- unit economics and concentration risk; and
+- a continue, narrow, partner, open-source, or stop decision.
+
+Exit gate:
+
+- no moat claim is made unless outcome intelligence shows reproducible lift,
+  the retained cohort shows recurring paid use, and at least one acquisition or
+  ecosystem channel compounds;
+- the board-level claim names the specific protected advantage and evidence,
+  not “AI,” “data,” or feature count in the abstract; and
+- failed criteria produce an explicit remediation or stop decision rather than
+  a ceremonial pass.
+
 ## Success Measures
 
 ### Operational measures
@@ -349,6 +508,17 @@ engagement targets before baseline evidence exists.
 - cost per approved adaptation; and
 - latency per approved adaptation.
 
+### Defensibility measures
+
+- evidence-complete campaigns per retained organization;
+- 30-, 60-, and 90-day organization retention;
+- repeat governed campaigns per organization;
+- first-pass acceptance and edit-effort lift against holdouts;
+- policy-pack and integration reuse;
+- partner/ecosystem share of qualified opportunities;
+- paid-pilot conversion and willingness-to-pay; and
+- export/re-import audit reconstruction.
+
 ## Delivery Slices
 
 Keep changes reviewable and independently verifiable:
@@ -358,7 +528,12 @@ Keep changes reviewable and independently verifiable:
 3. durable account/OAuth and scheduler infrastructure;
 4. durable event ingestion, attribution, queries, and workbook;
 5. AI provenance and quality adjudication; and
-6. LinkedIn pilot.
+6. LinkedIn pilot;
+7. design-partner evidence network;
+8. compounding outcome intelligence;
+9. evidence-grade workflow embeddedness;
+10. vertical distribution and extension flywheel; and
+11. defensibility review.
 
 Each slice requires `pnpm check-all`, a separate PR, deployment verification
 when runtime behavior changes, and a Baton closeout containing changed files,
@@ -387,6 +562,7 @@ tests, deployment evidence, residual risk, and next action.
 | 2026-07-24 | Separate the smoke gate from production readiness                                     | The current local campaign and memory-backed queue can prove one staffed publish but cannot support broad rollout      |
 | 2026-07-24 | Use Notion, Git, runtime, and Baton as distinct sources of truth joined by stable IDs | This preserves human governance, versioned contracts, live execution truth, and accountable delivery                   |
 | 2026-07-24 | Defer LinkedIn until durable campaign and measurement gates pass                      | The second platform should validate reuse of the operating system rather than add another one-off integration          |
+| 2026-07-25 | Treat Gates 0–6 as moat prerequisites, not proof of a moat                            | Defensibility requires retained paid use, proprietary evidence lift, embedded workflows, and compounding distribution  |
 
 ## Immediate Next Actions
 
@@ -398,3 +574,6 @@ tests, deployment evidence, residual risk, and next action.
    its human-readable slug.
 4. Start Gate 2 only after the Gate 1 schemas and validation are reviewed.
 5. Do not un-gate another provider until its named entry criteria pass.
+6. Recruit design partners only after the evidence boundary and deletion/export
+   controls are reviewable.
+7. Do not use “defensible moat” externally until Gate 11 passes.


### PR DESCRIPTION
## What changed

- add Gates 7-11 for design-partner evidence, outcome intelligence, workflow embeddedness, vertical distribution/extensions, and a final defensibility review
- add planned PR slices G-K with falsifiable verification criteria
- define defensibility measures and prohibit external moat claims before evidence passes
- update OmniPost positioning around evidence-grade campaign operations and ethical, portable switching costs
- create matching future Baton tasks under the existing campaign initiative

## Why

Gates 0-6 create a reliable governed publishing product, but features and schemas alone are copyable. The roadmap now requires retained paid usage, consented proprietary evidence, measurable recommendation lift, embedded workflows, and a compounding distribution or extension channel before OmniPost claims a defendable moat.

## Impact

The team has a dependency-ordered path from product reliability to evidence-backed defensibility, with explicit stop conditions when the moat thesis does not hold.

## Validation

- `pnpm run marketing:validate`
- targeted Prettier check for all three changed files
- `git diff --check`
