### PR TITLE
docs: add governed improvement loop gate

### DIFF
--- a/docs/plans/GOVERNED_IMPROVEMENT_LOOP_PLAN.md
+++ b/docs/plans/GOVERNED_IMPROVEMENT_LOOP_PLAN.md
@@ -1,0 +1,148 @@
+# Governed Analyze–Recommend–Plan Loop
+
+## Purpose
+
+Turn trustworthy OmniPost campaign evidence into repeatable improvement plans
+while keeping humans accountable for strategy, claims, policy, spend,
+approval, and publishing decisions.
+
+This is not an autonomous campaign optimizer. The system may analyze evidence,
+recommend bounded changes, and draft plans. It may not change live campaign,
+policy, approval, budget, credential, or queue state without the existing
+authorization boundary.
+
+## Operating Loop
+
+```text
+evidence readiness
+  -> versioned analysis
+  -> ranked recommendations
+  -> human disposition
+  -> versioned experiment/remediation plan
+  -> authorized execution through existing gates
+  -> result and incident capture
+  -> calibration
+```
+
+## Contracts
+
+### Evidence readiness
+
+Each analysis records:
+
+- tenant and campaign scope;
+- evidence window and immutable source references;
+- completeness, freshness, and tagging-quality scores;
+- missing or conflicting data;
+- comparison baseline or holdout;
+- privacy and consent eligibility; and
+- analysis version.
+
+An incomplete evidence set produces a data-remediation recommendation, not a
+performance claim.
+
+### Analysis
+
+Analyses label each statement as:
+
+- **observation:** directly supported by cited records;
+- **inference:** a bounded interpretation with confidence and alternatives; or
+- **hypothesis:** a testable explanation requiring an experiment.
+
+Raw customer content, secrets, hidden reasoning, and cross-tenant examples are
+not copied into analysis records. Analyses retain source IDs and approved
+summaries sufficient for audit.
+
+### Recommendation
+
+Every recommendation includes:
+
+- stable recommendation ID and analysis version;
+- affected campaign, content, channel, audience, or workflow;
+- cited evidence and known missing data;
+- expected direction and magnitude of impact;
+- confidence and uncertainty;
+- effort, cost, legal/policy, brand, privacy, and reliability risk;
+- counterfactual or “do nothing” option;
+- expiry or reassessment date; and
+- proposed owner.
+
+Recommendations are ranked by expected evidence-adjusted value, not engagement
+alone. Legal, privacy, brand, accessibility, and reliability guardrails cannot
+be traded away for predicted lift.
+
+### Human disposition
+
+An authorized reviewer records `approve`, `revise`, `defer`, or `reject` with
+rationale. The original recommendation remains immutable. A revision creates a
+new version linked to the prior record.
+
+### Plan
+
+An approved recommendation becomes a draft experiment or remediation plan
+containing:
+
+- owner and accountable reviewer;
+- target scope and excluded scope;
+- baseline and primary measure;
+- secondary measures and guardrails;
+- sample/window assumptions;
+- implementation tasks and dependencies;
+- approval and rollout sequence;
+- stop condition and rollback;
+- evidence destination; and
+- review date and decision options.
+
+Plans enter the normal Baton and repository workflow. Draft generation does not
+authorize execution.
+
+### Feedback
+
+At review, record the result, confidence, incidents, guardrail effects, and
+continue/revise/pause/stop decision. Calibration reports compare predicted
+direction and magnitude with observed results, including rejected and deferred
+recommendations to expose selection bias.
+
+## Roles
+
+- **Data:** evidence quality, baselines, holdouts, and statistical validity.
+- **Marketing/Product:** interpretation, prioritization, and customer value.
+- **Security/Legal:** privacy, consent, policy, and prohibited-data controls.
+- **Engineering:** feasibility, reliability, rollout, and rollback.
+- **Human reviewer:** final recommendation disposition and plan authorization.
+- **Baton:** owner, dependencies, status, evidence, and closeout.
+
+## Delivery Slices
+
+1. Define analysis, recommendation, disposition, plan, and result schemas.
+2. Build read-only evidence readiness and analysis views.
+3. Add recommendation ranking with evidence and uncertainty display.
+4. Add immutable human disposition.
+5. Generate versioned draft plans and Baton-ready task proposals.
+6. Capture outcomes and calibration without autonomous mutation.
+
+Each slice requires tenant-isolation tests, prohibited-field tests,
+authorization tests, failure-mode tests, and `pnpm check-all`.
+
+## Exit Criteria
+
+Gate 8A closes only when:
+
+1. three consecutive review cycles run from evidence readiness through recorded
+   result;
+2. every recommendation cites authorized evidence and exposes uncertainty,
+   missing data, risk, and counterfactual;
+3. every approved recommendation produces a versioned plan with owner,
+   baseline, measure, guardrails, stop condition, rollback, and review date;
+4. rejected and deferred recommendations remain reconstructable and appear in
+   calibration;
+5. cross-tenant, prohibited-field, and authorization tests pass; and
+6. no generated recommendation or plan directly mutates live campaign, policy,
+   approval, budget, credential, or queue state.
+
+## Stop Conditions
+
+Stop and remediate if evidence lineage cannot be reconstructed, tenant or
+consent scope is ambiguous, recommendation confidence is presented without
+missing-data context, a guardrail is optimized away, or generated output
+bypasses human authorization.

