### PR TITLE
fix: use vault URI for database reference

### DIFF
--- a/.azure/plan.md
+++ b/.azure/plan.md
@@ -1,6 +1,6 @@
 # Azure Deployment Plan
 
-> **Status:** Validated
+> **Status:** Deployed
 
 Generated: 2026-07-25
 
@@ -217,13 +217,13 @@ and deployment validation.
 ### Phase 4: Deployment
 
 - [x] Invoke the `azure-deploy` skill
-- [ ] Obtain explicit approval for cost, RBAC, and cutover
+- [x] Obtain explicit approval for cost, RBAC, and cutover
 - [x] Inventory existing SQLite rows before switching `DATABASE_URL`
-- [ ] Apply Terraform and migrations
-- [ ] Deploy the application
-- [ ] Verify health plus authenticated create/reload/restart/audit persistence
+- [x] Apply Terraform and migrations
+- [x] Deploy the application
+- [x] Verify health plus authenticated create/reload/restart/audit persistence
 - [ ] Record deployment SHA, workflow, Azure resources, residual risk, and Baton closeout
-- [ ] Update status to `Deployed`
+- [x] Update status to `Deployed`
 
 ---
 
@@ -254,7 +254,30 @@ destructive action.
 
 ---
 
-## 9. Files to Generate or Modify
+## 9. Deployment Proof
+
+| Check                     | Evidence                                                                                                   | Result                                                                                 |
+| ------------------------- | ---------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------- |
+| Infrastructure apply      | Terraform apply on 2026-07-25                                                                              | 12 added, 2 changed, 0 destroyed                                                       |
+| Cost controls             | `nl-dev-omnipost-psqlf-app` live configuration                                                             | North Europe, Burstable B1ms, 32 GiB, 7-day backup, no HA, no geo-redundant backup     |
+| Database migration        | GitHub Actions run `30164870954`, SHA `a8876a19b1048bee8ec8f1635cd643474cc3985d`                           | PostgreSQL baseline applied before package deployment                                  |
+| Application deployment    | GitHub Actions run `30164870954`                                                                           | Build, infrastructure plan, migration, Web App deployment, and automated health passed |
+| Key Vault resolution      | App Service connection-string reference status                                                             | `Resolved` through user-assigned identity; no plaintext application setting            |
+| Authenticated persistence | Production registration, canonical import, read, audit, App Service restart, then read/audit on 2026-07-25 | Version 1 and snapshot hash stable; one audit version and three attribution links      |
+
+The first deployed reference used the secret's ARM resource ID and App Service
+reported `InvalidSyntax`. PR #180 changes the expression to the provider's
+versionless vault URI. The corrected live plan updated the Web App in place
+with 0 additions and 0 destroys, after which App Service reported `Resolved`.
+
+**Residual risk:** this controlled dev topology permits public PostgreSQL
+network access from Azure services because the B1 App Service has no VNet
+integration. Private networking and tighter application-specific database
+roles remain later hardening work.
+
+---
+
+## 10. Files to Generate or Modify
 
 | File                                       | Purpose                                                            | Status   |
 | ------------------------------------------ | ------------------------------------------------------------------ | -------- |
@@ -266,16 +289,15 @@ destructive action.
 | `.github/workflows/ci.yml`                 | Ephemeral PostgreSQL CI service and generated client               | Complete |
 | `.github/workflows/azure-webapps-node.yml` | Production migration and package corrections                       | Complete |
 | `infra/terraform/env/dev/*.tf`             | Dedicated database server, database, secret, and runtime reference | Complete |
-| `docs/HANDOFF.md`                          | Gate 2 production closeout and Gate 3 continuation evidence        | Pending  |
+| `docs/HANDOFF.md`                          | Gate 2 production closeout and Gate 3 continuation evidence        | Complete |
 
 ---
 
-## 10. Next Steps
+## 11. Next Steps
 
-> Current: Validated; invoke `azure-deploy` before provisioning.
+> Current: deployed and restart-persistence verified.
 
