### PR TITLE
feat: add X OAuth account lifecycle

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -116,9 +116,14 @@ JWT_SECRET=your-secure-jwt-secret-key-here
 
 # Twitter/X
 # TWITTER_API_URL=https://api.x.com/2/tweets
-# OAuth user-context token with tweet.read, tweet.write, and users.read.
-# An app-only bearer token cannot create posts.
+# Legacy staffed-smoke token. Gate 3 OAuth connections replace this static value.
 # TWITTER_ACCESS_TOKEN=your-x-user-access-token
+# OAuth 2.0 Authorization Code with S256 PKCE.
+# X_CLIENT_ID=your-x-oauth-client-id
+# X_CLIENT_SECRET=your-x-confidential-client-secret
+# X_OAUTH_REDIRECT_URI=http://localhost:3000/api/platforms/x/callback
+# Generate with: node -e "console.log(require('node:crypto').randomBytes(32).toString('base64'))"
+# PLATFORM_TOKEN_ENCRYPTION_KEY=base64-encoded-32-byte-key
 
 # ============================================
 # EXTERNAL IDENTITY PROVIDER (Optional)

--- a/__tests__/lib/x-oauth.test.ts
+++ b/__tests__/lib/x-oauth.test.ts
@@ -1,0 +1,161 @@
+import { afterEach, beforeEach, describe, expect, jest, test } from '@jest/globals';
+import {
+  createPkcePair,
+  decryptSecret,
+  encryptSecret,
+  isPlatformTokenEncryptionConfigured,
+  safeEqual,
+} from '../../lib/platforms/x/crypto';
+import { openXOAuthFlow, sealXOAuthFlow } from '../../lib/platforms/x/flow';
+import {
+  createAuthorizationRequest,
+  exchangeAuthorizationCode,
+  fetchXIdentity,
+  isXOAuthClientConfigured,
+  refreshAccessToken,
+  revokeXToken,
+  X_OAUTH_SCOPES,
+} from '../../lib/platforms/x/oauth';
+
+const originalEnvironment = { ...process.env };
+const fetchMock = jest.fn<typeof fetch>();
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+  } as Response;
+}
+
+describe('X OAuth security primitives', () => {
+  beforeEach(() => {
+    process.env.PLATFORM_TOKEN_ENCRYPTION_KEY = Buffer.alloc(32, 7).toString('base64');
+    process.env.X_CLIENT_ID = 'x-client-id';
+    process.env.X_OAUTH_REDIRECT_URI = 'https://omnipost.example/api/platforms/x/callback';
+    delete process.env.X_CLIENT_SECRET;
+    global.fetch = fetchMock;
+    fetchMock.mockReset();
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnvironment };
+    jest.restoreAllMocks();
+  });
+
+  test('encrypts secrets with authenticated purpose binding', () => {
+    const encrypted = encryptSecret('access-token-value', 'x-access-token');
+
+    expect(encrypted).not.toContain('access-token-value');
+    expect(decryptSecret(encrypted, 'x-access-token')).toBe('access-token-value');
+    expect(() => decryptSecret(encrypted, 'x-refresh-token')).toThrow();
+  });
+
+  test('creates an S256 PKCE pair and compares state safely', () => {
+    const pair = createPkcePair();
+
+    expect(pair.verifier.length).toBeGreaterThanOrEqual(43);
+    expect(pair.challenge).not.toBe(pair.verifier);
+    expect(safeEqual('matching-state', 'matching-state')).toBe(true);
+    expect(safeEqual('matching-state', 'different-state')).toBe(false);
+  });
+
+  test('seals OAuth flow state and rejects expired state', () => {
+    const payload = {
+      state: 's'.repeat(43),
+      verifier: 'v'.repeat(64),
+      userId: 'user-1',
+      expiresAt: Date.now() + 60_000,
+    };
+    const sealed = sealXOAuthFlow(payload);
+
+    expect(openXOAuthFlow(sealed)).toEqual(payload);
+    expect(openXOAuthFlow(sealXOAuthFlow({ ...payload, expiresAt: Date.now() - 1 }))).toBeNull();
+  });
+
+  test('constructs a least-privilege X authorization request', () => {
+    const request = createAuthorizationRequest();
+    const url = new URL(request.authorizationUrl);
+
+    expect(url.origin).toBe('https://x.com');
+    expect(url.searchParams.get('response_type')).toBe('code');
+    expect(url.searchParams.get('client_id')).toBe('x-client-id');
+    expect(url.searchParams.get('redirect_uri')).toBe(
+      'https://omnipost.example/api/platforms/x/callback'
+    );
+    expect(url.searchParams.get('scope')).toBe(X_OAUTH_SCOPES.join(' '));
+    expect(url.searchParams.get('code_challenge_method')).toBe('S256');
+    expect(url.searchParams.get('state')).toBe(request.state);
+    expect(url.searchParams.get('code_challenge')).not.toBe(request.verifier);
+    expect(isXOAuthClientConfigured()).toBe(true);
+    expect(isPlatformTokenEncryptionConfigured()).toBe(true);
+  });
+
+  test('exchanges a code without exposing a public-client secret', async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        token_type: 'bearer',
+        expires_in: 7200,
+        access_token: 'access-token',
+        refresh_token: 'refresh-token',
+        scope: X_OAUTH_SCOPES.join(' '),
+      })
+    );
+
+    const tokens = await exchangeAuthorizationCode('authorization-code', 'pkce-verifier');
+    const [url, init] = fetchMock.mock.calls[0];
+    const body = init?.body as URLSearchParams;
+
+    expect(url).toBe('https://api.x.com/2/oauth2/token');
+    expect(init?.headers).not.toHaveProperty('Authorization');
+    expect(body.get('grant_type')).toBe('authorization_code');
+    expect(body.get('client_id')).toBe('x-client-id');
+    expect(body.get('code_verifier')).toBe('pkce-verifier');
+    expect(tokens.refresh_token).toBe('refresh-token');
+  });
+
+  test('refreshes, resolves identity, and revokes through user-context endpoints', async () => {
+    fetchMock
+      .mockResolvedValueOnce(
+        jsonResponse({
+          token_type: 'bearer',
+          expires_in: 7200,
+          access_token: 'rotated-access-token',
+          refresh_token: 'rotated-refresh-token',
+          scope: X_OAUTH_SCOPES.join(' '),
+        })
+      )
+      .mockResolvedValueOnce(jsonResponse({ data: { id: 'x-123', username: 'omnipost' } }))
+      .mockResolvedValueOnce(jsonResponse({ revoked: true }));
+
+    const tokens = await refreshAccessToken('refresh-token');
+    const identity = await fetchXIdentity(tokens.access_token);
+    await revokeXToken(tokens.refresh_token || tokens.access_token);
+
+    const refreshBody = fetchMock.mock.calls[0][1]?.body as URLSearchParams;
+    expect(refreshBody.get('grant_type')).toBe('refresh_token');
+    expect(refreshBody.get('refresh_token')).toBe('refresh-token');
+    expect(fetchMock.mock.calls[1][1]?.headers).toEqual({
+      Authorization: 'Bearer rotated-access-token',
+    });
+    expect(identity).toEqual({ id: 'x-123', username: 'omnipost' });
+    expect(fetchMock.mock.calls[2][0]).toBe('https://api.x.com/2/oauth2/revoke');
+  });
+
+  test('fails closed when the encryption key is absent', () => {
+    delete process.env.PLATFORM_TOKEN_ENCRYPTION_KEY;
+    expect(() => encryptSecret('token', 'x-access-token')).toThrow(
+      'PLATFORM_TOKEN_ENCRYPTION_KEY is not configured'
+    );
+  });
+
+  test('rejects an insecure production callback URI', () => {
+    process.env = { ...process.env, NODE_ENV: 'production' };
+    process.env.X_OAUTH_REDIRECT_URI = 'http://omnipost.example/api/platforms/x/callback';
+
+    expect(isXOAuthClientConfigured()).toBe(false);
+    expect(() => createAuthorizationRequest()).toThrow(
+      'X_OAUTH_REDIRECT_URI must use HTTPS in production'
+    );
+  });
+});

--- a/__tests__/lib/x-platform-repository.test.ts
+++ b/__tests__/lib/x-platform-repository.test.ts
@@ -376,6 +376,27 @@ describe('X platform account repository', () => {
     });
   });
 
+  test('requires revocation when refresh is rejected before the access token expires', async () => {
+    mockFindUnique.mockResolvedValueOnce({
+      id: 'account-1',
+      status: 'connected',
+      expiresAt: new Date(Date.now() + 60_000),
+      encryptedAccessToken: encryptSecret('still-live-access', 'x-access-token'),
+      encryptedRefreshToken: encryptSecret('invalid-refresh', 'x-refresh-token'),
+      updatedAt: new Date('2026-07-25T12:00:00Z'),
+    });
+    mockRefreshAccessToken.mockRejectedValueOnce(new XOAuthTokenRequestError(400, 'invalid_grant'));
+    mockUpdateMany.mockResolvedValueOnce({ count: 1 }).mockResolvedValueOnce({ count: 1 });
+
+    await expect(repository.getValidXAccessToken('user-1')).rejects.toThrow(
+      'X OAuth token request failed with status 400'
+    );
+    expect(mockUpdateMany).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ data: { status: 'revocation_required' } })
+    );
+  });
+
   test('does not overwrite a concurrent disconnect or reconnect after refresh', async () => {
     mockFindUnique.mockResolvedValueOnce({
       id: 'account-1',

--- a/__tests__/lib/x-platform-repository.test.ts
+++ b/__tests__/lib/x-platform-repository.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeAll, beforeEach, describe, expect, jest, test } from '
 import { readFileSync } from 'node:fs';
 import path from 'node:path';
 import { decryptSecret, encryptSecret } from '../../lib/platforms/x/crypto';
+import { XOAuthTokenRequestError } from '../../lib/platforms/x/oauth';
 
 const mockFindUnique = jest.fn<(args: unknown) => Promise<unknown>>();
 const mockUpsert = jest.fn<(args: unknown) => Promise<unknown>>();
@@ -99,6 +100,7 @@ describe('X platform account repository', () => {
       providerUsername: 'omnipost',
       scopes: 'tweet.read tweet.write',
       expiresAt: new Date(Date.now() - 60_000),
+      encryptedRefreshToken: null,
       status: 'connected',
       connectedAt: new Date('2026-07-25T12:00:00Z'),
     });
@@ -112,6 +114,24 @@ describe('X platform account repository', () => {
       expiresAt: expect.any(String),
       connectedAt: '2026-07-25T12:00:00.000Z',
     });
+  });
+
+  test('reports an account as connected when an expired access token can be refreshed', async () => {
+    mockFindUnique.mockResolvedValueOnce({
+      providerUsername: 'omnipost',
+      scopes: 'tweet.read tweet.write offline.access',
+      expiresAt: new Date(Date.now() - 60_000),
+      encryptedRefreshToken: encryptSecret('refresh-token', 'x-refresh-token'),
+      status: 'connected',
+      connectedAt: new Date('2026-07-25T12:00:00Z'),
+    });
+
+    await expect(repository.getXConnectionStatus('user-1')).resolves.toEqual(
+      expect.objectContaining({
+        connected: true,
+        status: 'connected',
+      })
+    );
   });
 
   test('refreshes an expiring token and persists rotated credentials', async () => {
@@ -140,6 +160,44 @@ describe('X platform account repository', () => {
     expect(decryptSecret(update.data.encryptedAccessToken, 'x-access-token')).toBe('new-access');
     expect(decryptSecret(update.data.encryptedRefreshToken, 'x-refresh-token')).toBe('new-refresh');
     expect(update.data.status).toBe('connected');
+  });
+
+  test('keeps an account connected after a transient refresh failure', async () => {
+    mockFindUnique.mockResolvedValueOnce({
+      id: 'account-1',
+      status: 'connected',
+      expiresAt: new Date(Date.now() - 1),
+      encryptedAccessToken: encryptSecret('old-access', 'x-access-token'),
+      encryptedRefreshToken: encryptSecret('old-refresh', 'x-refresh-token'),
+    });
+    mockRefreshAccessToken.mockRejectedValueOnce(
+      new XOAuthTokenRequestError(429, 'temporarily_unavailable')
+    );
+
+    await expect(repository.getValidXAccessToken('user-1')).rejects.toThrow(
+      'X OAuth token request failed with status 429'
+    );
+    expect(mockUpdate).not.toHaveBeenCalled();
+  });
+
+  test('expires an account after a definitive refresh-token rejection', async () => {
+    mockFindUnique.mockResolvedValueOnce({
+      id: 'account-1',
+      status: 'connected',
+      expiresAt: new Date(Date.now() - 1),
+      encryptedAccessToken: encryptSecret('old-access', 'x-access-token'),
+      encryptedRefreshToken: encryptSecret('old-refresh', 'x-refresh-token'),
+    });
+    mockRefreshAccessToken.mockRejectedValueOnce(new XOAuthTokenRequestError(400, 'invalid_grant'));
+    mockUpdate.mockResolvedValueOnce({ id: 'account-1' });
+
+    await expect(repository.getValidXAccessToken('user-1')).rejects.toThrow(
+      'X OAuth token request failed with status 400'
+    );
+    expect(mockUpdate).toHaveBeenCalledWith({
+      where: { id: 'account-1' },
+      data: { status: 'expired' },
+    });
   });
 
   test('revokes at the provider before erasing stored credentials', async () => {

--- a/__tests__/lib/x-platform-repository.test.ts
+++ b/__tests__/lib/x-platform-repository.test.ts
@@ -178,12 +178,19 @@ describe('X platform account repository', () => {
       refresh_token: 'new-refresh',
       scope: 'tweet.read tweet.write users.read offline.access',
     });
-    mockUpdateMany.mockResolvedValueOnce({ count: 1 });
+    mockUpdateMany.mockResolvedValueOnce({ count: 1 }).mockResolvedValueOnce({ count: 1 });
 
     await expect(repository.getValidXAccessToken('user-1')).resolves.toBe('new-access');
     expect(mockRefreshAccessToken).toHaveBeenCalledWith('old-refresh');
 
-    const update = mockUpdateMany.mock.calls[0][0] as {
+    expect(mockUpdateMany).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ data: { status: 'refreshing' } })
+    );
+    expect(mockUpdateMany.mock.invocationCallOrder[0]).toBeLessThan(
+      mockRefreshAccessToken.mock.invocationCallOrder[0]
+    );
+    const update = mockUpdateMany.mock.calls[1][0] as {
       data: { encryptedAccessToken: string; encryptedRefreshToken: string; status: string };
     };
     expect(decryptSecret(update.data.encryptedAccessToken, 'x-access-token')).toBe('new-access');
@@ -203,11 +210,15 @@ describe('X platform account repository', () => {
     mockRefreshAccessToken.mockRejectedValueOnce(
       new XOAuthTokenRequestError(429, 'temporarily_unavailable')
     );
+    mockUpdateMany.mockResolvedValueOnce({ count: 1 }).mockResolvedValueOnce({ count: 1 });
 
     await expect(repository.getValidXAccessToken('user-1')).rejects.toThrow(
       'X OAuth token request failed with status 429'
     );
-    expect(mockUpdate).not.toHaveBeenCalled();
+    expect(mockUpdateMany).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ data: { status: 'connected' } })
+    );
   });
 
   test('expires an account after a definitive refresh-token rejection', async () => {
@@ -220,13 +231,13 @@ describe('X platform account repository', () => {
       updatedAt: new Date('2026-07-25T12:00:00Z'),
     });
     mockRefreshAccessToken.mockRejectedValueOnce(new XOAuthTokenRequestError(400, 'invalid_grant'));
-    mockUpdateMany.mockResolvedValueOnce({ count: 1 });
+    mockUpdateMany.mockResolvedValueOnce({ count: 1 }).mockResolvedValueOnce({ count: 1 });
 
     await expect(repository.getValidXAccessToken('user-1')).rejects.toThrow(
       'X OAuth token request failed with status 400'
     );
-    expect(mockUpdateMany).toHaveBeenCalledWith({
-      where: expect.objectContaining({ id: 'account-1', status: 'connected' }),
+    expect(mockUpdateMany).toHaveBeenNthCalledWith(2, {
+      where: expect.objectContaining({ id: 'account-1', status: 'refreshing' }),
       data: { status: 'expired' },
     });
   });
@@ -247,7 +258,8 @@ describe('X platform account repository', () => {
       refresh_token: 'stale-refreshed-refresh',
       scope: 'tweet.read tweet.write users.read offline.access',
     });
-    mockUpdateMany.mockResolvedValueOnce({ count: 0 });
+    mockUpdateMany.mockResolvedValueOnce({ count: 1 }).mockResolvedValueOnce({ count: 0 });
+    mockRevokeXToken.mockResolvedValueOnce();
 
     await expect(repository.getValidXAccessToken('user-1')).rejects.toThrow(
       'X account changed while authorization was refreshing'
@@ -261,6 +273,24 @@ describe('X platform account repository', () => {
         }),
       })
     );
+    expect(mockRevokeXToken).toHaveBeenCalledWith('stale-refreshed-refresh');
+  });
+
+  test('does not call X when the refresh lifecycle claim is lost', async () => {
+    mockFindUnique.mockResolvedValueOnce({
+      id: 'account-1',
+      status: 'connected',
+      expiresAt: new Date(Date.now() - 1),
+      encryptedAccessToken: encryptSecret('old-access', 'x-access-token'),
+      encryptedRefreshToken: encryptSecret('old-refresh', 'x-refresh-token'),
+      updatedAt: new Date('2026-07-25T12:00:00Z'),
+    });
+    mockUpdateMany.mockResolvedValueOnce({ count: 0 });
+
+    await expect(repository.getValidXAccessToken('user-1')).rejects.toThrow(
+      'X account changed before authorization could be refreshed'
+    );
+    expect(mockRefreshAccessToken).not.toHaveBeenCalled();
   });
 
   test('revokes at the provider before erasing stored credentials', async () => {
@@ -367,6 +397,35 @@ describe('X platform account repository', () => {
     expect(mockUpdateMany).toHaveBeenNthCalledWith(1, {
       where: { id: 'account-1', status: 'connected', connectedAt },
       data: { status: 'revoking' },
+    });
+  });
+
+  test('removes expired local credentials without requiring provider revocation', async () => {
+    const encryptedAccessToken = encryptSecret('expired-access', 'x-access-token');
+    mockFindUnique.mockResolvedValueOnce({
+      id: 'account-1',
+      status: 'expired',
+      encryptedAccessToken,
+      encryptedRefreshToken: null,
+      updatedAt: new Date('2026-07-25T12:00:00Z'),
+    });
+    mockUpdateMany.mockResolvedValueOnce({ count: 1 });
+
+    await expect(repository.disconnectXAccount('user-1')).resolves.toBe(true);
+    expect(mockRevokeXToken).not.toHaveBeenCalled();
+    expect(mockUpdateMany).toHaveBeenCalledWith({
+      where: {
+        id: 'account-1',
+        status: 'expired',
+        encryptedAccessToken,
+        encryptedRefreshToken: null,
+        updatedAt: new Date('2026-07-25T12:00:00Z'),
+      },
+      data: expect.objectContaining({
+        encryptedAccessToken: '',
+        encryptedRefreshToken: null,
+        status: 'revoked',
+      }),
     });
   });
 });

--- a/__tests__/lib/x-platform-repository.test.ts
+++ b/__tests__/lib/x-platform-repository.test.ts
@@ -561,6 +561,27 @@ describe('X platform account repository', () => {
     });
   });
 