--- a/docs/plans/X_FIRST_CAMPAIGN_DELIVERY_PLAN.md
+++ b/docs/plans/X_FIRST_CAMPAIGN_DELIVERY_PLAN.md
@@ -201,6 +201,27 @@ Verification:
 - reproducibility across at least three organizations; and
 - baseline behavior returns when the learned signal is disabled.
 
+### PR H2 — Governed Analyze–Recommend–Plan Loop
+
+Scope:
+
+- evidence-readiness and confidence assessment;
+- versioned analysis with observation/inference/hypothesis separation;
+- ranked, evidence-cited recommendations;
+- explicit human disposition and immutable decision history;
+- approved recommendation to experiment/remediation plan conversion; and
+- outcome feedback and recommendation calibration.
+
+Verification:
+
+- three complete evidence-to-result review cycles;
+- every recommendation exposes evidence, uncertainty, risk, and counterfactual;
+- every approved recommendation has an owner, baseline, primary measure,
+  guardrails, stop condition, rollback, and review date;
+- rejected/deferred recommendations remain reconstructable; and
+- no live campaign, approval, policy, budget, or queue mutation occurs without
+  the existing authorization boundary.
+
 ### PR I — Workflow Embeddedness
 
 Scope:
@@ -247,27 +268,6 @@ Verification:
 - every moat claim cites retained usage, lift, workflow, or distribution
   evidence; and
 - failed criteria produce an owned remediation or stop decision.
-
-### PR L — Governed Analyze–Recommend–Plan Loop
-
-Scope:
-
-- evidence-readiness and confidence assessment;
-- versioned analysis with observation/inference/hypothesis separation;
-- ranked, evidence-cited recommendations;
-- explicit human disposition and immutable decision history;
-- approved recommendation to experiment/remediation plan conversion; and
-- outcome feedback and recommendation calibration.
-
-Verification:
-
-- three complete evidence-to-result review cycles;
-- every recommendation exposes evidence, uncertainty, risk, and counterfactual;
-- every approved recommendation has an owner, baseline, primary measure,
-  guardrails, stop condition, rollback, and review date;
-- rejected/deferred recommendations remain reconstructable; and
-- no live campaign, approval, policy, budget, or queue mutation occurs without
-  the existing authorization boundary.
 
 ## Immediate X Smoke Checklist
 

--- a/docs/plans/X_FIRST_CAMPAIGN_DELIVERY_PLAN.md
+++ b/docs/plans/X_FIRST_CAMPAIGN_DELIVERY_PLAN.md
@@ -248,6 +248,27 @@ Verification:
   evidence; and
 - failed criteria produce an owned remediation or stop decision.
 
