### PR TITLE
fix: resolve pnpm version in deploy job

### DIFF
--- a/.github/workflows/azure-webapps-node.yml
+++ b/.github/workflows/azure-webapps-node.yml
@@ -177,6 +177,8 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@fe02b34f77f8bc703788d5817da081398fad5dd2 # v4.0.0
+        with:
+          package_json_file: source/package.json
 
       - name: Set up Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
## Summary
- point the deploy job's pnpm setup at the nested checkout package manifest
- retain the repository-pinned pnpm 10.34.5 version
- unblock the PostgreSQL migration and Azure Web App deployment steps

## Root cause
The deploy job checks out source under source/, while pnpm/action-setup looked for package.json at the job root and failed before Azure login.

## Verification
- Prettier check
- git diff --check
- Gate 3 infrastructure already provisioned at B1ms / 32 GB / North Europe