+  test('keeps uncertain credentials recoverable when provider revocation fails', async () => {
+    const account = {
+      id: 'account-1',
+      status: 'recovery_required',
+      encryptedAccessToken: encryptSecret('access-token', 'x-access-token'),
+      encryptedRefreshToken: encryptSecret('refresh-token', 'x-refresh-token'),
+      connectedAt: new Date('2026-07-25T11:00:00Z'),
+      updatedAt: new Date(),
+    };
+    mockFindUnique
+      .mockResolvedValueOnce(account)
+      .mockResolvedValueOnce({ ...account, status: 'revoking' });
+    mockUpdateMany.mockResolvedValueOnce({ count: 1 }).mockResolvedValueOnce({ count: 1 });
+    mockRevokeXToken.mockRejectedValueOnce(new Error('provider unavailable'));
+
+    await expect(repository.disconnectXAccount('user-1')).rejects.toThrow('provider unavailable');
+    expect(mockUpdateMany).toHaveBeenLastCalledWith(
+      expect.objectContaining({ data: { status: 'recovery_required' } })
+    );
+  });
+
   test('removes expired local credentials without requiring provider revocation', async () => {
     const encryptedAccessToken = encryptSecret('expired-access', 'x-access-token');
     mockFindUnique.mockResolvedValueOnce({

--- a/__tests__/lib/x-platform-repository.test.ts
+++ b/__tests__/lib/x-platform-repository.test.ts
@@ -244,14 +244,20 @@ describe('X platform account repository', () => {
       status: 'connected',
       encryptedAccessToken: encryptSecret('access-token', 'x-access-token'),
       encryptedRefreshToken: encryptSecret('refresh-token', 'x-refresh-token'),
+      updatedAt: new Date('2026-07-25T12:00:00Z'),
     });
     mockRevokeXToken.mockResolvedValueOnce();
-    mockUpdate.mockResolvedValueOnce({ id: 'account-1' });
+    mockUpdateMany.mockResolvedValueOnce({ count: 1 });
 
     await expect(repository.disconnectXAccount('user-1')).resolves.toBe(true);
     expect(mockRevokeXToken).toHaveBeenCalledWith('refresh-token');
-    expect(mockUpdate).toHaveBeenCalledWith(
+    expect(mockUpdateMany).toHaveBeenCalledWith(
       expect.objectContaining({
+        where: expect.objectContaining({
+          id: 'account-1',
+          status: 'connected',
+          updatedAt: new Date('2026-07-25T12:00:00Z'),
+        }),
         data: expect.objectContaining({
           encryptedAccessToken: '',
           encryptedRefreshToken: null,
@@ -272,5 +278,33 @@ describe('X platform account repository', () => {
 
     await expect(repository.disconnectXAccount('user-1')).rejects.toThrow('provider unavailable');
     expect(mockUpdate).not.toHaveBeenCalled();
+    expect(mockUpdateMany).not.toHaveBeenCalled();
+  });
+
+  test('does not erase credentials from a concurrent reconnect after provider revocation', async () => {
+    const encryptedAccessToken = encryptSecret('old-access', 'x-access-token');
+    const encryptedRefreshToken = encryptSecret('old-refresh', 'x-refresh-token');
+    mockFindUnique.mockResolvedValueOnce({
+      id: 'account-1',
+      status: 'connected',
+      encryptedAccessToken,
+      encryptedRefreshToken,
+      updatedAt: new Date('2026-07-25T12:00:00Z'),
+    });
+    mockRevokeXToken.mockResolvedValueOnce();
+    mockUpdateMany.mockResolvedValueOnce({ count: 0 });
+
+    await expect(repository.disconnectXAccount('user-1')).resolves.toBe(false);
+    expect(mockUpdateMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          id: 'account-1',
+          status: 'connected',
+          encryptedAccessToken,
+          encryptedRefreshToken,
+          updatedAt: new Date('2026-07-25T12:00:00Z'),
+        },
+      })
+    );
   });
 });

--- a/__tests__/lib/x-platform-repository.test.ts
+++ b/__tests__/lib/x-platform-repository.test.ts
@@ -5,7 +5,7 @@ import { decryptSecret, encryptSecret } from '../../lib/platforms/x/crypto';
 import { XOAuthTokenRequestError } from '../../lib/platforms/x/oauth';
 
 const mockFindUnique = jest.fn<(args: unknown) => Promise<unknown>>();
-const mockUpsert = jest.fn<(args: unknown) => Promise<unknown>>();
+const mockCreate = jest.fn<(args: unknown) => Promise<unknown>>();
 const mockUpdate = jest.fn<(args: unknown) => Promise<unknown>>();
 const mockUpdateMany = jest.fn<(args: unknown) => Promise<{ count: number }>>();
 const mockRefreshAccessToken = jest.fn<(token: string) => Promise<unknown>>();
@@ -21,7 +21,7 @@ describe('X platform account repository', () => {
       default: {
         platformAccount: {
           findUnique: mockFindUnique,
-          upsert: mockUpsert,
+          create: mockCreate,
           update: mockUpdate,
           updateMany: mockUpdateMany,
         },
@@ -41,7 +41,7 @@ describe('X platform account repository', () => {
   beforeEach(() => {
     process.env.PLATFORM_TOKEN_ENCRYPTION_KEY = Buffer.alloc(32, 9).toString('base64');
     mockFindUnique.mockReset();
-    mockUpsert.mockReset();
+    mockCreate.mockReset();
     mockUpdate.mockReset();
     mockUpdateMany.mockReset();
     mockRefreshAccessToken.mockReset();
@@ -53,7 +53,8 @@ describe('X platform account repository', () => {
   });
 
   test('encrypts access and refresh tokens before persistence', async () => {
-    mockUpsert.mockResolvedValueOnce({ id: 'account-1' });
+    mockFindUnique.mockResolvedValueOnce(null);
+    mockCreate.mockResolvedValueOnce({ id: 'account-1' });
 
     await repository.saveXAccount(
       'user-1',
@@ -67,17 +68,59 @@ describe('X platform account repository', () => {
       }
     );
 
-    const call = mockUpsert.mock.calls[0][0] as {
-      create: { encryptedAccessToken: string; encryptedRefreshToken: string };
+    const call = mockCreate.mock.calls[0][0] as {
+      data: { encryptedAccessToken: string; encryptedRefreshToken: string };
     };
-    expect(call.create.encryptedAccessToken).not.toContain('plain-access-token');
-    expect(call.create.encryptedRefreshToken).not.toContain('plain-refresh-token');
-    expect(decryptSecret(call.create.encryptedAccessToken, 'x-access-token')).toBe(
+    expect(call.data.encryptedAccessToken).not.toContain('plain-access-token');
+    expect(call.data.encryptedRefreshToken).not.toContain('plain-refresh-token');
+    expect(decryptSecret(call.data.encryptedAccessToken, 'x-access-token')).toBe(
       'plain-access-token'
     );
-    expect(decryptSecret(call.create.encryptedRefreshToken, 'x-refresh-token')).toBe(
+    expect(decryptSecret(call.data.encryptedRefreshToken, 'x-refresh-token')).toBe(
       'plain-refresh-token'
     );
+  });
+
+  test('revokes displaced credentials before completing reconnect', async () => {
+    const existing = {
+      id: 'account-1',
+      status: 'connected',
+      encryptedAccessToken: encryptSecret('old-access', 'x-access-token'),
+      encryptedRefreshToken: encryptSecret('old-refresh', 'x-refresh-token'),
+      connectedAt: new Date('2026-07-25T11:00:00Z'),
+      updatedAt: new Date('2026-07-25T12:00:00Z'),
+    };
+    mockFindUnique.mockResolvedValueOnce(existing);
+    mockUpdateMany.mockResolvedValueOnce({ count: 1 }).mockResolvedValueOnce({ count: 1 });
+    mockRevokeXToken.mockResolvedValueOnce();
+
+    await repository.saveXAccount(
+      'user-1',
+      { id: 'x-1', username: 'omnipost' },
+      {
+        token_type: 'bearer',
+        expires_in: 7200,
+        access_token: 'new-access',
+        refresh_token: 'new-refresh',
+        scope: 'tweet.read tweet.write users.read offline.access',
+      }
+    );
+
+    expect(mockRevokeXToken).toHaveBeenCalledWith('old-refresh');
+    expect(mockUpdateMany).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ data: { status: 'reconnecting' } })
+    );
+    const replacement = mockUpdateMany.mock.calls[1][0] as {
+      data: { encryptedAccessToken: string; encryptedRefreshToken: string; status: string };
+    };
+    expect(decryptSecret(replacement.data.encryptedAccessToken, 'x-access-token')).toBe(
+      'new-access'
+    );
+    expect(decryptSecret(replacement.data.encryptedRefreshToken, 'x-refresh-token')).toBe(
+      'new-refresh'
+    );
+    expect(replacement.data.status).toBe('connected');
   });
 
   test('uses a forward-only tenant-owned platform account migration', () => {
@@ -276,21 +319,66 @@ describe('X platform account repository', () => {
     expect(mockRevokeXToken).toHaveBeenCalledWith('stale-refreshed-refresh');
   });
 
-  test('does not call X when the refresh lifecycle claim is lost', async () => {
-    mockFindUnique.mockResolvedValueOnce({
-      id: 'account-1',
-      status: 'connected',
-      expiresAt: new Date(Date.now() - 1),
-      encryptedAccessToken: encryptSecret('old-access', 'x-access-token'),
-      encryptedRefreshToken: encryptSecret('old-refresh', 'x-refresh-token'),
-      updatedAt: new Date('2026-07-25T12:00:00Z'),
-    });
+  test('consumes the winning token when another caller claims refresh first', async () => {
+    const winningAccessToken = encryptSecret('winning-access', 'x-access-token');
+    mockFindUnique
+      .mockResolvedValueOnce({
+        id: 'account-1',
+        status: 'connected',
+        expiresAt: new Date(Date.now() - 1),
+        encryptedAccessToken: encryptSecret('old-access', 'x-access-token'),
+        encryptedRefreshToken: encryptSecret('old-refresh', 'x-refresh-token'),
+        updatedAt: new Date('2026-07-25T12:00:00Z'),
+      })
+      .mockResolvedValueOnce({
+        id: 'account-1',
+        status: 'connected',
+        expiresAt: new Date(Date.now() + 60_000),
+        encryptedAccessToken: winningAccessToken,
+      });
     mockUpdateMany.mockResolvedValueOnce({ count: 0 });
 
-    await expect(repository.getValidXAccessToken('user-1')).rejects.toThrow(
-      'X account changed before authorization could be refreshed'
-    );
+    await expect(repository.getValidXAccessToken('user-1')).resolves.toBe('winning-access');
     expect(mockRefreshAccessToken).not.toHaveBeenCalled();
+  });
+
+  test('waits for an in-progress refresh and consumes its token', async () => {
+    mockFindUnique
+      .mockResolvedValueOnce({
+        id: 'account-1',
+        status: 'refreshing',
+        updatedAt: new Date(),
+      })
+      .mockResolvedValueOnce({
+        id: 'account-1',
+        status: 'connected',
+        expiresAt: new Date(Date.now() + 60_000),
+        encryptedAccessToken: encryptSecret('winning-access', 'x-access-token'),
+      });
+
+    await expect(repository.getValidXAccessToken('user-1')).resolves.toBe('winning-access');
+    expect(mockRefreshAccessToken).not.toHaveBeenCalled();
+  });
+
+  test('expires an abandoned refresh claim so the account can recover', async () => {
+    const staleUpdatedAt = new Date(Date.now() - 3 * 60 * 1000);
+    const refreshingAccount = {
+      id: 'account-1',
+      status: 'refreshing',
+      updatedAt: staleUpdatedAt,
+    };
+    mockFindUnique
+      .mockResolvedValueOnce(refreshingAccount)
+      .mockResolvedValueOnce(refreshingAccount);
+    mockUpdateMany.mockResolvedValueOnce({ count: 1 });
+
+    await expect(repository.getValidXAccessToken('user-1')).rejects.toThrow(
+      'X account refresh was interrupted; reconnect is required'
+    );
+    expect(mockUpdateMany).toHaveBeenCalledWith({
+      where: { id: 'account-1', status: 'refreshing', updatedAt: staleUpdatedAt },
+      data: { status: 'expired' },
+    });
   });
 
   test('revokes at the provider before erasing stored credentials', async () => {
@@ -398,6 +486,28 @@ describe('X platform account repository', () => {
       where: { id: 'account-1', status: 'connected', connectedAt },
       data: { status: 'revoking' },
     });
+  });
+
+  test('reclaims an abandoned revocation lifecycle', async () => {
+    const staleUpdatedAt = new Date(Date.now() - 3 * 60 * 1000);
+    const account = {
+      id: 'account-1',
+      status: 'revoking',
+      encryptedAccessToken: encryptSecret('access-token', 'x-access-token'),
+      encryptedRefreshToken: encryptSecret('refresh-token', 'x-refresh-token'),
+      connectedAt: new Date('2026-07-25T11:00:00Z'),
+      updatedAt: staleUpdatedAt,
+    };
+    mockFindUnique.mockResolvedValueOnce(account).mockResolvedValueOnce(account);
+    mockUpdateMany.mockResolvedValueOnce({ count: 1 }).mockResolvedValueOnce({ count: 1 });
+    mockRevokeXToken.mockResolvedValueOnce();
+
+    await expect(repository.disconnectXAccount('user-1')).resolves.toBe(true);
+    expect(mockUpdateMany).toHaveBeenNthCalledWith(1, {
+      where: { id: 'account-1', status: 'revoking', updatedAt: staleUpdatedAt },
+      data: { status: 'revoking' },
+    });
+    expect(mockRevokeXToken).toHaveBeenCalledWith('refresh-token');
   });
 
   test('removes expired local credentials without requiring provider revocation', async () => {

--- a/__tests__/lib/x-platform-repository.test.ts
+++ b/__tests__/lib/x-platform-repository.test.ts
@@ -370,10 +370,13 @@ describe('X platform account repository', () => {
     await expect(repository.getValidXAccessToken('user-1')).rejects.toThrow(
       'X OAuth token request failed with status 400'
     );
-    expect(mockUpdateMany).toHaveBeenNthCalledWith(2, {
-      where: expect.objectContaining({ id: 'account-1', status: 'refreshing' }),
-      data: { status: 'expired' },
-    });
+    expect(mockUpdateMany).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        where: expect.objectContaining({ id: 'account-1', status: 'refreshing' }),
+        data: { status: 'expired', encryptedRefreshToken: null },
+      })
+    );
   });
 
   test('requires revocation when refresh is rejected before the access token expires', async () => {
@@ -393,7 +396,9 @@ describe('X platform account repository', () => {
     );
     expect(mockUpdateMany).toHaveBeenNthCalledWith(
       2,
-      expect.objectContaining({ data: { status: 'revocation_required' } })
+      expect.objectContaining({
+        data: { status: 'revocation_required', encryptedRefreshToken: null },
+      })
     );
   });
 

--- a/__tests__/lib/x-platform-repository.test.ts
+++ b/__tests__/lib/x-platform-repository.test.ts
@@ -1,0 +1,180 @@
+import { afterEach, beforeAll, beforeEach, describe, expect, jest, test } from '@jest/globals';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { decryptSecret, encryptSecret } from '../../lib/platforms/x/crypto';
+
+const mockFindUnique = jest.fn<(args: unknown) => Promise<unknown>>();
+const mockUpsert = jest.fn<(args: unknown) => Promise<unknown>>();
+const mockUpdate = jest.fn<(args: unknown) => Promise<unknown>>();
+const mockRefreshAccessToken = jest.fn<(token: string) => Promise<unknown>>();
+const mockRevokeXToken = jest.fn<(token: string) => Promise<void>>();
+
+const originalEnvironment = { ...process.env };
+let repository: typeof import('../../lib/platforms/x/repository');
+
+describe('X platform account repository', () => {
+  beforeAll(async () => {
+    jest.doMock('@/lib/db/prisma', () => ({
+      __esModule: true,
+      default: {
+        platformAccount: {
+          findUnique: mockFindUnique,
+          upsert: mockUpsert,
+          update: mockUpdate,
+        },
+      },
+    }));
+    jest.doMock('../../lib/platforms/x/oauth', () => {
+      const actual = jest.requireActual('../../lib/platforms/x/oauth') as Record<string, unknown>;
+      return {
+        ...actual,
+        refreshAccessToken: mockRefreshAccessToken,
+        revokeXToken: mockRevokeXToken,
+      };
+    });
+    repository = await import('../../lib/platforms/x/repository');
+  });
+
+  beforeEach(() => {
+    process.env.PLATFORM_TOKEN_ENCRYPTION_KEY = Buffer.alloc(32, 9).toString('base64');
+    mockFindUnique.mockReset();
+    mockUpsert.mockReset();
+    mockUpdate.mockReset();
+    mockRefreshAccessToken.mockReset();
+    mockRevokeXToken.mockReset();
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnvironment };
+  });
+
+  test('encrypts access and refresh tokens before persistence', async () => {
+    mockUpsert.mockResolvedValueOnce({ id: 'account-1' });
+
+    await repository.saveXAccount(
+      'user-1',
+      { id: 'x-1', username: 'omnipost' },
+      {
+        token_type: 'bearer',
+        expires_in: 7200,
+        access_token: 'plain-access-token',
+        refresh_token: 'plain-refresh-token',
+        scope: 'tweet.read tweet.write users.read offline.access',
+      }
+    );
+
+    const call = mockUpsert.mock.calls[0][0] as {
+      create: { encryptedAccessToken: string; encryptedRefreshToken: string };
+    };
+    expect(call.create.encryptedAccessToken).not.toContain('plain-access-token');
+    expect(call.create.encryptedRefreshToken).not.toContain('plain-refresh-token');
+    expect(decryptSecret(call.create.encryptedAccessToken, 'x-access-token')).toBe(
+      'plain-access-token'
+    );
+    expect(decryptSecret(call.create.encryptedRefreshToken, 'x-refresh-token')).toBe(
+      'plain-refresh-token'
+    );
+  });
+
+  test('uses a forward-only tenant-owned platform account migration', () => {
+    const migration = readFileSync(
+      path.join(
+        process.cwd(),
+        'prisma',
+        'migrations',
+        '20260725173500_platform_account_oauth',
+        'migration.sql'
+      ),
+      'utf8'
+    );
+
+    expect(migration).toContain('CREATE TABLE "PlatformAccount"');
+    expect(migration).toContain('PlatformAccount_userId_platform_key');
+    expect(migration).toContain('REFERENCES "User"("id")');
+    expect(migration).not.toContain('DROP TABLE');
+  });
+
+  test('reports expired accounts without returning token material', async () => {
+    mockFindUnique.mockResolvedValueOnce({
+      providerUsername: 'omnipost',
+      scopes: 'tweet.read tweet.write',
+      expiresAt: new Date(Date.now() - 60_000),
+      status: 'connected',
+      connectedAt: new Date('2026-07-25T12:00:00Z'),
+    });
+
+    await expect(repository.getXConnectionStatus('user-1')).resolves.toEqual({
+      platform: 'twitter',
+      connected: false,
+      status: 'expired',
+      username: 'omnipost',
+      scopes: ['tweet.read', 'tweet.write'],
+      expiresAt: expect.any(String),
+      connectedAt: '2026-07-25T12:00:00.000Z',
+    });
+  });
+
+  test('refreshes an expiring token and persists rotated credentials', async () => {
+    mockFindUnique.mockResolvedValueOnce({
+      id: 'account-1',
+      status: 'connected',
+      expiresAt: new Date(Date.now() - 1),
+      encryptedAccessToken: encryptSecret('old-access', 'x-access-token'),
+      encryptedRefreshToken: encryptSecret('old-refresh', 'x-refresh-token'),
+    });
+    mockRefreshAccessToken.mockResolvedValueOnce({
+      token_type: 'bearer',
+      expires_in: 7200,
+      access_token: 'new-access',
+      refresh_token: 'new-refresh',
+      scope: 'tweet.read tweet.write users.read offline.access',
+    });
+    mockUpdate.mockResolvedValueOnce({ id: 'account-1' });
+
+    await expect(repository.getValidXAccessToken('user-1')).resolves.toBe('new-access');
+    expect(mockRefreshAccessToken).toHaveBeenCalledWith('old-refresh');
+
+    const update = mockUpdate.mock.calls[0][0] as {
+      data: { encryptedAccessToken: string; encryptedRefreshToken: string; status: string };
+    };
+    expect(decryptSecret(update.data.encryptedAccessToken, 'x-access-token')).toBe('new-access');
+    expect(decryptSecret(update.data.encryptedRefreshToken, 'x-refresh-token')).toBe('new-refresh');
+    expect(update.data.status).toBe('connected');
+  });
+
+  test('revokes at the provider before erasing stored credentials', async () => {
+    mockFindUnique.mockResolvedValueOnce({
+      id: 'account-1',
+      status: 'connected',
+      encryptedAccessToken: encryptSecret('access-token', 'x-access-token'),
+      encryptedRefreshToken: encryptSecret('refresh-token', 'x-refresh-token'),
+    });
+    mockRevokeXToken.mockResolvedValueOnce();
+    mockUpdate.mockResolvedValueOnce({ id: 'account-1' });
+
+    await expect(repository.disconnectXAccount('user-1')).resolves.toBe(true);
+    expect(mockRevokeXToken).toHaveBeenCalledWith('refresh-token');
+    expect(mockUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          encryptedAccessToken: '',
+          encryptedRefreshToken: null,
+          status: 'revoked',
+        }),
+      })
+    );
+  });
+
+  test('keeps credentials when provider revocation fails', async () => {
+    mockFindUnique.mockResolvedValueOnce({
+      id: 'account-1',
+      status: 'connected',
+      encryptedAccessToken: encryptSecret('access-token', 'x-access-token'),
+      encryptedRefreshToken: null,
+    });
+    mockRevokeXToken.mockRejectedValueOnce(new Error('provider unavailable'));
+
+    await expect(repository.disconnectXAccount('user-1')).rejects.toThrow('provider unavailable');
+    expect(mockUpdate).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/lib/x-platform-repository.test.ts
+++ b/__tests__/lib/x-platform-repository.test.ts
@@ -664,27 +664,33 @@ describe('X platform account repository', () => {
     );
   });
 
-  test('revokes a still-live access token before clearing an expired account', async () => {
+  test('removes definitively expired local credentials without provider revocation', async () => {
     const encryptedAccessToken = encryptSecret('expired-access', 'x-access-token');
-    const account = {
+    mockFindUnique.mockResolvedValueOnce({
       id: 'account-1',
       status: 'expired',
       encryptedAccessToken,
       encryptedRefreshToken: null,
-      connectedAt: new Date('2026-07-25T11:00:00Z'),
       updatedAt: new Date('2026-07-25T12:00:00Z'),
-    };
-    mockFindUnique
-      .mockResolvedValueOnce(account)
-      .mockResolvedValueOnce({ ...account, status: 'revoking' });
-    mockUpdateMany.mockResolvedValueOnce({ count: 1 }).mockResolvedValueOnce({ count: 1 });
-    mockRevokeXToken.mockResolvedValueOnce();
+    });
+    mockUpdateMany.mockResolvedValueOnce({ count: 1 });
 
     await expect(repository.disconnectXAccount('user-1')).resolves.toBe(true);
-    expect(mockRevokeXToken).toHaveBeenCalledWith('expired-access');
-    expect(mockUpdateMany).toHaveBeenNthCalledWith(1, {
-      where: { id: 'account-1', status: 'expired', updatedAt: account.updatedAt },
-      data: { status: 'revoking' },
+    expect(mockRevokeXToken).not.toHaveBeenCalled();
+    expect(mockUpdateMany).toHaveBeenCalledWith({
+      where: {
+        id: 'account-1',
+        status: 'expired',
+        encryptedAccessToken,
+        encryptedRefreshToken: null,
+        updatedAt: new Date('2026-07-25T12:00:00Z'),
+      },
+      data: {
+        encryptedAccessToken: '',
+        encryptedRefreshToken: null,
+        status: 'revoked',
+        revokedAt: expect.any(Date),
+      },
     });
   });
 });

--- a/__tests__/lib/x-platform-repository.test.ts
+++ b/__tests__/lib/x-platform-repository.test.ts
@@ -274,6 +274,28 @@ describe('X platform account repository', () => {
     });
   });
 
+  test('requires provider revocation while an unrefreshable access token is still live', async () => {
+    const expiresAt = new Date(Date.now() + 60_000);
+    const encryptedAccessToken = encryptSecret('live-access', 'x-access-token');
+    const updatedAt = new Date('2026-07-25T12:00:00Z');
+    mockFindUnique.mockResolvedValueOnce({
+      id: 'account-1',
+      status: 'connected',
+      expiresAt,
+      encryptedAccessToken,
+      encryptedRefreshToken: null,
+      updatedAt,
+    });
+    mockUpdateMany.mockResolvedValueOnce({ count: 1 });
+
+    await expect(repository.getValidXAccessToken('user-1')).rejects.toThrow(
+      'X account authorization has expired; reconnect is required'
+    );
+    expect(mockUpdateMany).toHaveBeenCalledWith(
+      expect.objectContaining({ data: { status: 'revocation_required' } })
+    );
+  });
+
   test('refreshes an expiring token and persists rotated credentials', async () => {
     mockFindUnique.mockResolvedValueOnce({
       id: 'account-1',
@@ -602,6 +624,25 @@ describe('X platform account repository', () => {
     });
   });
 
+  test('revokes a still-live unrefreshable access token before removal', async () => {
+    const account = {
+      id: 'account-1',
+      status: 'revocation_required',
+      encryptedAccessToken: encryptSecret('live-access', 'x-access-token'),
+      encryptedRefreshToken: null,
+      connectedAt: new Date('2026-07-25T11:00:00Z'),
+      updatedAt: new Date(),
+    };
+    mockFindUnique
+      .mockResolvedValueOnce(account)
+      .mockResolvedValueOnce({ ...account, status: 'revoking' });
+    mockUpdateMany.mockResolvedValueOnce({ count: 1 }).mockResolvedValueOnce({ count: 1 });
+    mockRevokeXToken.mockResolvedValueOnce();
+
+    await expect(repository.disconnectXAccount('user-1')).resolves.toBe(true);
+    expect(mockRevokeXToken).toHaveBeenCalledWith('live-access');
+  });
+
   test('keeps uncertain credentials recoverable when provider revocation fails', async () => {
     const account = {
       id: 'account-1',
@@ -623,32 +664,27 @@ describe('X platform account repository', () => {
     );
   });
 
-  test('removes expired local credentials without requiring provider revocation', async () => {
+  test('revokes a still-live access token before clearing an expired account', async () => {
     const encryptedAccessToken = encryptSecret('expired-access', 'x-access-token');
-    mockFindUnique.mockResolvedValueOnce({
+    const account = {
       id: 'account-1',
       status: 'expired',
       encryptedAccessToken,
       encryptedRefreshToken: null,
+      connectedAt: new Date('2026-07-25T11:00:00Z'),
       updatedAt: new Date('2026-07-25T12:00:00Z'),
-    });
-    mockUpdateMany.mockResolvedValueOnce({ count: 1 });
+    };
+    mockFindUnique
+      .mockResolvedValueOnce(account)
+      .mockResolvedValueOnce({ ...account, status: 'revoking' });
+    mockUpdateMany.mockResolvedValueOnce({ count: 1 }).mockResolvedValueOnce({ count: 1 });
+    mockRevokeXToken.mockResolvedValueOnce();
 
     await expect(repository.disconnectXAccount('user-1')).resolves.toBe(true);
-    expect(mockRevokeXToken).not.toHaveBeenCalled();
-    expect(mockUpdateMany).toHaveBeenCalledWith({
-      where: {
-        id: 'account-1',
-        status: 'expired',
-        encryptedAccessToken,
-        encryptedRefreshToken: null,
-        updatedAt: new Date('2026-07-25T12:00:00Z'),
-      },
-      data: expect.objectContaining({
-        encryptedAccessToken: '',
-        encryptedRefreshToken: null,
-        status: 'revoked',
-      }),
+    expect(mockRevokeXToken).toHaveBeenCalledWith('expired-access');
+    expect(mockUpdateMany).toHaveBeenNthCalledWith(1, {
+      where: { id: 'account-1', status: 'expired', updatedAt: account.updatedAt },
+      data: { status: 'revoking' },
     });
   });
 });

--- a/__tests__/lib/x-platform-repository.test.ts
+++ b/__tests__/lib/x-platform-repository.test.ts
@@ -7,6 +7,7 @@ import { XOAuthTokenRequestError } from '../../lib/platforms/x/oauth';
 const mockFindUnique = jest.fn<(args: unknown) => Promise<unknown>>();
 const mockUpsert = jest.fn<(args: unknown) => Promise<unknown>>();
 const mockUpdate = jest.fn<(args: unknown) => Promise<unknown>>();
+const mockUpdateMany = jest.fn<(args: unknown) => Promise<{ count: number }>>();
 const mockRefreshAccessToken = jest.fn<(token: string) => Promise<unknown>>();
 const mockRevokeXToken = jest.fn<(token: string) => Promise<void>>();
 
@@ -22,6 +23,7 @@ describe('X platform account repository', () => {
           findUnique: mockFindUnique,
           upsert: mockUpsert,
           update: mockUpdate,
+          updateMany: mockUpdateMany,
         },
       },
     }));
@@ -41,6 +43,7 @@ describe('X platform account repository', () => {
     mockFindUnique.mockReset();
     mockUpsert.mockReset();
     mockUpdate.mockReset();
+    mockUpdateMany.mockReset();
     mockRefreshAccessToken.mockReset();
     mockRevokeXToken.mockReset();
   });
@@ -141,6 +144,7 @@ describe('X platform account repository', () => {
       expiresAt: new Date(Date.now() - 1),
       encryptedAccessToken: encryptSecret('old-access', 'x-access-token'),
       encryptedRefreshToken: encryptSecret('old-refresh', 'x-refresh-token'),
+      updatedAt: new Date('2026-07-25T12:00:00Z'),
     });
     mockRefreshAccessToken.mockResolvedValueOnce({
       token_type: 'bearer',
@@ -149,12 +153,12 @@ describe('X platform account repository', () => {
       refresh_token: 'new-refresh',
       scope: 'tweet.read tweet.write users.read offline.access',
     });
-    mockUpdate.mockResolvedValueOnce({ id: 'account-1' });
+    mockUpdateMany.mockResolvedValueOnce({ count: 1 });
 
     await expect(repository.getValidXAccessToken('user-1')).resolves.toBe('new-access');
     expect(mockRefreshAccessToken).toHaveBeenCalledWith('old-refresh');
 
-    const update = mockUpdate.mock.calls[0][0] as {
+    const update = mockUpdateMany.mock.calls[0][0] as {
       data: { encryptedAccessToken: string; encryptedRefreshToken: string; status: string };
     };
     expect(decryptSecret(update.data.encryptedAccessToken, 'x-access-token')).toBe('new-access');
@@ -169,6 +173,7 @@ describe('X platform account repository', () => {
       expiresAt: new Date(Date.now() - 1),
       encryptedAccessToken: encryptSecret('old-access', 'x-access-token'),
       encryptedRefreshToken: encryptSecret('old-refresh', 'x-refresh-token'),
+      updatedAt: new Date('2026-07-25T12:00:00Z'),
     });
     mockRefreshAccessToken.mockRejectedValueOnce(
       new XOAuthTokenRequestError(429, 'temporarily_unavailable')
@@ -187,17 +192,50 @@ describe('X platform account repository', () => {
       expiresAt: new Date(Date.now() - 1),
       encryptedAccessToken: encryptSecret('old-access', 'x-access-token'),
       encryptedRefreshToken: encryptSecret('old-refresh', 'x-refresh-token'),
+      updatedAt: new Date('2026-07-25T12:00:00Z'),
     });
     mockRefreshAccessToken.mockRejectedValueOnce(new XOAuthTokenRequestError(400, 'invalid_grant'));
-    mockUpdate.mockResolvedValueOnce({ id: 'account-1' });
+    mockUpdateMany.mockResolvedValueOnce({ count: 1 });
 
     await expect(repository.getValidXAccessToken('user-1')).rejects.toThrow(
       'X OAuth token request failed with status 400'
     );
-    expect(mockUpdate).toHaveBeenCalledWith({
-      where: { id: 'account-1' },
+    expect(mockUpdateMany).toHaveBeenCalledWith({
+      where: expect.objectContaining({ id: 'account-1', status: 'connected' }),
       data: { status: 'expired' },
     });
+  });
+
+  test('does not overwrite a concurrent disconnect or reconnect after refresh', async () => {
+    mockFindUnique.mockResolvedValueOnce({
+      id: 'account-1',
+      status: 'connected',
+      expiresAt: new Date(Date.now() - 1),
+      encryptedAccessToken: encryptSecret('old-access', 'x-access-token'),
+      encryptedRefreshToken: encryptSecret('old-refresh', 'x-refresh-token'),
+      updatedAt: new Date('2026-07-25T12:00:00Z'),
+    });
+    mockRefreshAccessToken.mockResolvedValueOnce({
+      token_type: 'bearer',
+      expires_in: 7200,
+      access_token: 'stale-refreshed-access',
+      refresh_token: 'stale-refreshed-refresh',
+      scope: 'tweet.read tweet.write users.read offline.access',
+    });
+    mockUpdateMany.mockResolvedValueOnce({ count: 0 });
+
+    await expect(repository.getValidXAccessToken('user-1')).rejects.toThrow(
+      'X account changed while authorization was refreshing'
+    );
+    expect(mockUpdateMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          id: 'account-1',
+          status: 'connected',
+          updatedAt: new Date('2026-07-25T12:00:00Z'),
+        }),
+      })
+    );
   });
 
   test('revokes at the provider before erasing stored credentials', async () => {

--- a/__tests__/lib/x-platform-repository.test.ts
+++ b/__tests__/lib/x-platform-repository.test.ts
@@ -109,7 +109,9 @@ describe('X platform account repository', () => {
     expect(mockRevokeXToken).toHaveBeenCalledWith('old-refresh');
     expect(mockUpdateMany).toHaveBeenNthCalledWith(
       1,
-      expect.objectContaining({ data: { status: 'reconnecting' } })
+      expect.objectContaining({
+        data: expect.objectContaining({ status: 'reconnecting' }),
+      })
     );
     const replacement = mockUpdateMany.mock.calls[1][0] as {
       data: { encryptedAccessToken: string; encryptedRefreshToken: string; status: string };
@@ -149,6 +151,45 @@ describe('X platform account repository', () => {
     );
 
     expect(mockRevokeXToken).toHaveBeenCalledWith('uncertain-refresh');
+  });
+
+  test('reserves the provider identity before revoking a displaced grant', async () => {
+    const existing = {
+      id: 'account-1',
+      status: 'connected',
+      providerAccountId: 'old-x-account',
+      providerUsername: 'old-user',
+      encryptedAccessToken: encryptSecret('old-access', 'x-access-token'),
+      encryptedRefreshToken: encryptSecret('old-refresh', 'x-refresh-token'),
+      connectedAt: new Date('2026-07-25T11:00:00Z'),
+      updatedAt: new Date('2026-07-25T12:00:00Z'),
+    };
+    mockFindUnique.mockResolvedValueOnce(existing);
+    mockUpdateMany.mockRejectedValueOnce(new Error('provider identity is already connected'));
+
+    await expect(
+      repository.saveXAccount(
+        'user-1',
+        { id: 'conflicting-x-account', username: 'conflicting-user' },
+        {
+          token_type: 'bearer',
+          expires_in: 7200,
+          access_token: 'new-access',
+          refresh_token: 'new-refresh',
+          scope: 'tweet.read tweet.write users.read offline.access',
+        }
+      )
+    ).rejects.toThrow('provider identity is already connected');
+
+    expect(mockRevokeXToken).not.toHaveBeenCalled();
+    expect(mockUpdateMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          status: 'reconnecting',
+          providerAccountId: 'conflicting-x-account',
+        }),
+      })
+    );
   });
 
   test('uses a forward-only tenant-owned platform account migration', () => {

--- a/__tests__/lib/x-platform-repository.test.ts
+++ b/__tests__/lib/x-platform-repository.test.ts
@@ -123,6 +123,34 @@ describe('X platform account repository', () => {
     expect(replacement.data.status).toBe('connected');
   });
 
+  test('reconciles a displaced grant from a recovered stale claim before reconnect', async () => {
+    const existing = {
+      id: 'account-1',
+      status: 'recovery_required',
+      encryptedAccessToken: encryptSecret('uncertain-access', 'x-access-token'),
+      encryptedRefreshToken: encryptSecret('uncertain-refresh', 'x-refresh-token'),
+      connectedAt: new Date('2026-07-25T11:00:00Z'),
+      updatedAt: new Date(),
+    };
+    mockFindUnique.mockResolvedValueOnce(existing);
+    mockUpdateMany.mockResolvedValueOnce({ count: 1 }).mockResolvedValueOnce({ count: 1 });
+    mockRevokeXToken.mockResolvedValueOnce();
+
+    await repository.saveXAccount(
+      'user-1',
+      { id: 'x-1', username: 'omnipost' },
+      {
+        token_type: 'bearer',
+        expires_in: 7200,
+        access_token: 'new-access',
+        refresh_token: 'new-refresh',
+        scope: 'tweet.read tweet.write users.read offline.access',
+      }
+    );
+
+    expect(mockRevokeXToken).toHaveBeenCalledWith('uncertain-refresh');
+  });
+
   test('uses a forward-only tenant-owned platform account migration', () => {
     const migration = readFileSync(
       path.join(
@@ -373,11 +401,11 @@ describe('X platform account repository', () => {
     mockUpdateMany.mockResolvedValueOnce({ count: 1 });
 
     await expect(repository.getValidXAccessToken('user-1')).rejects.toThrow(
-      'X account refresh was interrupted; reconnect is required'
+      'X account refresh was interrupted; authorization recovery is required'
     );
     expect(mockUpdateMany).toHaveBeenCalledWith({
       where: { id: 'account-1', status: 'refreshing', updatedAt: staleUpdatedAt },
-      data: { status: 'expired' },
+      data: { status: 'recovery_required' },
     });
   });
 
@@ -508,6 +536,29 @@ describe('X platform account repository', () => {
       data: { status: 'revoking' },
     });
     expect(mockRevokeXToken).toHaveBeenCalledWith('refresh-token');
+  });
+
+  test('revokes uncertain credentials before clearing a recovery-required account', async () => {
+    const account = {
+      id: 'account-1',
+      status: 'recovery_required',
+      encryptedAccessToken: encryptSecret('access-token', 'x-access-token'),
+      encryptedRefreshToken: encryptSecret('refresh-token', 'x-refresh-token'),
+      connectedAt: new Date('2026-07-25T11:00:00Z'),
+      updatedAt: new Date(),
+    };
+    mockFindUnique
+      .mockResolvedValueOnce(account)
+      .mockResolvedValueOnce({ ...account, status: 'revoking' });
+    mockUpdateMany.mockResolvedValueOnce({ count: 1 }).mockResolvedValueOnce({ count: 1 });
+    mockRevokeXToken.mockResolvedValueOnce();
+
+    await expect(repository.disconnectXAccount('user-1')).resolves.toBe(true);
+    expect(mockRevokeXToken).toHaveBeenCalledWith('refresh-token');
+    expect(mockUpdateMany).toHaveBeenNthCalledWith(1, {
+      where: { id: 'account-1', status: 'recovery_required', updatedAt: account.updatedAt },
+      data: { status: 'revoking' },
+    });
   });
 
   test('removes expired local credentials without requiring provider revocation', async () => {

--- a/__tests__/lib/x-platform-repository.test.ts
+++ b/__tests__/lib/x-platform-repository.test.ts
@@ -137,6 +137,31 @@ describe('X platform account repository', () => {
     );
   });
 
+  test('does not expire a newly reconnected account from a stale no-refresh read', async () => {
+    mockFindUnique.mockResolvedValueOnce({
+      id: 'account-1',
+      status: 'connected',
+      expiresAt: new Date(Date.now() - 1),
+      encryptedAccessToken: encryptSecret('old-access', 'x-access-token'),
+      encryptedRefreshToken: null,
+      updatedAt: new Date('2026-07-25T12:00:00Z'),
+    });
+    mockUpdateMany.mockResolvedValueOnce({ count: 0 });
+
+    await expect(repository.getValidXAccessToken('user-1')).rejects.toThrow(
+      'X account changed while authorization expiry was recorded'
+    );
+    expect(mockUpdateMany).toHaveBeenCalledWith({
+      where: expect.objectContaining({
+        id: 'account-1',
+        status: 'connected',
+        encryptedRefreshToken: null,
+        updatedAt: new Date('2026-07-25T12:00:00Z'),
+      }),
+      data: { status: 'expired' },
+    });
+  });
+
   test('refreshes an expiring token and persists rotated credentials', async () => {
     mockFindUnique.mockResolvedValueOnce({
       id: 'account-1',
@@ -239,72 +264,109 @@ describe('X platform account repository', () => {
   });
 
   test('revokes at the provider before erasing stored credentials', async () => {
-    mockFindUnique.mockResolvedValueOnce({
+    const account = {
       id: 'account-1',
       status: 'connected',
       encryptedAccessToken: encryptSecret('access-token', 'x-access-token'),
       encryptedRefreshToken: encryptSecret('refresh-token', 'x-refresh-token'),
+      connectedAt: new Date('2026-07-25T11:00:00Z'),
       updatedAt: new Date('2026-07-25T12:00:00Z'),
-    });
+    };
+    mockFindUnique
+      .mockResolvedValueOnce(account)
+      .mockResolvedValueOnce({ ...account, status: 'revoking' });
     mockRevokeXToken.mockResolvedValueOnce();
-    mockUpdateMany.mockResolvedValueOnce({ count: 1 });
+    mockUpdateMany.mockResolvedValueOnce({ count: 1 }).mockResolvedValueOnce({ count: 1 });
 
     await expect(repository.disconnectXAccount('user-1')).resolves.toBe(true);
     expect(mockRevokeXToken).toHaveBeenCalledWith('refresh-token');
-    expect(mockUpdateMany).toHaveBeenCalledWith(
+    expect(mockUpdateMany).toHaveBeenNthCalledWith(1, {
+      where: {
+        id: 'account-1',
+        status: 'connected',
+        connectedAt: new Date('2026-07-25T11:00:00Z'),
+      },
+      data: { status: 'revoking' },
+    });
+    expect(mockUpdateMany).toHaveBeenNthCalledWith(
+      2,
       expect.objectContaining({
-        where: expect.objectContaining({
-          id: 'account-1',
-          status: 'connected',
-          updatedAt: new Date('2026-07-25T12:00:00Z'),
-        }),
-        data: expect.objectContaining({
-          encryptedAccessToken: '',
-          encryptedRefreshToken: null,
-          status: 'revoked',
-        }),
+        where: expect.objectContaining({ status: 'revoking' }),
+        data: expect.objectContaining({ status: 'revoked' }),
       })
     );
   });
 
   test('keeps credentials when provider revocation fails', async () => {
-    mockFindUnique.mockResolvedValueOnce({
+    const account = {
       id: 'account-1',
       status: 'connected',
       encryptedAccessToken: encryptSecret('access-token', 'x-access-token'),
       encryptedRefreshToken: null,
-    });
+      connectedAt: new Date('2026-07-25T11:00:00Z'),
+    };
+    mockFindUnique
+      .mockResolvedValueOnce(account)
+      .mockResolvedValueOnce({ ...account, status: 'revoking' });
+    mockUpdateMany.mockResolvedValueOnce({ count: 1 }).mockResolvedValueOnce({ count: 1 });
     mockRevokeXToken.mockRejectedValueOnce(new Error('provider unavailable'));
 
     await expect(repository.disconnectXAccount('user-1')).rejects.toThrow('provider unavailable');
     expect(mockUpdate).not.toHaveBeenCalled();
-    expect(mockUpdateMany).not.toHaveBeenCalled();
+    expect(mockUpdateMany).toHaveBeenLastCalledWith(
+      expect.objectContaining({ data: { status: 'connected' } })
+    );
   });
 
   test('does not erase credentials from a concurrent reconnect after provider revocation', async () => {
     const encryptedAccessToken = encryptSecret('old-access', 'x-access-token');
     const encryptedRefreshToken = encryptSecret('old-refresh', 'x-refresh-token');
-    mockFindUnique.mockResolvedValueOnce({
+    const account = {
       id: 'account-1',
       status: 'connected',
       encryptedAccessToken,
       encryptedRefreshToken,
+      connectedAt: new Date('2026-07-25T11:00:00Z'),
       updatedAt: new Date('2026-07-25T12:00:00Z'),
-    });
+    };
+    mockFindUnique
+      .mockResolvedValueOnce(account)
+      .mockResolvedValueOnce({ ...account, status: 'revoking' });
     mockRevokeXToken.mockResolvedValueOnce();
-    mockUpdateMany.mockResolvedValueOnce({ count: 0 });
+    mockUpdateMany.mockResolvedValueOnce({ count: 1 }).mockResolvedValueOnce({ count: 0 });
 
     await expect(repository.disconnectXAccount('user-1')).resolves.toBe(false);
-    expect(mockUpdateMany).toHaveBeenCalledWith(
+    expect(mockUpdateMany).toHaveBeenLastCalledWith(
       expect.objectContaining({
-        where: {
-          id: 'account-1',
-          status: 'connected',
-          encryptedAccessToken,
-          encryptedRefreshToken,
-          updatedAt: new Date('2026-07-25T12:00:00Z'),
-        },
+        where: expect.objectContaining({ status: 'revoking', connectedAt: account.connectedAt }),
       })
     );
+  });
+
+  test('disconnect revokes credentials rotated by an in-flight refresh before the claim', async () => {
+    const connectedAt = new Date('2026-07-25T11:00:00Z');
+    const initialAccount = {
+      id: 'account-1',
+      status: 'connected',
+      encryptedAccessToken: encryptSecret('old-access', 'x-access-token'),
+      encryptedRefreshToken: encryptSecret('old-refresh', 'x-refresh-token'),
+      connectedAt,
+    };
+    const claimedAccount = {
+      ...initialAccount,
+      status: 'revoking',
+      encryptedAccessToken: encryptSecret('rotated-access', 'x-access-token'),
+      encryptedRefreshToken: encryptSecret('rotated-refresh', 'x-refresh-token'),
+    };
+    mockFindUnique.mockResolvedValueOnce(initialAccount).mockResolvedValueOnce(claimedAccount);
+    mockUpdateMany.mockResolvedValueOnce({ count: 1 }).mockResolvedValueOnce({ count: 1 });
+    mockRevokeXToken.mockResolvedValueOnce();
+
+    await expect(repository.disconnectXAccount('user-1')).resolves.toBe(true);
+    expect(mockRevokeXToken).toHaveBeenCalledWith('rotated-refresh');
+    expect(mockUpdateMany).toHaveBeenNthCalledWith(1, {
+      where: { id: 'account-1', status: 'connected', connectedAt },
+      data: { status: 'revoking' },
+    });
   });
 });

--- a/__tests__/proxy.test.ts
+++ b/__tests__/proxy.test.ts
@@ -344,6 +344,17 @@ describe('proxy (root middleware on /api/:path*)', () => {
       expect(response.status).toBe(200);
       expect(response._requestHeaders).toBeUndefined();
     });
+
+    test('allows the exact X OAuth callback to validate its sealed flow cookie', () => {
+      const proxy = loadProxy();
+      const request = createMockNextRequest({
+        pathname: '/api/platforms/x/callback',
+      });
+      const response = proxy(request) as Record<string, unknown>;
+
+      expect(response.status).toBe(200);
+      expect(response._requestHeaders).toBeUndefined();
+    });
   });
 
   // ------------------------------------------------------------------

--- a/app/(dashboard)/settings/platforms/page.tsx
+++ b/app/(dashboard)/settings/platforms/page.tsx
@@ -117,9 +117,15 @@ export function PlatformSettingsPage() {
   const handleDisconnect = useCallback(async () => {
     setOperationError('');
     try {
-      await apiClient.delete<{ disconnected: boolean }>('/api/platforms/x');
+      const response = await apiClient.delete<{ disconnected: boolean }>('/api/platforms/x');
       setModal(null);
       await loadConnections();
+      if (!response.disconnected) {
+        setOperationError(
+          'The X connection changed before it could be disconnected. Review it and try again.'
+        );
+        return;
+      }
       track('platform_disconnected', { platformName: 'X', totalPlatforms: 0 });
     } catch {
       setOperationError('X could not be disconnected. Please try again.');

--- a/app/(dashboard)/settings/platforms/page.tsx
+++ b/app/(dashboard)/settings/platforms/page.tsx
@@ -72,7 +72,6 @@ export function PlatformSettingsPage() {
         '/api/platforms/connections'
       );
       setConnections(response.connections);
-      setOperationError('');
     } catch {
       setOperationError('Platform connection status could not be loaded.');
     } finally {

--- a/app/(dashboard)/settings/platforms/page.tsx
+++ b/app/(dashboard)/settings/platforms/page.tsx
@@ -231,13 +231,27 @@ export function PlatformSettingsPage() {
                     Disconnect
                   </button>
                 ) : (
-                  <button
-                    className={`${styles.connectButton} ${styles.connectButtonPrimary}`}
-                    onClick={() => void handleConnect(platform.slug)}
-                    disabled={isComingSoon || platform.slug !== 'twitter' || requiresConfiguration}
-                  >
-                    {isComingSoon ? 'Coming Soon' : requiresReconnect ? 'Reconnect' : 'Connect'}
-                  </button>
+                  <>
+                    <button
+                      className={`${styles.connectButton} ${styles.connectButtonPrimary}`}
+                      onClick={() => void handleConnect(platform.slug)}
+                      disabled={
+                        isComingSoon || platform.slug !== 'twitter' || requiresConfiguration
+                      }
+                    >
+                      {isComingSoon ? 'Coming Soon' : requiresReconnect ? 'Reconnect' : 'Connect'}
+                    </button>
+                    {requiresReconnect && (
+                      <button
+                        className={`${styles.connectButton} ${styles.connectButtonDanger}`}
+                        onClick={() =>
+                          setModal({ type: 'disconnect', platformSlug: platform.slug })
+                        }
+                      >
+                        Remove
+                      </button>
+                    )}
+                  </>
                 )}
               </div>
             </div>

--- a/app/(dashboard)/settings/platforms/page.tsx
+++ b/app/(dashboard)/settings/platforms/page.tsx
@@ -1,37 +1,39 @@
 /**
  * Platform Connections Settings Page
  *
- * Allows users to connect and disconnect social media platforms.
- * Currently uses an in-memory mock store; will be replaced with OAuth flows.
+ * X uses a server-owned OAuth lifecycle. Tokens never enter browser state.
  */
 
 'use client';
 
-import { useState, useCallback, useEffect } from 'react';
-import { useRouter } from 'next/navigation';
+import { useCallback, useEffect, useState } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
 import { useAuth } from '@/components/providers/AuthProvider';
 import { LoadingSpinner } from '@/components/ui/LoadingSpinner';
 import { platforms, platformConfigurations } from '@/lib/config/platforms';
+import { apiClient } from '@/lib/api-client';
 import { useAnalytics } from '@/hooks/useAnalytics';
 import styles from '@/styles/PlatformSettings.module.css';
 
-/** Shape of a stored platform connection (in-memory mock) */
 interface PlatformConnection {
-  apiKey: string;
-  handle: string;
-  connectedAt: string;
+  platform: 'twitter';
+  connected: boolean;
+  configured: boolean;
+  status: 'connected' | 'expired' | 'revoked';
+  username?: string;
+  scopes: string[];
+  expiresAt?: string;
+  connectedAt?: string;
 }
 
-/** Map of platform slug to connection data */
-type ConnectionStore = Record<string, PlatformConnection>;
+interface PlatformConnectionsResponse {
+  connections: {
+    twitter: PlatformConnection;
+  };
+}
 
-/** Which modal is open */
-type ModalState =
-  | { type: 'connect'; platformSlug: string }
-  | { type: 'disconnect'; platformSlug: string }
-  | null;
+type ModalState = { type: 'disconnect'; platformSlug: string } | null;
 
-/** Platform icon letter based on slug */
 function getPlatformIconLetter(slug: string): string {
   const map: Record<string, string> = {
     facebook: 'f',
@@ -42,7 +44,6 @@ function getPlatformIconLetter(slug: string): string {
   return map[slug] ?? slug.charAt(0).toUpperCase();
 }
 
-/** CSS class for platform icon color */
 function getIconColorClass(slug: string): string {
   const map: Record<string, string> = {
     facebook: styles.iconFacebook,
@@ -53,86 +54,82 @@ function getIconColorClass(slug: string): string {
   return map[slug] ?? '';
 }
 
-/** The four main platforms (excluding custom channel for this settings page) */
-const settingsPlatforms = platforms.filter(p => p.slug !== 'custom-channel');
+const settingsPlatforms = platforms.filter(platform => platform.slug !== 'custom-channel');
 
 export function PlatformSettingsPage() {
   const { isAuthenticated, isLoading } = useAuth();
   const router = useRouter();
-  const [connections, setConnections] = useState<ConnectionStore>({});
+  const searchParams = useSearchParams();
+  const [connections, setConnections] = useState<PlatformConnectionsResponse['connections']>();
+  const [connectionsLoading, setConnectionsLoading] = useState(true);
+  const [operationError, setOperationError] = useState('');
   const [modal, setModal] = useState<ModalState>(null);
-  const [apiKeyInput, setApiKeyInput] = useState('');
-  const [handleInput, setHandleInput] = useState('');
-  const { trackPlatformConnected, track } = useAnalytics();
+  const { track } = useAnalytics();
+
+  const loadConnections = useCallback(async () => {
+    try {
+      const response = await apiClient.get<PlatformConnectionsResponse>(
+        '/api/platforms/connections'
+      );
+      setConnections(response.connections);
+      setOperationError('');
+    } catch {
+      setOperationError('Platform connection status could not be loaded.');
+    } finally {
+      setConnectionsLoading(false);
+    }
+  }, []);
 
   useEffect(() => {
     if (!isAuthenticated && !isLoading) {
       router.push('/login');
+      return;
     }
-  }, [isAuthenticated, isLoading, router]);
+    if (isAuthenticated) void loadConnections();
+  }, [isAuthenticated, isLoading, loadConnections, router]);
 
-  const connectedCount = Object.keys(connections).length;
+  useEffect(() => {
+    const outcome = searchParams.get('xConnection');
+    if (outcome === 'success') {
+      track('platform_connected', { platformName: 'X' });
+    } else if (outcome === 'denied') {
+      setOperationError('X authorization was cancelled.');
+    } else if (outcome === 'invalid') {
+      setOperationError('The X authorization request expired or could not be verified.');
+    } else if (outcome === 'failed') {
+      setOperationError('X could not be connected. Please try again.');
+    }
+    if (outcome) router.replace('/settings/platforms');
+  }, [router, searchParams, track]);
 
-  const handleConnect = useCallback(
-    (platformSlug: string) => {
-      if (!apiKeyInput.trim()) return;
+  const handleConnect = useCallback(async (platformSlug: string) => {
+    if (platformSlug !== 'twitter') return;
+    setOperationError('');
+    try {
+      const response = await apiClient.post<{ authorizationUrl: string }>(
+        '/api/platforms/x/connect'
+      );
+      globalThis.location.assign(response.authorizationUrl);
+    } catch {
+      setOperationError('X authorization could not be started.');
+    }
+  }, []);
 
-      const handle = handleInput.trim() || `@${platformSlug}_user`;
-      setConnections(prev => ({
-        ...prev,
-        [platformSlug]: {
-          apiKey: apiKeyInput.trim(),
-          handle,
-          connectedAt: new Date().toISOString(),
-        },
-      }));
-
-      const platform = settingsPlatforms.find(p => p.slug === platformSlug);
-      trackPlatformConnected(platform?.name ?? platformSlug, connectedCount + 1);
-
+  const handleDisconnect = useCallback(async () => {
+    setOperationError('');
+    try {
+      await apiClient.delete<{ disconnected: boolean }>('/api/platforms/x');
       setModal(null);
-      setApiKeyInput('');
-      setHandleInput('');
-    },
-    [apiKeyInput, handleInput, connectedCount, trackPlatformConnected]
-  );
+      await loadConnections();
+      track('platform_disconnected', { platformName: 'X', totalPlatforms: 0 });
+    } catch {
+      setOperationError('X could not be disconnected. Please try again.');
+    }
+  }, [loadConnections, track]);
 
-  const handleDisconnect = useCallback(
-    (platformSlug: string) => {
-      setConnections(prev => {
-        const next = { ...prev };
-        delete next[platformSlug];
-        return next;
-      });
-
-      const platform = settingsPlatforms.find(p => p.slug === platformSlug);
-      track('platform_disconnected', {
-        platformName: platform?.name ?? platformSlug,
-        totalPlatforms: connectedCount - 1,
-      });
-
-      setModal(null);
-    },
-    [connectedCount, track]
-  );
-
-  const openConnectModal = (slug: string) => {
-    setApiKeyInput('');
-    setHandleInput('');
-    setModal({ type: 'connect', platformSlug: slug });
-  };
-
-  const openDisconnectModal = (slug: string) => {
-    setModal({ type: 'disconnect', platformSlug: slug });
-  };
-
-  const closeModal = () => {
-    setModal(null);
-    setApiKeyInput('');
-    setHandleInput('');
-  };
-
-  if (isLoading) return <LoadingSpinner size="lg" label="Loading..." />;
+  if (isLoading || (isAuthenticated && connectionsLoading)) {
+    return <LoadingSpinner size="lg" label="Loading..." />;
+  }
   if (!isAuthenticated) return null;
 
   return (
@@ -142,10 +139,15 @@ export function PlatformSettingsPage() {
         <p>Connect your social media accounts to publish content across platforms.</p>
       </div>
 
+      {operationError && <div className={styles.mockNotice}>{operationError}</div>}
+
       <div className={styles.platformGrid}>
         {settingsPlatforms.map(platform => {
-          const connection = connections[platform.slug];
-          const isConnected = Boolean(connection);
+          const connection = platform.slug === 'twitter' ? connections?.twitter : undefined;
+          const isConnected = Boolean(connection?.connected);
+          const requiresReconnect = connection?.status === 'expired';
+          const requiresConfiguration =
+            platform.slug === 'twitter' && connection?.configured === false;
           const config = platformConfigurations[platform.slug];
           const isComingSoon = platform.comingSoon;
 
@@ -187,21 +189,29 @@ export function PlatformSettingsPage() {
                           : styles.statusDotDisconnected
                     }`}
                   />
-                  {isComingSoon ? 'Coming Soon' : isConnected ? 'Connected' : 'Not Connected'}
+                  {isComingSoon
+                    ? 'Coming Soon'
+                    : requiresConfiguration
+                      ? 'Configuration Required'
+                      : requiresReconnect
+                        ? 'Reconnect Required'
+                        : isConnected
+                          ? 'Connected'
+                          : 'Not Connected'}
                 </span>
               </div>
 
-              {isConnected && connection && (
+              {connection?.username && (
                 <div className={styles.connectedInfo}>
-                  <strong>Handle:</strong> {connection.handle}
+                  <strong>Handle:</strong> @{connection.username}
                 </div>
               )}
 
               {config?.capabilities && (
                 <div className={styles.capabilities}>
-                  {config.capabilities.map(cap => (
-                    <span key={cap} className={styles.capabilityTag}>
-                      {cap}
+                  {config.capabilities.map(capability => (
+                    <span key={capability} className={styles.capabilityTag}>
+                      {capability}
                     </span>
                   ))}
                 </div>
@@ -211,17 +221,17 @@ export function PlatformSettingsPage() {
                 {isConnected ? (
                   <button
                     className={`${styles.connectButton} ${styles.connectButtonDanger}`}
-                    onClick={() => openDisconnectModal(platform.slug)}
+                    onClick={() => setModal({ type: 'disconnect', platformSlug: platform.slug })}
                   >
                     Disconnect
                   </button>
                 ) : (
                   <button
                     className={`${styles.connectButton} ${styles.connectButtonPrimary}`}
-                    onClick={() => openConnectModal(platform.slug)}
-                    disabled={isComingSoon}
+                    onClick={() => void handleConnect(platform.slug)}
+                    disabled={isComingSoon || platform.slug !== 'twitter' || requiresConfiguration}
                   >
-                    {isComingSoon ? 'Coming Soon' : 'Connect'}
+                    {isComingSoon ? 'Coming Soon' : requiresReconnect ? 'Reconnect' : 'Connect'}
                   </button>
                 )}
               </div>
@@ -230,86 +240,18 @@ export function PlatformSettingsPage() {
         })}
       </div>
 
-      {/* Connect Modal */}
-      {modal?.type === 'connect' && (
-        <div className={styles.modalOverlay} onClick={closeModal}>
-          <div className={styles.modal} onClick={e => e.stopPropagation()}>
-            <h2>
-              Connect{' '}
-              {settingsPlatforms.find(p => p.slug === modal.platformSlug)?.name ??
-                modal.platformSlug}
-            </h2>
-            <p>Enter your API credentials to connect this platform.</p>
-
-            <div className={styles.mockNotice}>
-              This is a simplified mock connection. OAuth integration will replace this in a future
-              release.
-            </div>
-
-            <div className={styles.inputGroup}>
-              <label htmlFor="api-key-input">
-                {settingsPlatforms.find(p => p.slug === modal.platformSlug)?.name ?? 'Platform'} API
-                Key
-              </label>
-              <input
-                id="api-key-input"
-                type="text"
-                value={apiKeyInput}
-                onChange={e => setApiKeyInput(e.target.value)}
-                placeholder="Enter your API key"
-                autoFocus
-              />
-            </div>
-
-            <div className={styles.inputGroup}>
-              <label htmlFor="handle-input">Username / Handle (optional)</label>
-              <input
-                id="handle-input"
-                type="text"
-                value={handleInput}
-                onChange={e => setHandleInput(e.target.value)}
-                placeholder="@yourhandle"
-              />
-            </div>
-
-            <div className={styles.modalActions}>
-              <button className={styles.modalButtonCancel} onClick={closeModal}>
-                Cancel
-              </button>
-              <button
-                className={styles.modalButtonSubmit}
-                onClick={() => handleConnect(modal.platformSlug)}
-                disabled={!apiKeyInput.trim()}
-              >
-                Connect
-              </button>
-            </div>
-          </div>
-        </div>
-      )}
-
-      {/* Disconnect Confirmation Modal */}
       {modal?.type === 'disconnect' && (
-        <div className={styles.modalOverlay} onClick={closeModal}>
-          <div className={styles.modal} onClick={e => e.stopPropagation()}>
-            <h2>
-              Disconnect{' '}
-              {settingsPlatforms.find(p => p.slug === modal.platformSlug)?.name ??
-                modal.platformSlug}
-              ?
-            </h2>
+        <div className={styles.modalOverlay} onClick={() => setModal(null)}>
+          <div className={styles.modal} onClick={event => event.stopPropagation()}>
+            <h2>Disconnect X?</h2>
             <p className={styles.confirmText}>
-              This will remove your connection. You can reconnect at any time.
+              OmniPost will revoke the authorization and remove its stored tokens.
             </p>
-
             <div className={styles.modalActions}>
-              <button className={styles.modalButtonCancel} onClick={closeModal}>
+              <button className={styles.modalButtonCancel} onClick={() => setModal(null)}>
                 Cancel
               </button>
-              <button
-                className={styles.modalButtonDanger}
-                onClick={() => handleDisconnect(modal.platformSlug)}
-              >
+              <button className={styles.modalButtonDanger} onClick={() => void handleDisconnect()}>
                 Disconnect
               </button>
             </div>

--- a/app/api/_utils/rateLimit.ts
+++ b/app/api/_utils/rateLimit.ts
@@ -391,7 +391,7 @@ const DEFAULT_WINDOW_MS = 15 * 60 * 1000;
  * Predefined rate limit configurations
  * Moved before checkRateLimitUpstash to be available for preset lookup
  */
-export const RateLimitPresets: Record<string, RateLimitConfig> = {
+export const RateLimitPresets = {
   /**
    * For authentication endpoints - prevent brute force
    * 5 requests per 15 minutes
@@ -452,14 +452,16 @@ export const RateLimitPresets: Record<string, RateLimitConfig> = {
     windowMs: 60 * 1000, // 1 minute
     message: 'Too many requests. Please try again in a minute.',
   },
-};
+} satisfies Record<string, RateLimitConfig>;
+
+type RateLimitPresetName = keyof typeof RateLimitPresets;
 
 /**
  * Check if request should be rate limited (Upstash version)
  */
 async function checkRateLimitUpstash(
   request: NextRequest,
-  presetName: string
+  presetName: RateLimitPresetName
 ): Promise<{ allowed: boolean; remaining: number; resetTime: number }> {
   // Lazy-initialize Upstash
   const limiters = await initUpstash();
@@ -496,7 +498,7 @@ export async function checkRateLimit(
   request: NextRequest,
   endpoint: string,
   config: RateLimitConfig,
-  presetName?: string
+  presetName?: RateLimitPresetName
 ): Promise<{ allowed: boolean; remaining: number; resetTime: number }> {
   // Use Upstash if configured and preset name provided
   if (isUpstashConfigured && presetName) {
@@ -523,7 +525,7 @@ export function checkRateLimitSync(
  */
 export function withRateLimit<
   T extends (request: NextRequest, ...args: unknown[]) => Promise<Response>,
->(handler: T, endpoint: string, config: RateLimitConfig, presetName?: string): T {
+>(handler: T, endpoint: string, config: RateLimitConfig, presetName?: RateLimitPresetName): T {
   // Resolve the effective config: use preset if provided, otherwise use passed config
   // This ensures headers and messages are consistent with the preset being enforced
   const effectiveConfig =

--- a/app/api/platforms/connections/route.ts
+++ b/app/api/platforms/connections/route.ts
@@ -1,0 +1,26 @@
+import { NextResponse } from 'next/server';
+import { getCurrentUserId, isAuthenticated } from '@/app/api/_utils/auth';
+import { Errors, withErrorHandling } from '@/app/api/_utils/errors';
+import { RateLimitPresets, withRateLimit } from '@/app/api/_utils/rateLimit';
+import { isPlatformTokenEncryptionConfigured } from '@/lib/platforms/x/crypto';
+import { isXOAuthClientConfigured } from '@/lib/platforms/x/oauth';
+import { getXConnectionStatus } from '@/lib/platforms/x/repository';
+
+export const GET = withRateLimit(
+  withErrorHandling(async () => {
+    if (!(await isAuthenticated())) return Errors.unauthorized();
+    const userId = await getCurrentUserId();
+    if (!userId) return Errors.unauthorized();
+
+    const x = {
+      ...(await getXConnectionStatus(userId)),
+      configured: isXOAuthClientConfigured() && isPlatformTokenEncryptionConfigured(),
+    };
+    return NextResponse.json(
+      { connections: { twitter: x } },
+      { headers: { 'Cache-Control': 'no-store, max-age=0' } }
+    );
+  }),
+  '/api/platforms/connections',
+  RateLimitPresets.GENERAL
+);

--- a/app/api/platforms/x/callback/route.ts
+++ b/app/api/platforms/x/callback/route.ts
@@ -1,0 +1,84 @@
+import { z } from 'zod';
+import { cookies } from 'next/headers';
+import { NextResponse } from 'next/server';
+import { withErrorHandling } from '@/app/api/_utils/errors';
+import { RateLimitPresets, withRateLimit } from '@/app/api/_utils/rateLimit';
+import { safeEqual } from '@/lib/platforms/x/crypto';
+import { openXOAuthFlow } from '@/lib/platforms/x/flow';
+import {
+  exchangeAuthorizationCode,
+  fetchXIdentity,
+  getXOAuthConfig,
+  X_OAUTH_FLOW_COOKIE,
+} from '@/lib/platforms/x/oauth';
+import { saveXAccount } from '@/lib/platforms/x/repository';
+
+const callbackSchema = z.object({
+  code: z.string().min(1),
+  state: z.string().min(32).max(500),
+});
+
+function settingsRedirect(outcome: 'success' | 'denied' | 'invalid' | 'failed') {
+  const publicOrigin = new URL(getXOAuthConfig().redirectUri).origin;
+  const url = new URL('/settings/platforms', publicOrigin);
+  url.searchParams.set('xConnection', outcome);
+  return NextResponse.redirect(url);
+}
+
+async function readFlowCookie() {
+  const cookie = (await cookies()).get(X_OAUTH_FLOW_COOKIE)?.value;
+  return cookie ? openXOAuthFlow(cookie) : null;
+}
+
+function clearFlowCookie(response: NextResponse): NextResponse {
+  response.cookies.set(X_OAUTH_FLOW_COOKIE, '', {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === 'production',
+    sameSite: 'lax',
+    maxAge: 0,
+    path: '/api/platforms/x/callback',
+  });
+  return response;
+}
+
+export const GET = withRateLimit(
+  withErrorHandling(async (request: Request) => {
+    const url = new URL(request.url);
+    const flow = await readFlowCookie();
+    const returnedState = url.searchParams.get('state');
+    const stateIsValid = Boolean(
+      flow &&
+      returnedState &&
+      returnedState.length >= 32 &&
+      returnedState.length <= 500 &&
+      safeEqual(flow.state, returnedState)
+    );
+
+    if (url.searchParams.has('error')) {
+      return clearFlowCookie(settingsRedirect(stateIsValid ? 'denied' : 'invalid'));
+    }
+
+    const parsed = callbackSchema.safeParse({
+      code: url.searchParams.get('code'),
+      state: returnedState,
+    });
+    if (!parsed.success || !flow || !stateIsValid) {
+      return clearFlowCookie(settingsRedirect('invalid'));
+    }
+
+    try {
+      const tokens = await exchangeAuthorizationCode(parsed.data.code, flow.verifier);
+      const identity = await fetchXIdentity(tokens.access_token);
+      await saveXAccount(flow.userId, identity, tokens);
+      return clearFlowCookie(settingsRedirect('success'));
+    } catch (error) {
+      console.error('[X OAuth] Callback failed', {
+        error: error instanceof Error ? error.message : 'Unknown error',
+      });
+      return clearFlowCookie(settingsRedirect('failed'));
+    }
+  }),
+  '/api/platforms/x/callback',
+  RateLimitPresets.OAUTH_CALLBACK,
+  'X_OAUTH_CALLBACK'
+);

--- a/app/api/platforms/x/callback/route.ts
+++ b/app/api/platforms/x/callback/route.ts
@@ -94,5 +94,5 @@ export const GET = withRateLimit(
   }),
   '/api/platforms/x/callback',
   RateLimitPresets.OAUTH_CALLBACK,
-  'X_OAUTH_CALLBACK'
+  'OAUTH_CALLBACK'
 );

--- a/app/api/platforms/x/callback/route.ts
+++ b/app/api/platforms/x/callback/route.ts
@@ -9,6 +9,8 @@ import {
   exchangeAuthorizationCode,
   fetchXIdentity,
   getXOAuthConfig,
+  revokeXToken,
+  type XTokenResponse,
   X_OAUTH_FLOW_COOKIE,
 } from '@/lib/platforms/x/oauth';
 import { saveXAccount } from '@/lib/platforms/x/repository';
@@ -66,12 +68,24 @@ export const GET = withRateLimit(
       return clearFlowCookie(settingsRedirect('invalid'));
     }
 
+    let issuedTokens: XTokenResponse | null = null;
     try {
-      const tokens = await exchangeAuthorizationCode(parsed.data.code, flow.verifier);
+      issuedTokens = await exchangeAuthorizationCode(parsed.data.code, flow.verifier);
+      const tokens = issuedTokens;
       const identity = await fetchXIdentity(tokens.access_token);
       await saveXAccount(flow.userId, identity, tokens);
+      issuedTokens = null;
       return clearFlowCookie(settingsRedirect('success'));
     } catch (error) {
+      if (issuedTokens) {
+        try {
+          await revokeXToken(issuedTokens.refresh_token ?? issuedTokens.access_token);
+        } catch (cleanupError) {
+          console.error('[X OAuth] Callback token cleanup failed', {
+            error: cleanupError instanceof Error ? cleanupError.message : 'Unknown error',
+          });
+        }
+      }
       console.error('[X OAuth] Callback failed', {
         error: error instanceof Error ? error.message : 'Unknown error',
       });

--- a/app/api/platforms/x/connect/route.ts
+++ b/app/api/platforms/x/connect/route.ts
@@ -1,0 +1,41 @@
+import { NextResponse } from 'next/server';
+import { getCurrentUserId, isAuthenticated } from '@/app/api/_utils/auth';
+import { Errors, withErrorHandling } from '@/app/api/_utils/errors';
+import { RateLimitPresets, withRateLimit } from '@/app/api/_utils/rateLimit';
+import { sealXOAuthFlow } from '@/lib/platforms/x/flow';
+import {
+  createAuthorizationRequest,
+  X_OAUTH_FLOW_COOKIE,
+  X_OAUTH_FLOW_MAX_AGE_SECONDS,
+} from '@/lib/platforms/x/oauth';
+
+export const POST = withRateLimit(
+  withErrorHandling(async () => {
+    if (!(await isAuthenticated())) return Errors.unauthorized();
+    const userId = await getCurrentUserId();
+    if (!userId) return Errors.unauthorized();
+
+    const request = createAuthorizationRequest();
+    const response = NextResponse.json({ authorizationUrl: request.authorizationUrl });
+    response.cookies.set(
+      X_OAUTH_FLOW_COOKIE,
+      sealXOAuthFlow({
+        state: request.state,
+        verifier: request.verifier,
+        userId,
+        expiresAt: Date.now() + X_OAUTH_FLOW_MAX_AGE_SECONDS * 1000,
+      }),
+      {
+        httpOnly: true,
+        secure: process.env.NODE_ENV === 'production',
+        sameSite: 'lax',
+        maxAge: X_OAUTH_FLOW_MAX_AGE_SECONDS,
+        path: '/api/platforms/x/callback',
+      }
+    );
+    return response;
+  }),
+  '/api/platforms/x/connect',
+  RateLimitPresets.AUTH,
+  'X_OAUTH_CONNECT'
+);

--- a/app/api/platforms/x/connect/route.ts
+++ b/app/api/platforms/x/connect/route.ts
@@ -37,5 +37,5 @@ export const POST = withRateLimit(
   }),
   '/api/platforms/x/connect',
   RateLimitPresets.AUTH,
-  'X_OAUTH_CONNECT'
+  'AUTH'
 );

--- a/app/api/platforms/x/route.ts
+++ b/app/api/platforms/x/route.ts
@@ -1,0 +1,19 @@
+import { NextResponse } from 'next/server';
+import { getCurrentUserId, isAuthenticated } from '@/app/api/_utils/auth';
+import { Errors, withErrorHandling } from '@/app/api/_utils/errors';
+import { RateLimitPresets, withRateLimit } from '@/app/api/_utils/rateLimit';
+import { disconnectXAccount } from '@/lib/platforms/x/repository';
+
+export const DELETE = withRateLimit(
+  withErrorHandling(async () => {
+    if (!(await isAuthenticated())) return Errors.unauthorized();
+    const userId = await getCurrentUserId();
+    if (!userId) return Errors.unauthorized();
+
+    const disconnected = await disconnectXAccount(userId);
+    return NextResponse.json({ disconnected });
+  }),
+  '/api/platforms/x',
+  RateLimitPresets.AUTH,
+  'X_OAUTH_DISCONNECT'
+);

--- a/app/api/platforms/x/route.ts
+++ b/app/api/platforms/x/route.ts
@@ -15,5 +15,5 @@ export const DELETE = withRateLimit(
   }),
   '/api/platforms/x',
   RateLimitPresets.AUTH,
-  'X_OAUTH_DISCONNECT'
+  'AUTH'
 );

--- a/docs/AZURE_SECRETS.md
+++ b/docs/AZURE_SECRETS.md
@@ -122,19 +122,27 @@ az webapp config appsettings set \
     LINKEDIN_API_URL="https://api.linkedin.com" \
     LINKEDIN_API_KEY="your-api-key"
 
-# Twitter/X
+# Twitter/X OAuth application (Gate 3 C1)
+# Store X_CLIENT_SECRET through the approved Key Vault path, then configure:
 az webapp config appsettings set \
   --name nl-dev-omnipost-web \
   --resource-group nl-dev-omnipost-rg \
   --settings \
-    TWITTER_API_URL="https://api.x.com/2/tweets" \
-    TWITTER_ACCESS_TOKEN="@Microsoft.KeyVault(SecretUri=https://nl-dev-omnipost-kv.vault.azure.net/secrets/TWITTER-ACCESS-TOKEN/<version>)"
+    X_CLIENT_ID="<x-oauth-client-id>" \
+    X_CLIENT_SECRET="@Microsoft.KeyVault(SecretUri=https://nl-dev-omnipost-kv.vault.azure.net/secrets/X-CLIENT-SECRET/<version>)" \
+    X_OAUTH_REDIRECT_URI="https://omnipost.neuralliquid.ai/api/platforms/x/callback"
 ```
 
-`TWITTER_ACCESS_TOKEN` must be an OAuth user-context token authorized for the
-publishing account with `tweet.write`; an app-only bearer token is insufficient.
-Create or rotate `TWITTER-ACCESS-TOKEN` through the approved secret-management
-path, never in shell history or committed files. Follow
+Register the callback URI as an exact match in the X Developer Console. OmniPost
+requests `tweet.read`, `tweet.write`, `users.read`, and `offline.access` through
+Authorization Code with S256 PKCE. The Terraform environment generates
+`omnipost-platform-token-encryption-key` and supplies it to App Service as the
+custom `PLATFORM_TOKEN_ENCRYPTION_KEY` connection string; do not copy that value
+into app settings or logs.
+
+`TWITTER_ACCESS_TOKEN` remains a legacy staffed-smoke fallback until Gate 3 C2
+wires the scheduler to per-account credentials. It must be a user-context token;
+an app-only bearer token is insufficient. Follow
 [X_CAMPAIGN_GO_LIVE.md](runbooks/X_CAMPAIGN_GO_LIVE.md) for the controlled smoke
 post and rollback procedure.
 

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -105,12 +105,16 @@ To publish to social platforms, you need API credentials for each one. Add these
 **Twitter/X:**
 
 1. Create a project and app in the [X Developer Console](https://developer.x.com/)
-2. Configure OAuth 2.0 user authentication with `tweet.read`, `tweet.write`, and
-   `users.read`; add `offline.access` when implementing token refresh
-3. Authorize the X account that will publish the campaign
-4. Set the resulting user-context token as `TWITTER_ACCESS_TOKEN` in `.env.local`
+2. Configure OAuth 2.0 user authentication with the exact callback
+   `http://localhost:3000/api/platforms/x/callback`
+3. Set `X_CLIENT_ID`, optional `X_CLIENT_SECRET`, `X_OAUTH_REDIRECT_URI`, and a
+   base64-encoded 32-byte `PLATFORM_TOKEN_ENCRYPTION_KEY` in `.env.local`
+4. Open **Settings → Platform Connections** and authorize the X account.
 
-An app-only bearer token cannot create posts. See the
+OmniPost requests `tweet.read`, `tweet.write`, `users.read`, and
+`offline.access` through Authorization Code with S256 PKCE. Tokens are encrypted
+before persistence and are never returned to the browser. An app-only bearer
+token cannot create posts. See the
 [X campaign go-live runbook](runbooks/X_CAMPAIGN_GO_LIVE.md) before enabling
 production publishing.
 

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -1,5 +1,69 @@
 # OmniPost Alpha — Handoff Document
 
+## 2026-07-25 X OAuth Account Lifecycle — Gate 3 C1
+
+### Current State
+
+- **Draft implementation PR:** [#181 — X OAuth account lifecycle](https://github.com/neuralliquid/omnipost/pull/181)
+- **Implementation branch:** `agent/gate3-x-oauth-lifecycle`
+- **Implementation commit before this handoff:** `4bd537c13174d667ffb67c59048fbc3ab04b3136`
+- **Baton Gate 3 task:** `8b2fe3e9-1765-464d-9e88-6f8aed147769`
+- The PR remains draft until its protected Terraform check passes and an
+  approved X OAuth application can provide real callback and account proof.
+
+### Delivered
+
+- Added tenant-owned `PlatformAccount` persistence with forward-only
+  PostgreSQL migration, provider/account uniqueness, lifecycle status, scopes,
+  expiry, and revocation timestamps.
+- Added X OAuth 2.0 Authorization Code with PKCE, short-lived sealed state and
+  verifier cookies, exact callback routing, production HTTPS enforcement,
+  refresh-token rotation, provider-side revocation, and reconnect handling.
+- Added versioned AES-256-GCM token encryption with purpose-bound associated
+  data. Raw provider tokens are neither returned by the API nor stored in
+  plaintext.
+- Added authenticated connect, connection-status, refresh-aware token access,
+  and disconnect routes plus the dashboard connection controls.
+- Added a generated Key Vault encryption key and App Service custom connection
+  reference. X client credentials deliberately remain externally supplied
+  secrets rather than Terraform-generated values.
+
+### Verification
+
+- `pnpm run type-check` passed.
+- `pnpm run lint` passed with zero errors and 120 pre-existing warnings.
+- Windows-safe repository Prettier validation passed. The standard
+  `pnpm check-all` format stage remains incompatible with the worktree's
+  existing CRLF files and reports unchanged files.
+- All 35 Jest suites and 255 executed tests passed; one PostgreSQL integration
+  suite was skipped because Docker Desktop was unavailable.
+- `pnpm run build` passed.
+- `pnpm run marketing:validate` passed.
+- Prisma 7.1 client generation passed.
+- Terraform formatting and `terraform validate` passed after provider
+  initialization.
+- At handoff, all eight application CI checks on PR #181 passed. The protected
+  Terraform check was still pending, and there were no submitted reviews or
+  inline review threads.
+
+### Deployment Boundary And Continuation
+
+- This slice does not configure an X developer application, purchase provider
+  credits, connect a real account, or prove a production post/revocation flow.
+  Those steps require approved external credentials and account authorization.
+- A health check is not authenticated X proof. Keep the PR draft until the
+  protected Terraform result is known, then obtain real consent through the
+  visible X flow and record connect, refresh/reconnect, post, and revoke proof
+  without exposing tokens.
+- The scheduler still uses the legacy static X token path. Gate 3 C2 must wire
+  publishing to the persisted account token accessor before the static token
+  can be removed.
+- Do not merge on green CI alone: inspect current human/bot reviews and all
+  unresolved threads again immediately before any ready-for-review or merge
+  transition.
+
+---
+
 ## 2026-07-25 Durable Application Database — Gate 3 Slice
 
 ### Current State

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -8,8 +8,8 @@
 - **Implementation branch:** `agent/gate3-x-oauth-lifecycle`
 - **Implementation commit before this handoff:** `4bd537c13174d667ffb67c59048fbc3ab04b3136`
 - **Baton Gate 3 task:** `8b2fe3e9-1765-464d-9e88-6f8aed147769`
-- The PR remains draft until its protected Terraform check passes and an
-  approved X OAuth application can provide real callback and account proof.
+- The PR remains draft until an approved X OAuth application can provide real
+  callback and account proof.
 
 ### Delivered
 
@@ -42,19 +42,17 @@
 - Prisma 7.1 client generation passed.
 - Terraform formatting and `terraform validate` passed after provider
   initialization.
-- At handoff, all eight application CI checks on PR #181 passed. The protected
-  Terraform check was still pending, and there were no submitted reviews or
-  inline review threads.
+- At handoff, all nine checks on PR #181 passed, including the protected
+  Terraform plan. There were no submitted reviews or inline review threads.
 
 ### Deployment Boundary And Continuation
 
 - This slice does not configure an X developer application, purchase provider
   credits, connect a real account, or prove a production post/revocation flow.
   Those steps require approved external credentials and account authorization.
-- A health check is not authenticated X proof. Keep the PR draft until the
-  protected Terraform result is known, then obtain real consent through the
-  visible X flow and record connect, refresh/reconnect, post, and revoke proof
-  without exposing tokens.
+- A health check is not authenticated X proof. Keep the PR draft, obtain real
+  consent through the visible X flow, and record connect, refresh/reconnect,
+  post, and revoke proof without exposing tokens.
 - The scheduler still uses the legacy static X token path. Gate 3 C2 must wire
   publishing to the persisted account token accessor before the static token
   can be removed.

--- a/infra/terraform/env/dev/main.tf
+++ b/infra/terraform/env/dev/main.tf
@@ -134,11 +134,26 @@ resource "azurerm_linux_web_app" "web" {
   }
 
   dynamic "connection_string" {
-    for_each = var.enable_app_postgresql && var.enable_key_vault ? [1] : []
+    for_each = merge(
+      var.enable_app_postgresql && var.enable_key_vault ? {
+        database = {
+          name  = "DATABASE_URL"
+          type  = "PostgreSQL"
+          value = "@Microsoft.KeyVault(SecretUri=${azurerm_key_vault_secret.app_database_url[0].versionless_id})"
+        }
+      } : {},
+      var.enable_key_vault ? {
+        platform_token_key = {
+          name  = "PLATFORM_TOKEN_ENCRYPTION_KEY"
+          type  = "Custom"
+          value = "@Microsoft.KeyVault(SecretUri=${azurerm_key_vault_secret.platform_token_encryption_key[0].versionless_id})"
+        }
+      } : {}
+    )
     content {
-      name  = "DATABASE_URL"
-      type  = "PostgreSQL"
-      value = "@Microsoft.KeyVault(SecretUri=${azurerm_key_vault_secret.app_database_url[0].versionless_id})"
+      name  = connection_string.value.name
+      type  = connection_string.value.type
+      value = connection_string.value.value
     }
   }
 
@@ -501,6 +516,12 @@ resource "random_password" "app_postgresql" {
   override_special = "_%@"
 }
 
+resource "random_id" "platform_token_encryption_key" {
+  count = var.enable_key_vault ? 1 : 0
+
+  byte_length = 32
+}
+
 resource "azurerm_postgresql_flexible_server" "app" {
   count = var.enable_app_postgresql ? 1 : 0
 
@@ -558,6 +579,23 @@ resource "azurerm_key_vault_secret" "app_database_url" {
 
   depends_on = [
     azurerm_postgresql_flexible_server_database.app_database,
+    azurerm_role_assignment.deployment_key_vault_secrets_officer,
+    azurerm_role_assignment.operator_key_vault_secrets_officer,
+    azurerm_role_assignment.web_identity_key_vault_secrets_officer,
+  ]
+}
+
+resource "azurerm_key_vault_secret" "platform_token_encryption_key" {
+  count = var.enable_key_vault ? 1 : 0
+
+  name             = "omnipost-platform-token-encryption-key"
+  value_wo         = random_id.platform_token_encryption_key[0].b64_std
+  value_wo_version = 1
+  key_vault_id     = azurerm_key_vault.this[0].id
+  content_type     = "AES-256-GCM key for provider token encryption"
+  tags             = merge(local.tags, { managedBy = "terraform", component = "platform-oauth" })
+
+  depends_on = [
     azurerm_role_assignment.deployment_key_vault_secrets_officer,
     azurerm_role_assignment.operator_key_vault_secrets_officer,
     azurerm_role_assignment.web_identity_key_vault_secrets_officer,

--- a/lib/platforms/x/crypto.ts
+++ b/lib/platforms/x/crypto.ts
@@ -1,0 +1,88 @@
+import {
+  createCipheriv,
+  createDecipheriv,
+  createHash,
+  randomBytes,
+  timingSafeEqual,
+} from 'node:crypto';
+
+const ALGORITHM = 'aes-256-gcm';
+const VERSION = 'v1';
+const IV_BYTES = 12;
+const KEY_BYTES = 32;
+
+function configuredEncryptionKey(): string | undefined {
+  return (
+    process.env.PLATFORM_TOKEN_ENCRYPTION_KEY ??
+    process.env.CUSTOMCONNSTR_PLATFORM_TOKEN_ENCRYPTION_KEY
+  );
+}
+
+function getEncryptionKey(): Buffer {
+  const configured = configuredEncryptionKey();
+  if (!configured) {
+    throw new Error('PLATFORM_TOKEN_ENCRYPTION_KEY is not configured');
+  }
+
+  const key = Buffer.from(configured, 'base64');
+  if (key.length !== KEY_BYTES) {
+    throw new Error('PLATFORM_TOKEN_ENCRYPTION_KEY must be a base64-encoded 32-byte key');
+  }
+  return key;
+}
+
+export function isPlatformTokenEncryptionConfigured(): boolean {
+  const configured = configuredEncryptionKey();
+  return Boolean(configured && Buffer.from(configured, 'base64').length === KEY_BYTES);
+}
+
+export function encryptSecret(value: string, purpose: string): string {
+  const iv = randomBytes(IV_BYTES);
+  const cipher = createCipheriv(ALGORITHM, getEncryptionKey(), iv);
+  cipher.setAAD(Buffer.from(purpose, 'utf8'));
+  const ciphertext = Buffer.concat([cipher.update(value, 'utf8'), cipher.final()]);
+  const tag = cipher.getAuthTag();
+
+  return [
+    VERSION,
+    iv.toString('base64url'),
+    tag.toString('base64url'),
+    ciphertext.toString('base64url'),
+  ].join('.');
+}
+
+export function decryptSecret(value: string, purpose: string): string {
+  const [version, ivValue, tagValue, ciphertextValue, ...extra] = value.split('.');
+  if (version !== VERSION || !ivValue || !tagValue || !ciphertextValue || extra.length > 0) {
+    throw new Error('Encrypted value has an unsupported format');
+  }
+
+  const decipher = createDecipheriv(
+    ALGORITHM,
+    getEncryptionKey(),
+    Buffer.from(ivValue, 'base64url')
+  );
+  decipher.setAAD(Buffer.from(purpose, 'utf8'));
+  decipher.setAuthTag(Buffer.from(tagValue, 'base64url'));
+  const plaintext = Buffer.concat([
+    decipher.update(Buffer.from(ciphertextValue, 'base64url')),
+    decipher.final(),
+  ]);
+  return plaintext.toString('utf8');
+}
+
+export function createPkcePair(): { verifier: string; challenge: string } {
+  const verifier = randomBytes(48).toString('base64url');
+  const challenge = createHash('sha256').update(verifier, 'ascii').digest('base64url');
+  return { verifier, challenge };
+}
+
+export function randomOAuthState(): string {
+  return randomBytes(32).toString('base64url');
+}
+
+export function safeEqual(left: string, right: string): boolean {
+  const leftBuffer = Buffer.from(left, 'utf8');
+  const rightBuffer = Buffer.from(right, 'utf8');
+  return leftBuffer.length === rightBuffer.length && timingSafeEqual(leftBuffer, rightBuffer);
+}

--- a/lib/platforms/x/flow.ts
+++ b/lib/platforms/x/flow.ts
@@ -1,0 +1,24 @@
+import { z } from 'zod';
+import { decryptSecret, encryptSecret } from './crypto';
+
+const flowPayloadSchema = z.object({
+  state: z.string().min(32).max(500),
+  verifier: z.string().min(43).max(128),
+  userId: z.string().min(1),
+  expiresAt: z.number().int().positive(),
+});
+
+export type XOAuthFlowPayload = z.infer<typeof flowPayloadSchema>;
+
+export function sealXOAuthFlow(payload: XOAuthFlowPayload): string {
+  return encryptSecret(JSON.stringify(flowPayloadSchema.parse(payload)), 'x-oauth-flow');
+}
+
+export function openXOAuthFlow(value: string): XOAuthFlowPayload | null {
+  try {
+    const payload = flowPayloadSchema.parse(JSON.parse(decryptSecret(value, 'x-oauth-flow')));
+    return payload.expiresAt > Date.now() ? payload : null;
+  } catch {
+    return null;
+  }
+}

--- a/lib/platforms/x/oauth.ts
+++ b/lib/platforms/x/oauth.ts
@@ -198,7 +198,7 @@ export async function fetchXIdentity(accessToken: string): Promise<{
   id: string;
   username: string;
 }> {
-  const response = await fetch(getXOAuthConfig().meUrl, {
+  const response = await fetchWithOAuthTimeout(getXOAuthConfig().meUrl, {
     headers: { Authorization: `Bearer ${accessToken}` },
     cache: 'no-store',
   });
@@ -213,7 +213,7 @@ export async function revokeXToken(token: string): Promise<void> {
   const body = new URLSearchParams({ token });
   if (!config.clientSecret) body.set('client_id', config.clientId);
 
-  const response = await fetch(config.revokeUrl, {
+  const response = await fetchWithOAuthTimeout(config.revokeUrl, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/x-www-form-urlencoded',

--- a/lib/platforms/x/oauth.ts
+++ b/lib/platforms/x/oauth.ts
@@ -1,0 +1,195 @@
+import { z } from 'zod';
+import { createPkcePair, randomOAuthState } from './crypto';
+
+export const X_PLATFORM_ID = 'twitter';
+export const X_OAUTH_SCOPES = [
+  'tweet.read',
+  'tweet.write',
+  'users.read',
+  'offline.access',
+] as const;
+export const X_OAUTH_FLOW_COOKIE = 'omnipost-x-oauth-flow';
+export const X_OAUTH_FLOW_MAX_AGE_SECONDS = 10 * 60;
+
+const tokenResponseSchema = z.object({
+  token_type: z.string().min(1),
+  expires_in: z.number().int().positive(),
+  access_token: z.string().min(1),
+  scope: z.string().min(1),
+  refresh_token: z.string().min(1).optional(),
+});
+
+const userResponseSchema = z.object({
+  data: z.object({
+    id: z.string().min(1),
+    username: z.string().min(1),
+  }),
+});
+
+export type XTokenResponse = z.infer<typeof tokenResponseSchema>;
+
+function requiredEnvironment(name: 'X_CLIENT_ID'): string {
+  const value = (process.env[name] ?? process.env[`CUSTOMCONNSTR_${name}`])?.trim();
+  if (!value) {
+    throw new Error(`${name} is not configured`);
+  }
+  return value;
+}
+
+export function getXOAuthConfig() {
+  const clientId = requiredEnvironment('X_CLIENT_ID');
+  const clientSecret = (
+    process.env.X_CLIENT_SECRET ?? process.env.CUSTOMCONNSTR_X_CLIENT_SECRET
+  )?.trim();
+  const siteUrl = process.env.NEXT_PUBLIC_SITE_URL?.trim();
+  const redirectUri =
+    process.env.X_OAUTH_REDIRECT_URI?.trim() ||
+    (siteUrl ? `${siteUrl.replace(/\/$/, '')}/api/platforms/x/callback` : '');
+
+  if (!redirectUri) {
+    throw new Error('X_OAUTH_REDIRECT_URI or NEXT_PUBLIC_SITE_URL is not configured');
+  }
+  const parsedRedirectUri = new URL(redirectUri);
+  if (parsedRedirectUri.pathname !== '/api/platforms/x/callback') {
+    throw new Error('X_OAUTH_REDIRECT_URI must target /api/platforms/x/callback');
+  }
+  if (process.env.NODE_ENV === 'production' && parsedRedirectUri.protocol !== 'https:') {
+    throw new Error('X_OAUTH_REDIRECT_URI must use HTTPS in production');
+  }
+
+  return {
+    clientId,
+    clientSecret,
+    redirectUri: parsedRedirectUri.toString(),
+    authorizeUrl: process.env.X_OAUTH_AUTHORIZE_URL || 'https://x.com/i/oauth2/authorize',
+    tokenUrl: process.env.X_OAUTH_TOKEN_URL || 'https://api.x.com/2/oauth2/token',
+    revokeUrl: process.env.X_OAUTH_REVOKE_URL || 'https://api.x.com/2/oauth2/revoke',
+    meUrl: process.env.X_API_ME_URL || 'https://api.x.com/2/users/me',
+  };
+}
+
+export function isXOAuthClientConfigured(): boolean {
+  try {
+    getXOAuthConfig();
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function createAuthorizationRequest(): {
+  authorizationUrl: string;
+  state: string;
+  verifier: string;
+} {
+  const config = getXOAuthConfig();
+  const state = randomOAuthState();
+  const { verifier, challenge } = createPkcePair();
+  const params = new URLSearchParams({
+    response_type: 'code',
+    client_id: config.clientId,
+    redirect_uri: config.redirectUri,
+    scope: X_OAUTH_SCOPES.join(' '),
+    state,
+    code_challenge: challenge,
+    code_challenge_method: 'S256',
+  });
+
+  return {
+    authorizationUrl: `${config.authorizeUrl}?${params.toString()}`,
+    state,
+    verifier,
+  };
+}
+
+function confidentialClientHeaders(clientId: string, clientSecret?: string): HeadersInit {
+  if (!clientSecret) return {};
+  return {
+    Authorization: `Basic ${Buffer.from(`${clientId}:${clientSecret}`, 'utf8').toString('base64')}`,
+  };
+}
+
+async function parseTokenResponse(response: Response): Promise<XTokenResponse> {
+  if (!response.ok) {
+    throw new Error(`X OAuth token request failed with status ${response.status}`);
+  }
+  return tokenResponseSchema.parse(await response.json());
+}
+
+export async function exchangeAuthorizationCode(
+  code: string,
+  verifier: string
+): Promise<XTokenResponse> {
+  const config = getXOAuthConfig();
+  const body = new URLSearchParams({
+    code,
+    grant_type: 'authorization_code',
+    redirect_uri: config.redirectUri,
+    code_verifier: verifier,
+  });
+  if (!config.clientSecret) body.set('client_id', config.clientId);
+
+  const response = await fetch(config.tokenUrl, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded',
+      ...confidentialClientHeaders(config.clientId, config.clientSecret),
+    },
+    body,
+    cache: 'no-store',
+  });
+  return parseTokenResponse(response);
+}
+
+export async function refreshAccessToken(refreshToken: string): Promise<XTokenResponse> {
+  const config = getXOAuthConfig();
+  const body = new URLSearchParams({
+    refresh_token: refreshToken,
+    grant_type: 'refresh_token',
+  });
+  if (!config.clientSecret) body.set('client_id', config.clientId);
+
+  const response = await fetch(config.tokenUrl, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded',
+      ...confidentialClientHeaders(config.clientId, config.clientSecret),
+    },
+    body,
+    cache: 'no-store',
+  });
+  return parseTokenResponse(response);
+}
+
+export async function fetchXIdentity(accessToken: string): Promise<{
+  id: string;
+  username: string;
+}> {
+  const response = await fetch(getXOAuthConfig().meUrl, {
+    headers: { Authorization: `Bearer ${accessToken}` },
+    cache: 'no-store',
+  });
+  if (!response.ok) {
+    throw new Error(`X identity request failed with status ${response.status}`);
+  }
+  return userResponseSchema.parse(await response.json()).data;
+}
+
+export async function revokeXToken(token: string): Promise<void> {
+  const config = getXOAuthConfig();
+  const body = new URLSearchParams({ token });
+  if (!config.clientSecret) body.set('client_id', config.clientId);
+
+  const response = await fetch(config.revokeUrl, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded',
+      ...confidentialClientHeaders(config.clientId, config.clientSecret),
+    },
+    body,
+    cache: 'no-store',
+  });
+  if (!response.ok) {
+    throw new Error(`X OAuth revoke request failed with status ${response.status}`);
+  }
+}

--- a/lib/platforms/x/oauth.ts
+++ b/lib/platforms/x/oauth.ts
@@ -28,6 +28,23 @@ const userResponseSchema = z.object({
 
 export type XTokenResponse = z.infer<typeof tokenResponseSchema>;
 
+export class XOAuthTokenRequestError extends Error {
+  constructor(
+    readonly status: number,
+    readonly oauthError?: string
+  ) {
+    super(`X OAuth token request failed with status ${status}`);
+    this.name = 'XOAuthTokenRequestError';
+  }
+}
+
+export function isDefinitiveXAuthorizationError(error: unknown): boolean {
+  return (
+    error instanceof XOAuthTokenRequestError &&
+    (error.oauthError === 'invalid_grant' || error.oauthError === 'invalid_token')
+  );
+}
+
 function requiredEnvironment(name: 'X_CLIENT_ID'): string {
   const value = (process.env[name] ?? process.env[`CUSTOMCONNSTR_${name}`])?.trim();
   if (!value) {
@@ -111,7 +128,12 @@ function confidentialClientHeaders(clientId: string, clientSecret?: string): Hea
 
 async function parseTokenResponse(response: Response): Promise<XTokenResponse> {
   if (!response.ok) {
-    throw new Error(`X OAuth token request failed with status ${response.status}`);
+    const payload = (await response
+      .clone()
+      .json()
+      .catch(() => null)) as { error?: unknown } | null;
+    const oauthError = typeof payload?.error === 'string' ? payload.error : undefined;
+    throw new XOAuthTokenRequestError(response.status, oauthError);
   }
   return tokenResponseSchema.parse(await response.json());
 }

--- a/lib/platforms/x/oauth.ts
+++ b/lib/platforms/x/oauth.ts
@@ -10,6 +10,7 @@ export const X_OAUTH_SCOPES = [
 ] as const;
 export const X_OAUTH_FLOW_COOKIE = 'omnipost-x-oauth-flow';
 export const X_OAUTH_FLOW_MAX_AGE_SECONDS = 10 * 60;
+const X_OAUTH_REQUEST_TIMEOUT_MS = 15_000;
 
 const tokenResponseSchema = z.object({
   token_type: z.string().min(1),
@@ -126,6 +127,16 @@ function confidentialClientHeaders(clientId: string, clientSecret?: string): Hea
   };
 }
 
+async function fetchWithOAuthTimeout(url: string, init: RequestInit): Promise<Response> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), X_OAUTH_REQUEST_TIMEOUT_MS);
+  try {
+    return await fetch(url, { ...init, signal: controller.signal });
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
 async function parseTokenResponse(response: Response): Promise<XTokenResponse> {
   if (!response.ok) {
     const payload = (await response
@@ -151,7 +162,7 @@ export async function exchangeAuthorizationCode(
   });
   if (!config.clientSecret) body.set('client_id', config.clientId);
 
-  const response = await fetch(config.tokenUrl, {
+  const response = await fetchWithOAuthTimeout(config.tokenUrl, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/x-www-form-urlencoded',
@@ -171,7 +182,7 @@ export async function refreshAccessToken(refreshToken: string): Promise<XTokenRe
   });
   if (!config.clientSecret) body.set('client_id', config.clientId);
 
-  const response = await fetch(config.tokenUrl, {
+  const response = await fetchWithOAuthTimeout(config.tokenUrl, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/x-www-form-urlencoded',

--- a/lib/platforms/x/oauth.ts
+++ b/lib/platforms/x/oauth.ts
@@ -127,11 +127,11 @@ function confidentialClientHeaders(clientId: string, clientSecret?: string): Hea
   };
 }
 
-async function fetchWithOAuthTimeout(url: string, init: RequestInit): Promise<Response> {
+async function withOAuthTimeout<T>(operation: (signal: AbortSignal) => Promise<T>): Promise<T> {
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), X_OAUTH_REQUEST_TIMEOUT_MS);
   try {
-    return await fetch(url, { ...init, signal: controller.signal });
+    return await operation(controller.signal);
   } finally {
     clearTimeout(timeout);
   }
@@ -162,16 +162,19 @@ export async function exchangeAuthorizationCode(
   });
   if (!config.clientSecret) body.set('client_id', config.clientId);
 
-  const response = await fetchWithOAuthTimeout(config.tokenUrl, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/x-www-form-urlencoded',
-      ...confidentialClientHeaders(config.clientId, config.clientSecret),
-    },
-    body,
-    cache: 'no-store',
+  return withOAuthTimeout(async signal => {
+    const response = await fetch(config.tokenUrl, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+        ...confidentialClientHeaders(config.clientId, config.clientSecret),
+      },
+      body,
+      cache: 'no-store',
+      signal,
+    });
+    return parseTokenResponse(response);
   });
-  return parseTokenResponse(response);
 }
 
 export async function refreshAccessToken(refreshToken: string): Promise<XTokenResponse> {
@@ -182,30 +185,36 @@ export async function refreshAccessToken(refreshToken: string): Promise<XTokenRe
   });
   if (!config.clientSecret) body.set('client_id', config.clientId);
 
-  const response = await fetchWithOAuthTimeout(config.tokenUrl, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/x-www-form-urlencoded',
-      ...confidentialClientHeaders(config.clientId, config.clientSecret),
-    },
-    body,
-    cache: 'no-store',
+  return withOAuthTimeout(async signal => {
+    const response = await fetch(config.tokenUrl, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+        ...confidentialClientHeaders(config.clientId, config.clientSecret),
+      },
+      body,
+      cache: 'no-store',
+      signal,
+    });
+    return parseTokenResponse(response);
   });
-  return parseTokenResponse(response);
 }
 
 export async function fetchXIdentity(accessToken: string): Promise<{
   id: string;
   username: string;
 }> {
-  const response = await fetchWithOAuthTimeout(getXOAuthConfig().meUrl, {
-    headers: { Authorization: `Bearer ${accessToken}` },
-    cache: 'no-store',
+  return withOAuthTimeout(async signal => {
+    const response = await fetch(getXOAuthConfig().meUrl, {
+      headers: { Authorization: `Bearer ${accessToken}` },
+      cache: 'no-store',
+      signal,
+    });
+    if (!response.ok) {
+      throw new Error(`X identity request failed with status ${response.status}`);
+    }
+    return userResponseSchema.parse(await response.json()).data;
   });
-  if (!response.ok) {
-    throw new Error(`X identity request failed with status ${response.status}`);
-  }
-  return userResponseSchema.parse(await response.json()).data;
 }
 
 export async function revokeXToken(token: string): Promise<void> {
@@ -213,16 +222,19 @@ export async function revokeXToken(token: string): Promise<void> {
   const body = new URLSearchParams({ token });
   if (!config.clientSecret) body.set('client_id', config.clientId);
 
-  const response = await fetchWithOAuthTimeout(config.revokeUrl, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/x-www-form-urlencoded',
-      ...confidentialClientHeaders(config.clientId, config.clientSecret),
-    },
-    body,
-    cache: 'no-store',
+  await withOAuthTimeout(async signal => {
+    const response = await fetch(config.revokeUrl, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+        ...confidentialClientHeaders(config.clientId, config.clientSecret),
+      },
+      body,
+      cache: 'no-store',
+      signal,
+    });
+    if (!response.ok) {
+      throw new Error(`X OAuth revoke request failed with status ${response.status}`);
+    }
   });
-  if (!response.ok) {
-    throw new Error(`X OAuth revoke request failed with status ${response.status}`);
-  }
 }

--- a/lib/platforms/x/repository.ts
+++ b/lib/platforms/x/repository.ts
@@ -12,6 +12,9 @@ import {
 const ACCESS_TOKEN_PURPOSE = 'x-access-token';
 const REFRESH_TOKEN_PURPOSE = 'x-refresh-token';
 const REFRESH_WINDOW_MS = 5 * 60 * 1000;
+const LIFECYCLE_CLAIM_TTL_MS = 2 * 60 * 1000;
+const REFRESH_CONTENDER_ATTEMPTS = 20;
+const REFRESH_CONTENDER_DELAY_MS = 100;
 
 function getClient(): PrismaClient {
   if (!prisma) {
@@ -34,43 +37,131 @@ function tokenExpiry(tokens: XTokenResponse): Date {
   return new Date(Date.now() + tokens.expires_in * 1000);
 }
 
+function lifecycleClaimIsStale(updatedAt: Date): boolean {
+  return updatedAt.getTime() <= Date.now() - LIFECYCLE_CLAIM_TTL_MS;
+}
+
+function wait(milliseconds: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, milliseconds));
+}
+
+async function waitForWinningRefresh(client: PrismaClient, userId: string): Promise<string> {
+  for (let attempt = 0; attempt < REFRESH_CONTENDER_ATTEMPTS; attempt += 1) {
+    const account = await client.platformAccount.findUnique({
+      where: { userId_platform: { userId, platform: X_PLATFORM_ID } },
+    });
+    if (!account) throw new Error('X account is not connected');
+
+    if (account.status === 'connected') {
+      if (!account.expiresAt || account.expiresAt.getTime() > Date.now()) {
+        return decryptSecret(account.encryptedAccessToken, ACCESS_TOKEN_PURPOSE);
+      }
+      return getValidXAccessToken(userId);
+    }
+    if (account.status !== 'refreshing') {
+      throw new Error('X account is not connected');
+    }
+    if (lifecycleClaimIsStale(account.updatedAt)) {
+      await client.platformAccount.updateMany({
+        where: { id: account.id, status: 'refreshing', updatedAt: account.updatedAt },
+        data: { status: 'expired' },
+      });
+      throw new Error('X account refresh was interrupted; reconnect is required');
+    }
+    await wait(REFRESH_CONTENDER_DELAY_MS);
+  }
+  throw new Error('X account refresh is still in progress');
+}
+
 export async function saveXAccount(
   userId: string,
   identity: { id: string; username: string },
   tokens: XTokenResponse
 ) {
-  return getClient().platformAccount.upsert({
+  const client = getClient();
+  const encryptedAccessToken = encryptSecret(tokens.access_token, ACCESS_TOKEN_PURPOSE);
+  const encryptedRefreshToken = tokens.refresh_token
+    ? encryptSecret(tokens.refresh_token, REFRESH_TOKEN_PURPOSE)
+    : null;
+  const tokenData = {
+    providerAccountId: identity.id,
+    providerUsername: identity.username,
+    encryptedAccessToken,
+    encryptedRefreshToken,
+    tokenType: tokens.token_type.toLowerCase(),
+    scopes: tokens.scope,
+    expiresAt: tokenExpiry(tokens),
+    status: 'connected',
+  } as const;
+  const existing = await client.platformAccount.findUnique({
     where: { userId_platform: { userId, platform: X_PLATFORM_ID } },
-    create: {
-      userId,
-      platform: X_PLATFORM_ID,
-      providerAccountId: identity.id,
-      providerUsername: identity.username,
-      encryptedAccessToken: encryptSecret(tokens.access_token, ACCESS_TOKEN_PURPOSE),
-      encryptedRefreshToken: tokens.refresh_token
-        ? encryptSecret(tokens.refresh_token, REFRESH_TOKEN_PURPOSE)
-        : null,
-      tokenType: tokens.token_type.toLowerCase(),
-      scopes: tokens.scope,
-      expiresAt: tokenExpiry(tokens),
-      status: 'connected',
+  });
+
+  if (!existing) {
+    return client.platformAccount.create({
+      data: {
+        userId,
+        platform: X_PLATFORM_ID,
+        ...tokenData,
+      },
+    });
+  }
+
+  const busy = ['refreshing', 'revoking', 'reconnecting'].includes(existing.status);
+  if (busy && !lifecycleClaimIsStale(existing.updatedAt)) {
+    throw new Error('X account authorization is currently changing');
+  }
+  const claim = await client.platformAccount.updateMany({
+    where: { id: existing.id, status: existing.status, updatedAt: existing.updatedAt },
+    data: { status: 'reconnecting' },
+  });
+  if (claim.count !== 1) {
+    throw new Error('X account authorization changed during reconnect');
+  }
+
+  const displacedToken = existing.encryptedRefreshToken
+    ? decryptSecret(existing.encryptedRefreshToken, REFRESH_TOKEN_PURPOSE)
+    : existing.encryptedAccessToken
+      ? decryptSecret(existing.encryptedAccessToken, ACCESS_TOKEN_PURPOSE)
+      : null;
+  const displacedAuthorizationMayBeLive = existing.status === 'connected';
+  if (displacedToken && displacedAuthorizationMayBeLive) {
+    try {
+      await revokeXToken(displacedToken);
+    } catch (error) {
+      await client.platformAccount.updateMany({
+        where: {
+          id: existing.id,
+          status: 'reconnecting',
+          connectedAt: existing.connectedAt,
+          encryptedAccessToken: existing.encryptedAccessToken,
+          encryptedRefreshToken: existing.encryptedRefreshToken,
+        },
+        data: { status: existing.status },
+      });
+      throw error;
+    }
+  }
+
+  const update = await client.platformAccount.updateMany({
+    where: {
+      id: existing.id,
+      status: 'reconnecting',
+      connectedAt: existing.connectedAt,
+      encryptedAccessToken: existing.encryptedAccessToken,
+      encryptedRefreshToken: existing.encryptedRefreshToken,
     },
-    update: {
-      providerAccountId: identity.id,
-      providerUsername: identity.username,
-      encryptedAccessToken: encryptSecret(tokens.access_token, ACCESS_TOKEN_PURPOSE),
-      encryptedRefreshToken: tokens.refresh_token
-        ? encryptSecret(tokens.refresh_token, REFRESH_TOKEN_PURPOSE)
-        : null,
-      tokenType: tokens.token_type.toLowerCase(),
-      scopes: tokens.scope,
-      expiresAt: tokenExpiry(tokens),
-      status: 'connected',
+    data: {
+      ...tokenData,
       connectedAt: new Date(),
       refreshedAt: null,
       revokedAt: null,
     },
   });
+  if (update.count !== 1) {
+    throw new Error('X account authorization changed while reconnecting');
+  }
+  return update;
 }
 
 export async function getXConnectionStatus(userId: string): Promise<PlatformConnectionStatus> {
@@ -83,6 +174,7 @@ export async function getXConnectionStatus(userId: string): Promise<PlatformConn
       encryptedRefreshToken: true,
       status: true,
       connectedAt: true,
+      updatedAt: true,
     },
   });
 
@@ -94,7 +186,9 @@ export async function getXConnectionStatus(userId: string): Promise<PlatformConn
     account.expiresAt && account.expiresAt.getTime() <= Date.now()
   );
   const authorizationExpired = accessTokenExpired && !account.encryptedRefreshToken;
-  const lifecycleConnected = account.status === 'connected' || account.status === 'refreshing';
+  const lifecycleConnected =
+    account.status === 'connected' ||
+    (account.status === 'refreshing' && !lifecycleClaimIsStale(account.updatedAt));
   const status = authorizationExpired || !lifecycleConnected ? 'expired' : 'connected';
   return {
     platform: X_PLATFORM_ID,
@@ -112,9 +206,11 @@ export async function getValidXAccessToken(userId: string): Promise<string> {
   const account = await client.platformAccount.findUnique({
     where: { userId_platform: { userId, platform: X_PLATFORM_ID } },
   });
-  if (!account || account.status !== 'connected') {
+  if (!account) {
     throw new Error('X account is not connected');
   }
+  if (account.status === 'refreshing') return waitForWinningRefresh(client, userId);
+  if (account.status !== 'connected') throw new Error('X account is not connected');
 
   if (!account.expiresAt || account.expiresAt.getTime() > Date.now() + REFRESH_WINDOW_MS) {
     return decryptSecret(account.encryptedAccessToken, ACCESS_TOKEN_PURPOSE);
@@ -149,7 +245,7 @@ export async function getValidXAccessToken(userId: string): Promise<string> {
     data: { status: 'refreshing' },
   });
   if (claim.count !== 1) {
-    throw new Error('X account changed before authorization could be refreshed');
+    return waitForWinningRefresh(client, userId);
   }
 
   let tokens: XTokenResponse;
@@ -219,14 +315,15 @@ export async function disconnectXAccount(userId: string): Promise<boolean> {
     });
     return update.count === 1;
   }
-  if (account.status !== 'connected') return false;
+  const busy = ['refreshing', 'revoking', 'reconnecting'].includes(account.status);
+  if (busy && !lifecycleClaimIsStale(account.updatedAt)) return false;
+  if (account.status !== 'connected' && !busy) return false;
 
   const claim = await client.platformAccount.updateMany({
-    where: {
-      id: account.id,
-      status: 'connected',
-      connectedAt: account.connectedAt,
-    },
+    where:
+      account.status === 'connected'
+        ? { id: account.id, status: 'connected', connectedAt: account.connectedAt }
+        : { id: account.id, status: account.status, updatedAt: account.updatedAt },
     data: { status: 'revoking' },
   });
   if (claim.count !== 1) return false;
@@ -248,7 +345,7 @@ export async function disconnectXAccount(userId: string): Promise<boolean> {
         encryptedAccessToken: claimedAccount.encryptedAccessToken,
         encryptedRefreshToken: claimedAccount.encryptedRefreshToken,
       },
-      data: { status: 'connected' },
+      data: { status: account.status === 'connected' ? 'connected' : 'expired' },
     });
     throw error;
   }

--- a/lib/platforms/x/repository.ts
+++ b/lib/platforms/x/repository.ts
@@ -119,10 +119,19 @@ export async function getValidXAccessToken(userId: string): Promise<string> {
     return decryptSecret(account.encryptedAccessToken, ACCESS_TOKEN_PURPOSE);
   }
   if (!account.encryptedRefreshToken) {
-    await client.platformAccount.update({
-      where: { id: account.id },
+    const update = await client.platformAccount.updateMany({
+      where: {
+        id: account.id,
+        status: 'connected',
+        encryptedAccessToken: account.encryptedAccessToken,
+        encryptedRefreshToken: null,
+        updatedAt: account.updatedAt,
+      },
       data: { status: 'expired' },
     });
+    if (update.count !== 1) {
+      throw new Error('X account changed while authorization expiry was recorded');
+    }
     throw new Error('X account authorization has expired; reconnect is required');
   }
 
@@ -169,20 +178,47 @@ export async function disconnectXAccount(userId: string): Promise<boolean> {
   const account = await client.platformAccount.findUnique({
     where: { userId_platform: { userId, platform: X_PLATFORM_ID } },
   });
-  if (!account || account.status === 'revoked') return false;
+  if (!account || account.status !== 'connected') return false;
 
-  const token = account.encryptedRefreshToken
-    ? decryptSecret(account.encryptedRefreshToken, REFRESH_TOKEN_PURPOSE)
-    : decryptSecret(account.encryptedAccessToken, ACCESS_TOKEN_PURPOSE);
-  await revokeXToken(token);
+  const claim = await client.platformAccount.updateMany({
+    where: {
+      id: account.id,
+      status: 'connected',
+      connectedAt: account.connectedAt,
+    },
+    data: { status: 'revoking' },
+  });
+  if (claim.count !== 1) return false;
+
+  const claimedAccount = await client.platformAccount.findUnique({ where: { id: account.id } });
+  if (!claimedAccount || claimedAccount.status !== 'revoking') return false;
+
+  const token = claimedAccount.encryptedRefreshToken
+    ? decryptSecret(claimedAccount.encryptedRefreshToken, REFRESH_TOKEN_PURPOSE)
+    : decryptSecret(claimedAccount.encryptedAccessToken, ACCESS_TOKEN_PURPOSE);
+  try {
+    await revokeXToken(token);
+  } catch (error) {
+    await client.platformAccount.updateMany({
+      where: {
+        id: claimedAccount.id,
+        status: 'revoking',
+        connectedAt: account.connectedAt,
+        encryptedAccessToken: claimedAccount.encryptedAccessToken,
+        encryptedRefreshToken: claimedAccount.encryptedRefreshToken,
+      },
+      data: { status: 'connected' },
+    });
+    throw error;
+  }
 
   const update = await client.platformAccount.updateMany({
     where: {
-      id: account.id,
-      status: account.status,
-      encryptedAccessToken: account.encryptedAccessToken,
-      encryptedRefreshToken: account.encryptedRefreshToken,
-      updatedAt: account.updatedAt,
+      id: claimedAccount.id,
+      status: 'revoking',
+      connectedAt: account.connectedAt,
+      encryptedAccessToken: claimedAccount.encryptedAccessToken,
+      encryptedRefreshToken: claimedAccount.encryptedRefreshToken,
     },
     data: {
       encryptedAccessToken: '',

--- a/lib/platforms/x/repository.ts
+++ b/lib/platforms/x/repository.ts
@@ -269,10 +269,11 @@ export async function getValidXAccessToken(userId: string): Promise<string> {
   try {
     tokens = await refreshAccessToken(currentRefreshToken);
   } catch (error) {
+    const definitiveAuthorizationError = isDefinitiveXAuthorizationError(error);
     const accessTokenMayStillBeLive = Boolean(
       account.expiresAt && account.expiresAt.getTime() > Date.now()
     );
-    const failureStatus = isDefinitiveXAuthorizationError(error)
+    const failureStatus = definitiveAuthorizationError
       ? accessTokenMayStillBeLive
         ? 'revocation_required'
         : 'expired'
@@ -284,7 +285,9 @@ export async function getValidXAccessToken(userId: string): Promise<string> {
         encryptedRefreshToken: account.encryptedRefreshToken,
         connectedAt: account.connectedAt,
       },
-      data: { status: failureStatus },
+      data: definitiveAuthorizationError
+        ? { status: failureStatus, encryptedRefreshToken: null }
+        : { status: failureStatus },
     });
     throw error;
   }

--- a/lib/platforms/x/repository.ts
+++ b/lib/platforms/x/repository.ts
@@ -348,7 +348,7 @@ export async function disconnectXAccount(userId: string): Promise<boolean> {
         encryptedAccessToken: claimedAccount.encryptedAccessToken,
         encryptedRefreshToken: claimedAccount.encryptedRefreshToken,
       },
-      data: { status: account.status === 'connected' ? 'connected' : 'expired' },
+      data: { status: account.status === 'connected' ? 'connected' : 'recovery_required' },
     });
     throw error;
   }

--- a/lib/platforms/x/repository.ts
+++ b/lib/platforms/x/repository.ts
@@ -1,0 +1,168 @@
+import type { PrismaClient } from '@prisma/client';
+import prisma from '@/lib/db/prisma';
+import { decryptSecret, encryptSecret } from './crypto';
+import { refreshAccessToken, revokeXToken, type XTokenResponse, X_PLATFORM_ID } from './oauth';
+
+const ACCESS_TOKEN_PURPOSE = 'x-access-token';
+const REFRESH_TOKEN_PURPOSE = 'x-refresh-token';
+const REFRESH_WINDOW_MS = 5 * 60 * 1000;
+
+function getClient(): PrismaClient {
+  if (!prisma) {
+    throw new Error('Platform account persistence is not configured');
+  }
+  return prisma;
+}
+
+export interface PlatformConnectionStatus {
+  platform: typeof X_PLATFORM_ID;
+  connected: boolean;
+  status: 'connected' | 'expired' | 'revoked';
+  username?: string;
+  scopes: string[];
+  expiresAt?: string;
+  connectedAt?: string;
+}
+
+function tokenExpiry(tokens: XTokenResponse): Date {
+  return new Date(Date.now() + tokens.expires_in * 1000);
+}
+
+export async function saveXAccount(
+  userId: string,
+  identity: { id: string; username: string },
+  tokens: XTokenResponse
+) {
+  return getClient().platformAccount.upsert({
+    where: { userId_platform: { userId, platform: X_PLATFORM_ID } },
+    create: {
+      userId,
+      platform: X_PLATFORM_ID,
+      providerAccountId: identity.id,
+      providerUsername: identity.username,
+      encryptedAccessToken: encryptSecret(tokens.access_token, ACCESS_TOKEN_PURPOSE),
+      encryptedRefreshToken: tokens.refresh_token
+        ? encryptSecret(tokens.refresh_token, REFRESH_TOKEN_PURPOSE)
+        : null,
+      tokenType: tokens.token_type.toLowerCase(),
+      scopes: tokens.scope,
+      expiresAt: tokenExpiry(tokens),
+      status: 'connected',
+    },
+    update: {
+      providerAccountId: identity.id,
+      providerUsername: identity.username,
+      encryptedAccessToken: encryptSecret(tokens.access_token, ACCESS_TOKEN_PURPOSE),
+      encryptedRefreshToken: tokens.refresh_token
+        ? encryptSecret(tokens.refresh_token, REFRESH_TOKEN_PURPOSE)
+        : null,
+      tokenType: tokens.token_type.toLowerCase(),
+      scopes: tokens.scope,
+      expiresAt: tokenExpiry(tokens),
+      status: 'connected',
+      connectedAt: new Date(),
+      refreshedAt: null,
+      revokedAt: null,
+    },
+  });
+}
+
+export async function getXConnectionStatus(userId: string): Promise<PlatformConnectionStatus> {
+  const account = await getClient().platformAccount.findUnique({
+    where: { userId_platform: { userId, platform: X_PLATFORM_ID } },
+    select: {
+      providerUsername: true,
+      scopes: true,
+      expiresAt: true,
+      status: true,
+      connectedAt: true,
+    },
+  });
+
+  if (!account || account.status === 'revoked') {
+    return { platform: X_PLATFORM_ID, connected: false, status: 'revoked', scopes: [] };
+  }
+
+  const expired = Boolean(account.expiresAt && account.expiresAt.getTime() <= Date.now());
+  const status = expired || account.status !== 'connected' ? 'expired' : 'connected';
+  return {
+    platform: X_PLATFORM_ID,
+    connected: status === 'connected',
+    status,
+    username: account.providerUsername || undefined,
+    scopes: account.scopes.split(' ').filter(Boolean),
+    expiresAt: account.expiresAt?.toISOString(),
+    connectedAt: account.connectedAt.toISOString(),
+  };
+}
+
+export async function getValidXAccessToken(userId: string): Promise<string> {
+  const client = getClient();
+  const account = await client.platformAccount.findUnique({
+    where: { userId_platform: { userId, platform: X_PLATFORM_ID } },
+  });
+  if (!account || account.status !== 'connected') {
+    throw new Error('X account is not connected');
+  }
+
+  if (!account.expiresAt || account.expiresAt.getTime() > Date.now() + REFRESH_WINDOW_MS) {
+    return decryptSecret(account.encryptedAccessToken, ACCESS_TOKEN_PURPOSE);
+  }
+  if (!account.encryptedRefreshToken) {
+    await client.platformAccount.update({
+      where: { id: account.id },
+      data: { status: 'expired' },
+    });
+    throw new Error('X account authorization has expired; reconnect is required');
+  }
+
+  const currentRefreshToken = decryptSecret(account.encryptedRefreshToken, REFRESH_TOKEN_PURPOSE);
+  try {
+    const tokens = await refreshAccessToken(currentRefreshToken);
+    await client.platformAccount.update({
+      where: { id: account.id },
+      data: {
+        encryptedAccessToken: encryptSecret(tokens.access_token, ACCESS_TOKEN_PURPOSE),
+        encryptedRefreshToken: tokens.refresh_token
+          ? encryptSecret(tokens.refresh_token, REFRESH_TOKEN_PURPOSE)
+          : account.encryptedRefreshToken,
+        tokenType: tokens.token_type.toLowerCase(),
+        scopes: tokens.scope,
+        expiresAt: tokenExpiry(tokens),
+        refreshedAt: new Date(),
+        status: 'connected',
+      },
+    });
+    return tokens.access_token;
+  } catch (error) {
+    await client.platformAccount.update({
+      where: { id: account.id },
+      data: { status: 'expired' },
+    });
+    throw error;
+  }
+}
+
+export async function disconnectXAccount(userId: string): Promise<boolean> {
+  const client = getClient();
+  const account = await client.platformAccount.findUnique({
+    where: { userId_platform: { userId, platform: X_PLATFORM_ID } },
+  });
+  if (!account || account.status === 'revoked') return false;
+
+  const token = account.encryptedRefreshToken
+    ? decryptSecret(account.encryptedRefreshToken, REFRESH_TOKEN_PURPOSE)
+    : decryptSecret(account.encryptedAccessToken, ACCESS_TOKEN_PURPOSE);
+  await revokeXToken(token);
+
+  await client.platformAccount.update({
+    where: { id: account.id },
+    data: {
+      encryptedAccessToken: '',
+      encryptedRefreshToken: null,
+      status: 'revoked',
+      revokedAt: new Date(),
+    },
+  });
+  return true;
+}

--- a/lib/platforms/x/repository.ts
+++ b/lib/platforms/x/repository.ts
@@ -127,10 +127,16 @@ export async function getValidXAccessToken(userId: string): Promise<string> {
   }
 
   const currentRefreshToken = decryptSecret(account.encryptedRefreshToken, REFRESH_TOKEN_PURPOSE);
+  const refreshGuard = {
+    id: account.id,
+    status: 'connected',
+    encryptedRefreshToken: account.encryptedRefreshToken,
+    updatedAt: account.updatedAt,
+  };
   try {
     const tokens = await refreshAccessToken(currentRefreshToken);
-    await client.platformAccount.update({
-      where: { id: account.id },
+    const update = await client.platformAccount.updateMany({
+      where: refreshGuard,
       data: {
         encryptedAccessToken: encryptSecret(tokens.access_token, ACCESS_TOKEN_PURPOSE),
         encryptedRefreshToken: tokens.refresh_token
@@ -143,11 +149,14 @@ export async function getValidXAccessToken(userId: string): Promise<string> {
         status: 'connected',
       },
     });
+    if (update.count !== 1) {
+      throw new Error('X account changed while authorization was refreshing');
+    }
     return tokens.access_token;
   } catch (error) {
     if (isDefinitiveXAuthorizationError(error)) {
-      await client.platformAccount.update({
-        where: { id: account.id },
+      await client.platformAccount.updateMany({
+        where: refreshGuard,
         data: { status: 'expired' },
       });
     }

--- a/lib/platforms/x/repository.ts
+++ b/lib/platforms/x/repository.ts
@@ -1,7 +1,13 @@
 import type { PrismaClient } from '@prisma/client';
 import prisma from '@/lib/db/prisma';
 import { decryptSecret, encryptSecret } from './crypto';
-import { refreshAccessToken, revokeXToken, type XTokenResponse, X_PLATFORM_ID } from './oauth';
+import {
+  isDefinitiveXAuthorizationError,
+  refreshAccessToken,
+  revokeXToken,
+  type XTokenResponse,
+  X_PLATFORM_ID,
+} from './oauth';
 
 const ACCESS_TOKEN_PURPOSE = 'x-access-token';
 const REFRESH_TOKEN_PURPOSE = 'x-refresh-token';
@@ -74,6 +80,7 @@ export async function getXConnectionStatus(userId: string): Promise<PlatformConn
       providerUsername: true,
       scopes: true,
       expiresAt: true,
+      encryptedRefreshToken: true,
       status: true,
       connectedAt: true,
     },
@@ -83,8 +90,11 @@ export async function getXConnectionStatus(userId: string): Promise<PlatformConn
     return { platform: X_PLATFORM_ID, connected: false, status: 'revoked', scopes: [] };
   }
 
-  const expired = Boolean(account.expiresAt && account.expiresAt.getTime() <= Date.now());
-  const status = expired || account.status !== 'connected' ? 'expired' : 'connected';
+  const accessTokenExpired = Boolean(
+    account.expiresAt && account.expiresAt.getTime() <= Date.now()
+  );
+  const authorizationExpired = accessTokenExpired && !account.encryptedRefreshToken;
+  const status = authorizationExpired || account.status !== 'connected' ? 'expired' : 'connected';
   return {
     platform: X_PLATFORM_ID,
     connected: status === 'connected',
@@ -135,10 +145,12 @@ export async function getValidXAccessToken(userId: string): Promise<string> {
     });
     return tokens.access_token;
   } catch (error) {
-    await client.platformAccount.update({
-      where: { id: account.id },
-      data: { status: 'expired' },
-    });
+    if (isDefinitiveXAuthorizationError(error)) {
+      await client.platformAccount.update({
+        where: { id: account.id },
+        data: { status: 'expired' },
+      });
+    }
     throw error;
   }
 }

--- a/lib/platforms/x/repository.ts
+++ b/lib/platforms/x/repository.ts
@@ -114,7 +114,11 @@ export async function saveXAccount(
   }
   const claim = await client.platformAccount.updateMany({
     where: { id: existing.id, status: existing.status, updatedAt: existing.updatedAt },
-    data: { status: 'reconnecting' },
+    data: {
+      status: 'reconnecting',
+      providerAccountId: identity.id,
+      providerUsername: identity.username,
+    },
   });
   if (claim.count !== 1) {
     throw new Error('X account authorization changed during reconnect');
@@ -135,11 +139,16 @@ export async function saveXAccount(
         where: {
           id: existing.id,
           status: 'reconnecting',
+          providerAccountId: identity.id,
           connectedAt: existing.connectedAt,
           encryptedAccessToken: existing.encryptedAccessToken,
           encryptedRefreshToken: existing.encryptedRefreshToken,
         },
-        data: { status: existing.status },
+        data: {
+          status: existing.status === 'connected' ? 'connected' : 'recovery_required',
+          providerAccountId: existing.providerAccountId,
+          providerUsername: existing.providerUsername,
+        },
       });
       throw error;
     }
@@ -149,6 +158,7 @@ export async function saveXAccount(
     where: {
       id: existing.id,
       status: 'reconnecting',
+      providerAccountId: identity.id,
       connectedAt: existing.connectedAt,
       encryptedAccessToken: existing.encryptedAccessToken,
       encryptedRefreshToken: existing.encryptedRefreshToken,

--- a/lib/platforms/x/repository.ts
+++ b/lib/platforms/x/repository.ts
@@ -176,8 +176,14 @@ export async function disconnectXAccount(userId: string): Promise<boolean> {
     : decryptSecret(account.encryptedAccessToken, ACCESS_TOKEN_PURPOSE);
   await revokeXToken(token);
 
-  await client.platformAccount.update({
-    where: { id: account.id },
+  const update = await client.platformAccount.updateMany({
+    where: {
+      id: account.id,
+      status: account.status,
+      encryptedAccessToken: account.encryptedAccessToken,
+      encryptedRefreshToken: account.encryptedRefreshToken,
+      updatedAt: account.updatedAt,
+    },
     data: {
       encryptedAccessToken: '',
       encryptedRefreshToken: null,
@@ -185,5 +191,5 @@ export async function disconnectXAccount(userId: string): Promise<boolean> {
       revokedAt: new Date(),
     },
   });
-  return true;
+  return update.count === 1;
 }

--- a/lib/platforms/x/repository.ts
+++ b/lib/platforms/x/repository.ts
@@ -94,7 +94,8 @@ export async function getXConnectionStatus(userId: string): Promise<PlatformConn
     account.expiresAt && account.expiresAt.getTime() <= Date.now()
   );
   const authorizationExpired = accessTokenExpired && !account.encryptedRefreshToken;
-  const status = authorizationExpired || account.status !== 'connected' ? 'expired' : 'connected';
+  const lifecycleConnected = account.status === 'connected' || account.status === 'refreshing';
+  const status = authorizationExpired || !lifecycleConnected ? 'expired' : 'connected';
   return {
     platform: X_PLATFORM_ID,
     connected: status === 'connected',
@@ -142,35 +143,55 @@ export async function getValidXAccessToken(userId: string): Promise<string> {
     encryptedRefreshToken: account.encryptedRefreshToken,
     updatedAt: account.updatedAt,
   };
+
+  const claim = await client.platformAccount.updateMany({
+    where: refreshGuard,
+    data: { status: 'refreshing' },
+  });
+  if (claim.count !== 1) {
+    throw new Error('X account changed before authorization could be refreshed');
+  }
+
+  let tokens: XTokenResponse;
   try {
-    const tokens = await refreshAccessToken(currentRefreshToken);
-    const update = await client.platformAccount.updateMany({
-      where: refreshGuard,
-      data: {
-        encryptedAccessToken: encryptSecret(tokens.access_token, ACCESS_TOKEN_PURPOSE),
-        encryptedRefreshToken: tokens.refresh_token
-          ? encryptSecret(tokens.refresh_token, REFRESH_TOKEN_PURPOSE)
-          : account.encryptedRefreshToken,
-        tokenType: tokens.token_type.toLowerCase(),
-        scopes: tokens.scope,
-        expiresAt: tokenExpiry(tokens),
-        refreshedAt: new Date(),
-        status: 'connected',
-      },
-    });
-    if (update.count !== 1) {
-      throw new Error('X account changed while authorization was refreshing');
-    }
-    return tokens.access_token;
+    tokens = await refreshAccessToken(currentRefreshToken);
   } catch (error) {
-    if (isDefinitiveXAuthorizationError(error)) {
-      await client.platformAccount.updateMany({
-        where: refreshGuard,
-        data: { status: 'expired' },
-      });
-    }
+    await client.platformAccount.updateMany({
+      where: {
+        id: account.id,
+        status: 'refreshing',
+        encryptedRefreshToken: account.encryptedRefreshToken,
+        connectedAt: account.connectedAt,
+      },
+      data: { status: isDefinitiveXAuthorizationError(error) ? 'expired' : 'connected' },
+    });
     throw error;
   }
+
+  const update = await client.platformAccount.updateMany({
+    where: {
+      id: account.id,
+      status: 'refreshing',
+      encryptedRefreshToken: account.encryptedRefreshToken,
+      connectedAt: account.connectedAt,
+    },
+    data: {
+      encryptedAccessToken: encryptSecret(tokens.access_token, ACCESS_TOKEN_PURPOSE),
+      encryptedRefreshToken: tokens.refresh_token
+        ? encryptSecret(tokens.refresh_token, REFRESH_TOKEN_PURPOSE)
+        : account.encryptedRefreshToken,
+      tokenType: tokens.token_type.toLowerCase(),
+      scopes: tokens.scope,
+      expiresAt: tokenExpiry(tokens),
+      refreshedAt: new Date(),
+      status: 'connected',
+    },
+  });
+  if (update.count !== 1) {
+    await revokeXToken(tokens.refresh_token ?? tokens.access_token);
+    throw new Error('X account changed while authorization was refreshing');
+  }
+  return tokens.access_token;
 }
 
 export async function disconnectXAccount(userId: string): Promise<boolean> {
@@ -178,7 +199,27 @@ export async function disconnectXAccount(userId: string): Promise<boolean> {
   const account = await client.platformAccount.findUnique({
     where: { userId_platform: { userId, platform: X_PLATFORM_ID } },
   });
-  if (!account || account.status !== 'connected') return false;
+  if (!account || account.status === 'revoked') return false;
+
+  if (account.status === 'expired') {
+    const update = await client.platformAccount.updateMany({
+      where: {
+        id: account.id,
+        status: 'expired',
+        encryptedAccessToken: account.encryptedAccessToken,
+        encryptedRefreshToken: account.encryptedRefreshToken,
+        updatedAt: account.updatedAt,
+      },
+      data: {
+        encryptedAccessToken: '',
+        encryptedRefreshToken: null,
+        status: 'revoked',
+        revokedAt: new Date(),
+      },
+    });
+    return update.count === 1;
+  }
+  if (account.status !== 'connected') return false;
 
   const claim = await client.platformAccount.updateMany({
     where: {

--- a/lib/platforms/x/repository.ts
+++ b/lib/platforms/x/repository.ts
@@ -314,8 +314,27 @@ export async function disconnectXAccount(userId: string): Promise<boolean> {
   });
   if (!account || account.status === 'revoked') return false;
 
+  if (account.status === 'expired') {
+    const update = await client.platformAccount.updateMany({
+      where: {
+        id: account.id,
+        status: 'expired',
+        encryptedAccessToken: account.encryptedAccessToken,
+        encryptedRefreshToken: account.encryptedRefreshToken,
+        updatedAt: account.updatedAt,
+      },
+      data: {
+        encryptedAccessToken: '',
+        encryptedRefreshToken: null,
+        status: 'revoked',
+        revokedAt: new Date(),
+      },
+    });
+    return update.count === 1;
+  }
+
   const activeClaim = ['refreshing', 'revoking', 'reconnecting'].includes(account.status);
-  const recoveryRequired = account.status === 'recovery_required' || account.status === 'expired';
+  const recoveryRequired = account.status === 'recovery_required';
   const revocationRequired = account.status === 'revocation_required';
   if (activeClaim && !lifecycleClaimIsStale(account.updatedAt)) return false;
   if (account.status !== 'connected' && !activeClaim && !recoveryRequired && !revocationRequired)
@@ -348,12 +367,7 @@ export async function disconnectXAccount(userId: string): Promise<boolean> {
         encryptedRefreshToken: claimedAccount.encryptedRefreshToken,
       },
       data: {
-        status:
-          account.status === 'connected'
-            ? 'connected'
-            : account.status === 'expired'
-              ? 'expired'
-              : 'recovery_required',
+        status: account.status === 'connected' ? 'connected' : 'recovery_required',
       },
     });
     throw error;

--- a/lib/platforms/x/repository.ts
+++ b/lib/platforms/x/repository.ts
@@ -13,8 +13,8 @@ const ACCESS_TOKEN_PURPOSE = 'x-access-token';
 const REFRESH_TOKEN_PURPOSE = 'x-refresh-token';
 const REFRESH_WINDOW_MS = 5 * 60 * 1000;
 const LIFECYCLE_CLAIM_TTL_MS = 2 * 60 * 1000;
-const REFRESH_CONTENDER_ATTEMPTS = 20;
-const REFRESH_CONTENDER_DELAY_MS = 100;
+const REFRESH_CONTENDER_ATTEMPTS = 80;
+const REFRESH_CONTENDER_DELAY_MS = 250;
 
 function getClient(): PrismaClient {
   if (!prisma) {
@@ -64,9 +64,9 @@ async function waitForWinningRefresh(client: PrismaClient, userId: string): Prom
     if (lifecycleClaimIsStale(account.updatedAt)) {
       await client.platformAccount.updateMany({
         where: { id: account.id, status: 'refreshing', updatedAt: account.updatedAt },
-        data: { status: 'expired' },
+        data: { status: 'recovery_required' },
       });
-      throw new Error('X account refresh was interrupted; reconnect is required');
+      throw new Error('X account refresh was interrupted; authorization recovery is required');
     }
     await wait(REFRESH_CONTENDER_DELAY_MS);
   }
@@ -107,8 +107,9 @@ export async function saveXAccount(
     });
   }
 
-  const busy = ['refreshing', 'revoking', 'reconnecting'].includes(existing.status);
-  if (busy && !lifecycleClaimIsStale(existing.updatedAt)) {
+  const activeClaim = ['refreshing', 'revoking', 'reconnecting'].includes(existing.status);
+  const recoveryRequired = existing.status === 'recovery_required';
+  if (activeClaim && !lifecycleClaimIsStale(existing.updatedAt)) {
     throw new Error('X account authorization is currently changing');
   }
   const claim = await client.platformAccount.updateMany({
@@ -124,7 +125,8 @@ export async function saveXAccount(
     : existing.encryptedAccessToken
       ? decryptSecret(existing.encryptedAccessToken, ACCESS_TOKEN_PURPOSE)
       : null;
-  const displacedAuthorizationMayBeLive = existing.status === 'connected';
+  const displacedAuthorizationMayBeLive =
+    existing.status === 'connected' || activeClaim || recoveryRequired;
   if (displacedToken && displacedAuthorizationMayBeLive) {
     try {
       await revokeXToken(displacedToken);
@@ -315,9 +317,10 @@ export async function disconnectXAccount(userId: string): Promise<boolean> {
     });
     return update.count === 1;
   }
-  const busy = ['refreshing', 'revoking', 'reconnecting'].includes(account.status);
-  if (busy && !lifecycleClaimIsStale(account.updatedAt)) return false;
-  if (account.status !== 'connected' && !busy) return false;
+  const activeClaim = ['refreshing', 'revoking', 'reconnecting'].includes(account.status);
+  const recoveryRequired = account.status === 'recovery_required';
+  if (activeClaim && !lifecycleClaimIsStale(account.updatedAt)) return false;
+  if (account.status !== 'connected' && !activeClaim && !recoveryRequired) return false;
 
   const claim = await client.platformAccount.updateMany({
     where:

--- a/lib/platforms/x/repository.ts
+++ b/lib/platforms/x/repository.ts
@@ -109,6 +109,7 @@ export async function saveXAccount(
 
   const activeClaim = ['refreshing', 'revoking', 'reconnecting'].includes(existing.status);
   const recoveryRequired = existing.status === 'recovery_required';
+  const revocationRequired = existing.status === 'revocation_required';
   if (activeClaim && !lifecycleClaimIsStale(existing.updatedAt)) {
     throw new Error('X account authorization is currently changing');
   }
@@ -130,7 +131,7 @@ export async function saveXAccount(
       ? decryptSecret(existing.encryptedAccessToken, ACCESS_TOKEN_PURPOSE)
       : null;
   const displacedAuthorizationMayBeLive =
-    existing.status === 'connected' || activeClaim || recoveryRequired;
+    existing.status === 'connected' || activeClaim || recoveryRequired || revocationRequired;
   if (displacedToken && displacedAuthorizationMayBeLive) {
     try {
       await revokeXToken(displacedToken);
@@ -228,6 +229,10 @@ export async function getValidXAccessToken(userId: string): Promise<string> {
     return decryptSecret(account.encryptedAccessToken, ACCESS_TOKEN_PURPOSE);
   }
   if (!account.encryptedRefreshToken) {
+    const status =
+      account.expiresAt && account.expiresAt.getTime() > Date.now()
+        ? 'revocation_required'
+        : 'expired';
     const update = await client.platformAccount.updateMany({
       where: {
         id: account.id,
@@ -236,7 +241,7 @@ export async function getValidXAccessToken(userId: string): Promise<string> {
         encryptedRefreshToken: null,
         updatedAt: account.updatedAt,
       },
-      data: { status: 'expired' },
+      data: { status },
     });
     if (update.count !== 1) {
       throw new Error('X account changed while authorization expiry was recorded');
@@ -309,28 +314,12 @@ export async function disconnectXAccount(userId: string): Promise<boolean> {
   });
   if (!account || account.status === 'revoked') return false;
 
-  if (account.status === 'expired') {
-    const update = await client.platformAccount.updateMany({
-      where: {
-        id: account.id,
-        status: 'expired',
-        encryptedAccessToken: account.encryptedAccessToken,
-        encryptedRefreshToken: account.encryptedRefreshToken,
-        updatedAt: account.updatedAt,
-      },
-      data: {
-        encryptedAccessToken: '',
-        encryptedRefreshToken: null,
-        status: 'revoked',
-        revokedAt: new Date(),
-      },
-    });
-    return update.count === 1;
-  }
   const activeClaim = ['refreshing', 'revoking', 'reconnecting'].includes(account.status);
-  const recoveryRequired = account.status === 'recovery_required';
+  const recoveryRequired = account.status === 'recovery_required' || account.status === 'expired';
+  const revocationRequired = account.status === 'revocation_required';
   if (activeClaim && !lifecycleClaimIsStale(account.updatedAt)) return false;
-  if (account.status !== 'connected' && !activeClaim && !recoveryRequired) return false;
+  if (account.status !== 'connected' && !activeClaim && !recoveryRequired && !revocationRequired)
+    return false;
 
   const claim = await client.platformAccount.updateMany({
     where:
@@ -358,7 +347,14 @@ export async function disconnectXAccount(userId: string): Promise<boolean> {
         encryptedAccessToken: claimedAccount.encryptedAccessToken,
         encryptedRefreshToken: claimedAccount.encryptedRefreshToken,
       },
-      data: { status: account.status === 'connected' ? 'connected' : 'recovery_required' },
+      data: {
+        status:
+          account.status === 'connected'
+            ? 'connected'
+            : account.status === 'expired'
+              ? 'expired'
+              : 'recovery_required',
+      },
     });
     throw error;
   }

--- a/lib/platforms/x/repository.ts
+++ b/lib/platforms/x/repository.ts
@@ -269,6 +269,14 @@ export async function getValidXAccessToken(userId: string): Promise<string> {
   try {
     tokens = await refreshAccessToken(currentRefreshToken);
   } catch (error) {
+    const accessTokenMayStillBeLive = Boolean(
+      account.expiresAt && account.expiresAt.getTime() > Date.now()
+    );
+    const failureStatus = isDefinitiveXAuthorizationError(error)
+      ? accessTokenMayStillBeLive
+        ? 'revocation_required'
+        : 'expired'
+      : 'connected';
     await client.platformAccount.updateMany({
       where: {
         id: account.id,
@@ -276,7 +284,7 @@ export async function getValidXAccessToken(userId: string): Promise<string> {
         encryptedRefreshToken: account.encryptedRefreshToken,
         connectedAt: account.connectedAt,
       },
-      data: { status: isDefinitiveXAuthorizationError(error) ? 'expired' : 'connected' },
+      data: { status: failureStatus },
     });
     throw error;
   }

--- a/prisma/migrations/20260725173500_platform_account_oauth/migration.sql
+++ b/prisma/migrations/20260725173500_platform_account_oauth/migration.sql
@@ -1,0 +1,34 @@
+-- Persist tenant-owned OAuth credentials encrypted by the application.
+CREATE TABLE "PlatformAccount" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "platform" TEXT NOT NULL,
+    "providerAccountId" TEXT NOT NULL,
+    "providerUsername" TEXT,
+    "encryptedAccessToken" TEXT NOT NULL,
+    "encryptedRefreshToken" TEXT,
+    "tokenType" TEXT NOT NULL DEFAULT 'bearer',
+    "scopes" TEXT NOT NULL,
+    "expiresAt" TIMESTAMP(3),
+    "status" TEXT NOT NULL DEFAULT 'connected',
+    "connectedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "refreshedAt" TIMESTAMP(3),
+    "revokedAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    CONSTRAINT "PlatformAccount_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "PlatformAccount_userId_platform_key"
+    ON "PlatformAccount"("userId", "platform");
+CREATE UNIQUE INDEX "PlatformAccount_platform_providerAccountId_key"
+    ON "PlatformAccount"("platform", "providerAccountId");
+CREATE INDEX "PlatformAccount_userId_status_idx"
+    ON "PlatformAccount"("userId", "status");
+CREATE INDEX "PlatformAccount_platform_status_idx"
+    ON "PlatformAccount"("platform", "status");
+
+ALTER TABLE "PlatformAccount"
+    ADD CONSTRAINT "PlatformAccount_userId_fkey"
+    FOREIGN KEY ("userId") REFERENCES "User"("id")
+    ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -27,8 +27,37 @@ model User {
   updatedAt    DateTime @updatedAt
 
   // Relations
-  campaigns Campaign[]
-  auditLogs AuditLog[]
+  campaigns        Campaign[]
+  auditLogs        AuditLog[]
+  platformAccounts PlatformAccount[]
+}
+
+// Tenant-owned provider credentials. Token values are encrypted by the
+// application before they reach PostgreSQL and are never returned by APIs.
+model PlatformAccount {
+  id                    String    @id @default(cuid())
+  userId                String
+  platform              String
+  providerAccountId     String
+  providerUsername      String?
+  encryptedAccessToken  String
+  encryptedRefreshToken String?
+  tokenType             String    @default("bearer")
+  scopes                String
+  expiresAt             DateTime?
+  status                String    @default("connected")
+  connectedAt           DateTime  @default(now())
+  refreshedAt           DateTime?
+  revokedAt             DateTime?
+  createdAt             DateTime  @default(now())
+  updatedAt             DateTime  @updatedAt
+
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@unique([userId, platform])
+  @@unique([platform, providerAccountId])
+  @@index([userId, status])
+  @@index([platform, status])
 }
 
 // Campaign model for content campaigns

--- a/proxy.ts
+++ b/proxy.ts
@@ -20,6 +20,10 @@ const authenticatedPaths = [
   '/api/scheduler',
 ];
 
+// Provider callbacks cannot carry the browser's Authorization header. These
+// exact routes enforce their own sealed, expiring OAuth state boundary.
+const authenticationExemptPaths = ['/api/platforms/x/callback'];
+
 // Define paths that require admin authentication
 const adminPaths = ['/api/feature-flags', '/api/audit'];
 
@@ -92,6 +96,9 @@ function verifyToken(token: string): jwt.JwtPayload | null {
  * Check if path requires authentication
  */
 function requiresAuthentication(pathname: string): { auth: boolean; admin: boolean } {
+  if (authenticationExemptPaths.includes(pathname)) {
+    return { auth: false, admin: false };
+  }
   const requiresAdmin = adminPaths.some(path => pathname.startsWith(path));
   const requiresAuth = authenticatedPaths.some(path => pathname.startsWith(path)) || requiresAdmin;
 


### PR DESCRIPTION
## Summary

- replace the platform-settings mock API-key flow with X OAuth 2.0 Authorization Code + S256 PKCE
- persist tenant-owned X accounts and AES-256-GCM-encrypted access/refresh tokens in PostgreSQL
- add refresh, expiry, revoke, reconnect, token-free status, and exact callback proxy handling
- provision a generated 32-byte encryption key through Key Vault as a custom App Service connection string
- document local and Azure configuration while retaining the legacy static token only until Gate 3 C2 wires the scheduler

## Security boundary

The browser never receives or stores X tokens. Connect initiation requires the existing authenticated API boundary; the provider callback is exempted from JWT middleware only at the exact callback path and must validate a sealed, expiring, purpose-bound state/PKCE cookie. Production callbacks must use HTTPS. Revocation must succeed at X before stored credentials are erased.

## Validation

- `pnpm run marketing:validate`
- `pnpm run type-check`
- repository lint: 0 errors, 120 pre-existing warnings
- Windows-safe repository Prettier check with `--end-of-line auto`
- `pnpm exec jest --runInBand --silent`: 35 suites / 255 tests passed; 1 PostgreSQL integration test skipped locally because Docker is unavailable
- `pnpm run build`
- `terraform fmt -check -diff infra/terraform/env/dev`
- `terraform -chdir=infra/terraform/env/dev validate`

## Deployment boundary

Do not claim the production OAuth smoke yet. It still requires an authorized X app/account, exact callback registration, `X_CLIENT_ID`, an approved Key Vault-backed `X_CLIENT_SECRET` when the app is confidential, and X API credits. GitHub CI/Terraform should provide the PostgreSQL migration and protected-variable plan proof before this draft is marked ready.