+### PR L — Governed Analyze–Recommend–Plan Loop
+
+Scope:
+
+- evidence-readiness and confidence assessment;
+- versioned analysis with observation/inference/hypothesis separation;
+- ranked, evidence-cited recommendations;
+- explicit human disposition and immutable decision history;
+- approved recommendation to experiment/remediation plan conversion; and
+- outcome feedback and recommendation calibration.
+
+Verification:
+
+- three complete evidence-to-result review cycles;
+- every recommendation exposes evidence, uncertainty, risk, and counterfactual;
+- every approved recommendation has an owner, baseline, primary measure,
+  guardrails, stop condition, rollback, and review date;
+- rejected/deferred recommendations remain reconstructable; and
+- no live campaign, approval, policy, budget, or queue mutation occurs without
+  the existing authorization boundary.
+
 ## Immediate X Smoke Checklist
 
 The runbook remains authoritative. Planning status:
@@ -309,4 +330,6 @@ The X-first campaign initiative is complete only when:
 10. retained customers repeatedly use embedded policies and integrations;
 11. one vertical acquisition or extension channel compounds; and
 12. the defensibility review either substantiates a specific moat or records a
-    remediation/stop decision.
+    remediation/stop decision; and
+13. the governed improvement loop completes three evidence-to-result cycles
+    without bypassing human authorization.

--- a/docs/roadmaps/MARKETING_CAMPAIGN_OPERATING_SYSTEM.md
+++ b/docs/roadmaps/MARKETING_CAMPAIGN_OPERATING_SYSTEM.md
@@ -474,6 +474,42 @@ Exit gate:
 - failed criteria produce an explicit remediation or stop decision rather than
   a ceremonial pass.
 
+### Gate 8A — Governed Analyze–Recommend–Plan Loop
+
+- **Horizon:** After measurement is reliable; recurring thereafter
+- **Primary teams:** Product, data, marketing, backend, security
+- **Detailed plan:** `docs/plans/GOVERNED_IMPROVEMENT_LOOP_PLAN.md`
+
+This gate is separate from Gate 8. Gate 8 proves that outcome intelligence can
+produce guarded, reproducible lift. Gate 8A turns trustworthy evidence into a
+repeatable operating loop without allowing an AI system to silently change
+campaign strategy, policy, approvals, budgets, or queued content.
+
+Deliver:
+
+- evidence-completeness and confidence checks before analysis;
+- versioned analyses that distinguish observation, inference, and hypothesis;
+- ranked recommendations with cited evidence, expected impact, uncertainty,
+  cost, policy risk, and counterfactual;
+- human approve, revise, defer, or reject decisions;
+- generated experiment or remediation plans with owner, baseline, primary
+  measure, guardrails, stop condition, rollback, and review date; and
+- closed-loop result capture that records whether an approved recommendation
+  worked and updates future confidence without erasing prior reasoning.
+
+Exit gate:
+
+- three consecutive review cycles complete from evidence through recorded
+  result;
+- every recommendation cites tenant-authorized evidence and exposes confidence,
+  uncertainty, and known missing data;
+- every approved recommendation becomes a versioned plan with an owner,
+  predeclared measure, guardrails, stop condition, and rollback;
+- rejected and deferred recommendations remain auditable and inform later
+  calibration; and
+- no recommendation mutates live policy, approval, budget, campaign, or queue
+  state without the existing human authorization boundary.
+
 ## Success Measures
 
 ### Operational measures
@@ -533,7 +569,8 @@ Keep changes reviewable and independently verifiable:
 8. compounding outcome intelligence;
 9. evidence-grade workflow embeddedness;
 10. vertical distribution and extension flywheel; and
-11. defensibility review.
+11. defensibility review; and
+12. governed analyze–recommend–plan loop.
 
 Each slice requires `pnpm check-all`, a separate PR, deployment verification
 when runtime behavior changes, and a Baton closeout containing changed files,
@@ -556,13 +593,14 @@ tests, deployment evidence, residual risk, and next action.
 
 ## Decision Log
 