-1. Review and publish the isolated
-   `agent/production-durable-database` branch.
-2. Invoke `azure-deploy` and obtain explicit cost/RBAC/cutover authorization
-   before applying the validated plan. The deployed SQLite inventory is empty,
-   so no row migration is required.
+1. Reconcile the Gate 3 deployment evidence and remaining slices in Baton.
+2. Continue Gate 3 in separate PRs for X OAuth lifecycle, durable queue leases,
+   recurring processing, retry/dead-letter handling, rate limits, and provider
+   reconciliation.

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -6,9 +6,13 @@
 
 - **Gate 2 implementation:** PR #177 merged at
   `e32a5b769a1cff642cd7bb87b9f642266df0cb79`.
-- **Gate 3 branch:** `agent/production-durable-database`.
-- **Azure plan:** `.azure/plan.md` is `Validated`; live provisioning and
-  cutover remain intentionally pending.
+- **Gate 3 implementation:** PR #178 merged at
+  `1316d260bebaacbd56ee0a13269ef5471d1ec392`.
+- **Deployment workflow fix:** PR #179 merged at
+  `a8876a19b1048bee8ec8f1635cd643474cc3985d`.
+- **Key Vault reference fix:** PR #180; the corrected reference is applied and
+  production persistence proof passes.
+- **Azure plan:** `.azure/plan.md` is `Deployed`.
 - **Database region:** North Europe, the lowest-cost supported European B1ms
   region verified for this subscription, estimated at approximately USD 17.19
   per 730-hour month with 32 GiB before backup overage and transfer.
@@ -34,6 +38,17 @@
 
 ### Verification
 
+- Terraform provisioned 12 resources, changed 2 in place, and destroyed 0.
+- The live database is PostgreSQL 16 on Burstable B1ms with 32 GiB, seven-day
+  backup, no HA, and no geo-redundant backup.
+- GitHub Actions run `30164870954` passed build, Terraform planning, the
+  PostgreSQL migration, Web App deployment, and automated health verification.
+- App Service reports the Key Vault connection-string reference as `Resolved`
+  through `nl-dev-omnipost-msi-web-kv`.
+- An authenticated production smoke registered a non-PII evidence user,
+  imported the canonical campaign, read its audit state, restarted App Service,
+  and read it again. Version 1 and the snapshot hash were unchanged; the audit
+  retained one version and all three attribution links.
 - PostgreSQL baseline migration applied successfully to a clean PostgreSQL 16
   container.
 - Restart-persistence integration passed with immutable approval and
@@ -53,11 +68,12 @@
 
 ### Deployment Boundary And Continuation
 
-- Live apply changes RBAC, enables irreversible Key Vault purge protection, and
-  starts the estimated USD 17.19/month database cost; it requires explicit
-  deployment authorization.
-- After infrastructure and migrations are live, deploy the application and
-  prove authenticated create/reload/App Service restart/audit persistence.
+- Gate 3's durable application database slice is live and verified. Key Vault
+  purge protection is enabled, and the estimated USD 17.19/month database cost
+  is active.
+- The controlled dev database currently permits public access from Azure
+  services because the B1 App Service has no VNet integration. Private
+  networking and application-specific database roles remain hardening work.
 - Continue Gate 3 in separate PRs for X OAuth lifecycle, durable queue leases
   and idempotency, recurring processing, retries/dead-lettering, rate limits,
   and provider reconciliation.

--- a/infra/terraform/env/dev/main.tf
+++ b/infra/terraform/env/dev/main.tf
@@ -138,7 +138,7 @@ resource "azurerm_linux_web_app" "web" {
     content {
       name  = "DATABASE_URL"
       type  = "PostgreSQL"
-      value = "@Microsoft.KeyVault(SecretUri=${azurerm_key_vault_secret.app_database_url[0].resource_versionless_id})"
+      value = "@Microsoft.KeyVault(SecretUri=${azurerm_key_vault_secret.app_database_url[0].versionless_id})"
     }
   }
 


### PR DESCRIPTION
## Summary
- use the Key Vault secret data-plane URI in the App Service connection-string reference
- replace the invalid ARM resource ID reference that Prisma received literally

## Root cause
App Service reported DATABASE_URL as InvalidSyntax because resource_versionless_id expands to /subscriptions/... rather than https://...vault.azure.net/secrets/....

## Verification
- official AzureRM provider attribute documentation
- terraform fmt
- terraform validate
- live plan: 0 add, 2 safe in-place changes, 0 destroy