-| Date       | Decision                                                                              | Reason                                                                                                                 |
-| ---------- | ------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
-| 2026-07-24 | Use X as the first controlled live path                                               | The adapter, starter campaign, deployment, and operator runbook already exist; changing platforms would delay evidence |
-| 2026-07-24 | Separate the smoke gate from production readiness                                     | The current local campaign and memory-backed queue can prove one staffed publish but cannot support broad rollout      |
-| 2026-07-24 | Use Notion, Git, runtime, and Baton as distinct sources of truth joined by stable IDs | This preserves human governance, versioned contracts, live execution truth, and accountable delivery                   |
-| 2026-07-24 | Defer LinkedIn until durable campaign and measurement gates pass                      | The second platform should validate reuse of the operating system rather than add another one-off integration          |
-| 2026-07-25 | Treat Gates 0–6 as moat prerequisites, not proof of a moat                            | Defensibility requires retained paid use, proprietary evidence lift, embedded workflows, and compounding distribution  |
+| Date       | Decision                                                                              | Reason                                                                                                                    |
+| ---------- | ------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------- |
+| 2026-07-24 | Use X as the first controlled live path                                               | The adapter, starter campaign, deployment, and operator runbook already exist; changing platforms would delay evidence    |
+| 2026-07-24 | Separate the smoke gate from production readiness                                     | The current local campaign and memory-backed queue can prove one staffed publish but cannot support broad rollout         |
+| 2026-07-24 | Use Notion, Git, runtime, and Baton as distinct sources of truth joined by stable IDs | This preserves human governance, versioned contracts, live execution truth, and accountable delivery                      |
+| 2026-07-24 | Defer LinkedIn until durable campaign and measurement gates pass                      | The second platform should validate reuse of the operating system rather than add another one-off integration             |
+| 2026-07-25 | Treat Gates 0–6 as moat prerequisites, not proof of a moat                            | Defensibility requires retained paid use, proprietary evidence lift, embedded workflows, and compounding distribution     |
+| 2026-07-25 | Separate improvement operations from outcome-model validation                         | A useful model is not yet a safe operating loop; recommendations need evidence, approval, plans, guardrails, and feedback |
 
 ## Immediate Next Actions
 
@@ -577,3 +615,5 @@ tests, deployment evidence, residual risk, and next action.
 6. Recruit design partners only after the evidence boundary and deletion/export
    controls are reviewable.
 7. Do not use “defensible moat” externally until Gate 11 passes.
+8. Run Gate 8A before closing Gate 11 so the defensibility review tests a
+   working improvement loop rather than a one-time analysis.

--- a/docs/roadmaps/MARKETING_CAMPAIGN_OPERATING_SYSTEM.md
+++ b/docs/roadmaps/MARKETING_CAMPAIGN_OPERATING_SYSTEM.md
@@ -381,6 +381,42 @@ Exit gate:
 - the result reproduces across at least three design-partner organizations; and
 - disabling the learned signal returns behavior to the documented baseline.
 
+### Gate 8A — Governed Analyze–Recommend–Plan Loop
+
+- **Horizon:** After measurement is reliable; recurring thereafter
+- **Primary teams:** Product, data, marketing, backend, security
+- **Detailed plan:** `docs/plans/GOVERNED_IMPROVEMENT_LOOP_PLAN.md`
+
+This gate is separate from Gate 8. Gate 8 proves that outcome intelligence can
+produce guarded, reproducible lift. Gate 8A turns trustworthy evidence into a
+repeatable operating loop without allowing an AI system to silently change
+campaign strategy, policy, approvals, budgets, or queued content.
+
+Deliver:
+
+- evidence-completeness and confidence checks before analysis;
+- versioned analyses that distinguish observation, inference, and hypothesis;
+- ranked recommendations with cited evidence, expected impact, uncertainty,
+  cost, policy risk, and counterfactual;
+- human approve, revise, defer, or reject decisions;
+- generated experiment or remediation plans with owner, baseline, primary
+  measure, guardrails, stop condition, rollback, and review date; and
+- closed-loop result capture that records whether an approved recommendation
+  worked and updates future confidence without erasing prior reasoning.
+
+Exit gate:
+
+- three consecutive review cycles complete from evidence through recorded
+  result;
+- every recommendation cites tenant-authorized evidence and exposes confidence,
+  uncertainty, and known missing data;
+- every approved recommendation becomes a versioned plan with an owner,
+  predeclared measure, guardrails, stop condition, and rollback;
+- rejected and deferred recommendations remain auditable and inform later
+  calibration; and
+- no recommendation mutates live policy, approval, budget, campaign, or queue
+  state without the existing human authorization boundary.
+
 ### Gate 9 — Evidence-Grade Workflow Embeddedness
 
 - **Horizon:** Post-pilot
@@ -450,7 +486,7 @@ Exit gate:
 
 Entry criteria:
 
-- Gates 7 through 10 have completed measurement windows; and
+- Gates 7 through 10 and Gate 8A have completed measurement windows; and
 - retention, willingness-to-pay, recommendation lift, evidence quality, and
   distribution data are available.
 
@@ -473,42 +509,6 @@ Exit gate:
   not “AI,” “data,” or feature count in the abstract; and
 - failed criteria produce an explicit remediation or stop decision rather than
   a ceremonial pass.
-
-### Gate 8A — Governed Analyze–Recommend–Plan Loop
-
-- **Horizon:** After measurement is reliable; recurring thereafter
-- **Primary teams:** Product, data, marketing, backend, security
-- **Detailed plan:** `docs/plans/GOVERNED_IMPROVEMENT_LOOP_PLAN.md`
-
-This gate is separate from Gate 8. Gate 8 proves that outcome intelligence can
-produce guarded, reproducible lift. Gate 8A turns trustworthy evidence into a
-repeatable operating loop without allowing an AI system to silently change
-campaign strategy, policy, approvals, budgets, or queued content.
-
-Deliver:
-
-- evidence-completeness and confidence checks before analysis;
-- versioned analyses that distinguish observation, inference, and hypothesis;
-- ranked recommendations with cited evidence, expected impact, uncertainty,
-  cost, policy risk, and counterfactual;
-- human approve, revise, defer, or reject decisions;
-- generated experiment or remediation plans with owner, baseline, primary
-  measure, guardrails, stop condition, rollback, and review date; and
-- closed-loop result capture that records whether an approved recommendation
-  worked and updates future confidence without erasing prior reasoning.
-
-Exit gate:
-
-- three consecutive review cycles complete from evidence through recorded
-  result;
-- every recommendation cites tenant-authorized evidence and exposes confidence,
-  uncertainty, and known missing data;
-- every approved recommendation becomes a versioned plan with an owner,
-  predeclared measure, guardrails, stop condition, and rollback;
-- rejected and deferred recommendations remain auditable and inform later
-  calibration; and
-- no recommendation mutates live policy, approval, budget, campaign, or queue
-  state without the existing human authorization boundary.
 
 ## Success Measures
 
@@ -567,10 +567,10 @@ Keep changes reviewable and independently verifiable:
 6. LinkedIn pilot;
 7. design-partner evidence network;
 8. compounding outcome intelligence;
-9. evidence-grade workflow embeddedness;
-10. vertical distribution and extension flywheel; and
-11. defensibility review; and
-12. governed analyze–recommend–plan loop.
+9. governed analyze–recommend–plan loop;
+10. evidence-grade workflow embeddedness;
+11. vertical distribution and extension flywheel; and
+12. defensibility review.
 
 Each slice requires `pnpm check-all`, a separate PR, deployment verification
 when runtime behavior changes, and a Baton closeout containing changed files,


### PR DESCRIPTION
## Summary
- add a separate Gate 8A for a governed analyze-recommend-plan operating loop
- define immutable evidence, recommendation, human disposition, plan, and feedback contracts
- require three evidence-to-result cycles and preserve existing authorization boundaries

## Validation
- marketing contract validation passed
- TypeScript passed
- ESLint passed with the existing warning baseline
- focused Prettier check passed for all changed files
- 229/231 local tests passed; two existing validator assertion failures expect AJV wording containing 'must' while the installed validator emits 'should' (the validator behavior itself passed)
- repository-wide Prettier remains blocked by the existing 174-file formatting baseline