### PR TITLE
feat(scheduler): persist jobs with durable leases

### DIFF
--- a/__tests__/api/scheduler-routes.test.ts
+++ b/__tests__/api/scheduler-routes.test.ts
@@ -6,6 +6,7 @@
  */
 
 import { beforeEach, describe, expect, jest, test } from '@jest/globals';
+import { SchedulerQueueError } from '../../lib/scheduler/prisma-queue';
 import '../setup';
 
 // Mock audit trail
@@ -191,6 +192,30 @@ describe('Scheduler API Routes', () => {
       expect(response.status).toBe(400);
       expect(data.message).toContain('Invalid input');
       expect(mockSchedule).not.toHaveBeenCalled();
+    });
+
+    test('rejects an idempotency key reused for a different request', async () => {
+      mockSchedule.mockRejectedValueOnce(
+        new SchedulerQueueError(
+          'IDEMPOTENCY_CONFLICT',
+          'Idempotency key belongs to another request'
+        )
+      );
+
+      const response = await POST(
+        createRequest('POST', {
+          type: 'standalone',
+          contentId: 'content-1',
+          platformId: 'twitter',
+          content: { text: 'Hello world from scheduler test' },
+          scheduledTime: '2026-04-01T12:00:00Z',
+          idempotencyKey: 'request-key-123',
+        })
+      );
+      const data = await response.json();
+
+      expect(response.status).toBe(409);
+      expect(data.message).toContain('Idempotency key');
     });
 
     test('binds a campaign post to its approved immutable version', async () => {

--- a/__tests__/api/scheduler-routes.test.ts
+++ b/__tests__/api/scheduler-routes.test.ts
@@ -6,7 +6,17 @@
  */
 
 import { beforeEach, describe, expect, jest, test } from '@jest/globals';
-import { SchedulerQueueError } from '../../lib/scheduler/prisma-queue';
+import type {
+  CreateJobInput,
+  ListJobsOptions,
+  ListJobsResult,
+  ScheduleJobResult,
+  ScheduledJob,
+} from '../../lib/scheduler/types';
+import {
+  type CampaignPublishAuditInput,
+  SchedulerQueueError,
+} from '../../lib/scheduler/prisma-queue';
 import '../setup';
 
 // Mock audit trail
@@ -16,12 +26,12 @@ jest.mock('../../app/api/_utils/audit', () => ({
 }));
 
 // Mock scheduler module
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const mockSchedule = jest.fn<any>();
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const mockScheduleCampaign = jest.fn<any>();
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const mockListJobs = jest.fn<any>();
+const mockSchedule = jest.fn<(input: CreateJobInput) => Promise<ScheduleJobResult>>();
+const mockScheduleCampaign =
+  jest.fn<
+    (input: CreateJobInput, audit: CampaignPublishAuditInput) => Promise<ScheduleJobResult>
+  >();
+const mockListJobs = jest.fn<(options: ListJobsOptions) => Promise<ListJobsResult>>();
 const mockAssertApprovedForQueue = jest.fn<
   () => Promise<{
     campaignRowId: string;
@@ -72,15 +82,21 @@ function createRequest(
   } as unknown as Request;
 }
 
-const sampleJob = {
+const sampleJob: ScheduledJob = {
   id: 'job-1',
+  idempotencyKey: 'scheduler-route-key',
+  requestFingerprint: 'scheduler-route-fingerprint',
   type: 'standalone',
   contentId: 'content-1',
   platformId: 'twitter',
   content: { text: 'Hello world' },
   scheduledTime: '2026-04-01T12:00:00Z',
   timezone: 'UTC',
-  status: 'pending',
+  status: 'scheduled',
+  attempts: 0,
+  maxAttempts: 5,
+  createdAt: '2026-04-01T11:00:00Z',
+  updatedAt: '2026-04-01T11:00:00Z',
   createdBy: '1', // Matches the mock x-user-id from setup.ts
 };
 

--- a/__tests__/api/scheduler-routes.test.ts
+++ b/__tests__/api/scheduler-routes.test.ts
@@ -24,6 +24,7 @@ const mockScheduleCampaign = jest.fn<any>();
 const mockListJobs = jest.fn<any>();
 const mockAssertApprovedForQueue = jest.fn<
   () => Promise<{
+    campaignRowId: string;
     versionId: string;
     contentHash: string;
     content: { text: string; mediaUrls?: string[]; hashtags?: string[]; mentions?: string[] };
@@ -92,6 +93,7 @@ describe('Scheduler API Routes', () => {
     mockSchedule.mockResolvedValue({ job: sampleJob, created: true });
     mockScheduleCampaign.mockResolvedValue({ job: sampleJob, created: true });
     mockAssertApprovedForQueue.mockResolvedValue({
+      campaignRowId: 'campaign-row-1',
       versionId: 'version-1',
       contentHash: `sha256:${'a'.repeat(64)}`,
       content: {
@@ -274,7 +276,7 @@ describe('Scheduler API Routes', () => {
           },
         }),
         expect.objectContaining({
-          campaignId: 'campaign-1',
+          campaignId: 'campaign-row-1',
           campaignVersionId: 'version-1',
           variantId: 'variant-1',
         })

--- a/__tests__/api/scheduler-routes.test.ts
+++ b/__tests__/api/scheduler-routes.test.ts
@@ -19,6 +19,8 @@ jest.mock('../../app/api/_utils/audit', () => ({
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const mockSchedule = jest.fn<any>();
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
+const mockScheduleCampaign = jest.fn<any>();
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 const mockGetAllJobs = jest.fn<any>();
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const mockGetJobsByStatus = jest.fn<any>();
@@ -31,11 +33,8 @@ const mockAssertApprovedForQueue = jest.fn<
     content: { text: string; mediaUrls?: string[]; hashtags?: string[]; mentions?: string[] };
   }>
 >();
-const mockRecordPublishAttempt = jest.fn<() => Promise<{ id: string }>>();
-
 jest.mock('../../lib/campaigns/repository', () => ({
   assertApprovedForQueue: mockAssertApprovedForQueue,
-  recordPublishAttempt: mockRecordPublishAttempt,
 }));
 
 // Mock the sanitize module
@@ -97,6 +96,7 @@ describe('Scheduler API Routes', () => {
     mockGetJobsByStatus.mockResolvedValue([sampleJob]);
     mockGetJobsByCampaign.mockResolvedValue([sampleJob]);
     mockSchedule.mockResolvedValue({ job: sampleJob, created: true });
+    mockScheduleCampaign.mockResolvedValue({ job: sampleJob, created: true });
     mockAssertApprovedForQueue.mockResolvedValue({
       versionId: 'version-1',
       contentHash: `sha256:${'a'.repeat(64)}`,
@@ -105,12 +105,12 @@ describe('Scheduler API Routes', () => {
         hashtags: ['approved'],
       },
     });
-    mockRecordPublishAttempt.mockResolvedValue({ id: 'attempt-1' });
 
     // Mock the scheduler before importing the route
     jest.doMock('../../lib/scheduler', () => ({
       getScheduler: () => ({
         scheduleWithResult: mockSchedule,
+        scheduleCampaignWithAudit: mockScheduleCampaign,
         cancel: jest.fn(),
         getAllJobs: mockGetAllJobs,
         getJobsByStatus: mockGetJobsByStatus,
@@ -244,14 +244,7 @@ describe('Scheduler API Routes', () => {
           platformId: 'twitter',
         })
       );
-      expect(mockRecordPublishAttempt).toHaveBeenCalledWith(
-        expect.objectContaining({
-          campaignId: 'campaign-1',
-          variantId: 'variant-1',
-          schedulerJobId: sampleJob.id,
-        })
-      );
-      expect(mockSchedule).toHaveBeenCalledWith(
+      expect(mockScheduleCampaign).toHaveBeenCalledWith(
         expect.objectContaining({
           campaignVersionId: 'version-1',
           approvedContentHash: contentHash,
@@ -259,12 +252,17 @@ describe('Scheduler API Routes', () => {
             text: 'Approved campaign post',
             hashtags: ['approved'],
           },
+        }),
+        expect.objectContaining({
+          campaignId: 'campaign-1',
+          campaignVersionId: 'version-1',
+          variantId: 'variant-1',
         })
       );
     });
 
     test('replays an idempotent campaign request without duplicating its audit attempt', async () => {
-      mockSchedule.mockResolvedValueOnce({ job: sampleJob, created: false });
+      mockScheduleCampaign.mockResolvedValueOnce({ job: sampleJob, created: false });
       const contentHash = `sha256:${'a'.repeat(64)}`;
       const response = await POST(
         createRequest('POST', {
@@ -282,10 +280,7 @@ describe('Scheduler API Routes', () => {
       );
 
       expect(response.status).toBe(200);
-      expect(mockRecordPublishAttempt).toHaveBeenCalledTimes(1);
-      expect(mockRecordPublishAttempt).toHaveBeenCalledWith(
-        expect.objectContaining({ schedulerJobId: sampleJob.id })
-      );
+      expect(mockScheduleCampaign).toHaveBeenCalledTimes(1);
     });
 
     test('rejects a campaign post without immutable approval fields', async () => {

--- a/__tests__/api/scheduler-routes.test.ts
+++ b/__tests__/api/scheduler-routes.test.ts
@@ -27,6 +27,8 @@ jest.mock('../../app/api/_utils/audit', () => ({
 
 // Mock scheduler module
 const mockSchedule = jest.fn<(input: CreateJobInput) => Promise<ScheduleJobResult>>();
+const mockFindIdempotentReplay =
+  jest.fn<(input: CreateJobInput) => Promise<ScheduleJobResult | null>>();
 const mockScheduleCampaign =
   jest.fn<
     (input: CreateJobInput, audit: CampaignPublishAuditInput) => Promise<ScheduleJobResult>
@@ -107,6 +109,7 @@ describe('Scheduler API Routes', () => {
 
     mockListJobs.mockResolvedValue({ jobs: [sampleJob], total: 1 });
     mockSchedule.mockResolvedValue({ job: sampleJob, created: true });
+    mockFindIdempotentReplay.mockResolvedValue(null);
     mockScheduleCampaign.mockResolvedValue({ job: sampleJob, created: true });
     mockAssertApprovedForQueue.mockResolvedValue({
       campaignRowId: 'campaign-row-1',
@@ -122,6 +125,7 @@ describe('Scheduler API Routes', () => {
     jest.doMock('../../lib/scheduler', () => ({
       getScheduler: () => ({
         scheduleWithResult: mockSchedule,
+        findIdempotentReplay: mockFindIdempotentReplay,
         scheduleCampaignWithAudit: mockScheduleCampaign,
         cancel: jest.fn(),
         listJobs: mockListJobs,
@@ -300,7 +304,7 @@ describe('Scheduler API Routes', () => {
     });
 
     test('replays an idempotent campaign request without duplicating its audit attempt', async () => {
-      mockScheduleCampaign.mockResolvedValueOnce({ job: sampleJob, created: false });
+      mockFindIdempotentReplay.mockResolvedValueOnce({ job: sampleJob, created: false });
       const contentHash = `sha256:${'a'.repeat(64)}`;
       const response = await POST(
         createRequest('POST', {
@@ -318,7 +322,33 @@ describe('Scheduler API Routes', () => {
       );
 
       expect(response.status).toBe(200);
-      expect(mockScheduleCampaign).toHaveBeenCalledTimes(1);
+      expect(mockFindIdempotentReplay).toHaveBeenCalledTimes(1);
+      expect(mockAssertApprovedForQueue).not.toHaveBeenCalled();
+      expect(mockScheduleCampaign).not.toHaveBeenCalled();
+    });
+
+    test('rejects a changed campaign replay before approval validation', async () => {
+      mockFindIdempotentReplay.mockRejectedValueOnce(
+        new SchedulerQueueError('IDEMPOTENCY_CONFLICT', 'Different request')
+      );
+      const response = await POST(
+        createRequest('POST', {
+          type: 'campaign_post',
+          campaignId: 'campaign-1',
+          campaignVersion: 2,
+          contentHash: `sha256:${'a'.repeat(64)}`,
+          variantId: 'variant-1',
+          contentId: 'content-1',
+          platformId: 'twitter',
+          content: { text: 'Changed campaign request' },
+          scheduledTime: '2026-04-01T12:00:00Z',
+          idempotencyKey: 'campaign-request-123',
+        })
+      );
+
+      expect(response.status).toBe(409);
+      expect(mockAssertApprovedForQueue).not.toHaveBeenCalled();
+      expect(mockScheduleCampaign).not.toHaveBeenCalled();
     });
 
     test('rejects a campaign post without immutable approval fields', async () => {

--- a/__tests__/api/scheduler-routes.test.ts
+++ b/__tests__/api/scheduler-routes.test.ts
@@ -219,6 +219,27 @@ describe('Scheduler API Routes', () => {
       expect(data.message).toContain('Idempotency key');
     });
 
+    test('does not misreport a corrupt durable row as an idempotency conflict', async () => {
+      mockSchedule.mockRejectedValueOnce(
+        new SchedulerQueueError('CORRUPT_JOB', 'Stored scheduler content is invalid')
+      );
+
+      const response = await POST(
+        createRequest('POST', {
+          type: 'standalone',
+          contentId: 'content-1',
+          platformId: 'twitter',
+          content: { text: 'Hello world from scheduler test' },
+          scheduledTime: '2026-04-01T12:00:00Z',
+          idempotencyKey: 'request-key-123',
+        })
+      );
+      const data = await response.json();
+
+      expect(response.status).toBe(500);
+      expect(data.message).not.toContain('Idempotency key');
+    });
+
     test('binds a campaign post to its approved immutable version', async () => {
       const contentHash = `sha256:${'a'.repeat(64)}`;
       const request = createRequest('POST', {

--- a/__tests__/api/scheduler-routes.test.ts
+++ b/__tests__/api/scheduler-routes.test.ts
@@ -21,11 +21,7 @@ const mockSchedule = jest.fn<any>();
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const mockScheduleCampaign = jest.fn<any>();
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-const mockGetAllJobs = jest.fn<any>();
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const mockGetJobsByStatus = jest.fn<any>();
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const mockGetJobsByCampaign = jest.fn<any>();
+const mockListJobs = jest.fn<any>();
 const mockAssertApprovedForQueue = jest.fn<
   () => Promise<{
     versionId: string;
@@ -92,9 +88,7 @@ describe('Scheduler API Routes', () => {
     jest.clearAllMocks();
     jest.resetModules();
 
-    mockGetAllJobs.mockResolvedValue([sampleJob]);
-    mockGetJobsByStatus.mockResolvedValue([sampleJob]);
-    mockGetJobsByCampaign.mockResolvedValue([sampleJob]);
+    mockListJobs.mockResolvedValue({ jobs: [sampleJob], total: 1 });
     mockSchedule.mockResolvedValue({ job: sampleJob, created: true });
     mockScheduleCampaign.mockResolvedValue({ job: sampleJob, created: true });
     mockAssertApprovedForQueue.mockResolvedValue({
@@ -112,9 +106,7 @@ describe('Scheduler API Routes', () => {
         scheduleWithResult: mockSchedule,
         scheduleCampaignWithAudit: mockScheduleCampaign,
         cancel: jest.fn(),
-        getAllJobs: mockGetAllJobs,
-        getJobsByStatus: mockGetJobsByStatus,
-        getJobsByCampaign: mockGetJobsByCampaign,
+        listJobs: mockListJobs,
       }),
     }));
 
@@ -149,6 +141,13 @@ describe('Scheduler API Routes', () => {
       expect(Array.isArray(data.jobs)).toBe(true);
       expect(data.count).toBeDefined();
       expect(data.total).toBeDefined();
+      expect(mockListJobs).toHaveBeenCalledWith({
+        userId: '1',
+        status: undefined,
+        campaignId: undefined,
+        limit: 100,
+        offset: 0,
+      });
     });
   });
 

--- a/__tests__/api/scheduler-routes.test.ts
+++ b/__tests__/api/scheduler-routes.test.ts
@@ -96,7 +96,7 @@ describe('Scheduler API Routes', () => {
     mockGetAllJobs.mockResolvedValue([sampleJob]);
     mockGetJobsByStatus.mockResolvedValue([sampleJob]);
     mockGetJobsByCampaign.mockResolvedValue([sampleJob]);
-    mockSchedule.mockResolvedValue(sampleJob);
+    mockSchedule.mockResolvedValue({ job: sampleJob, created: true });
     mockAssertApprovedForQueue.mockResolvedValue({
       versionId: 'version-1',
       contentHash: `sha256:${'a'.repeat(64)}`,
@@ -110,7 +110,8 @@ describe('Scheduler API Routes', () => {
     // Mock the scheduler before importing the route
     jest.doMock('../../lib/scheduler', () => ({
       getScheduler: () => ({
-        schedule: mockSchedule,
+        scheduleWithResult: mockSchedule,
+        cancel: jest.fn(),
         getAllJobs: mockGetAllJobs,
         getJobsByStatus: mockGetJobsByStatus,
         getJobsByCampaign: mockGetJobsByCampaign,
@@ -244,7 +245,11 @@ describe('Scheduler API Routes', () => {
         })
       );
       expect(mockRecordPublishAttempt).toHaveBeenCalledWith(
-        expect.objectContaining({ campaignId: 'campaign-1', variantId: 'variant-1' })
+        expect.objectContaining({
+          campaignId: 'campaign-1',
+          variantId: 'variant-1',
+          schedulerJobId: sampleJob.id,
+        })
       );
       expect(mockSchedule).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -255,6 +260,31 @@ describe('Scheduler API Routes', () => {
             hashtags: ['approved'],
           },
         })
+      );
+    });
+
+    test('replays an idempotent campaign request without duplicating its audit attempt', async () => {
+      mockSchedule.mockResolvedValueOnce({ job: sampleJob, created: false });
+      const contentHash = `sha256:${'a'.repeat(64)}`;
+      const response = await POST(
+        createRequest('POST', {
+          type: 'campaign_post',
+          campaignId: 'campaign-1',
+          campaignVersion: 2,
+          contentHash,
+          variantId: 'variant-1',
+          contentId: 'content-1',
+          platformId: 'twitter',
+          content: { text: 'Approved campaign post' },
+          scheduledTime: '2026-04-01T12:00:00Z',
+          idempotencyKey: 'campaign-request-123',
+        })
+      );
+
+      expect(response.status).toBe(200);
+      expect(mockRecordPublishAttempt).toHaveBeenCalledTimes(1);
+      expect(mockRecordPublishAttempt).toHaveBeenCalledWith(
+        expect.objectContaining({ schedulerJobId: sampleJob.id })
       );
     });
 

--- a/__tests__/integration/campaign-persistence.test.ts
+++ b/__tests__/integration/campaign-persistence.test.ts
@@ -128,6 +128,7 @@ describePostgres('campaign persistence restart behavior', () => {
 
     expect(afterRestart.snapshotHash).toBe(persisted.snapshotHash);
     expect(approvalBinding).toEqual({
+      campaignRowId: expect.any(String),
       versionId: persisted.versionId,
       contentHash,
       content: {
@@ -137,6 +138,7 @@ describePostgres('campaign persistence restart behavior', () => {
         mentions: omnipostXCampaignSeed.contentItems[0].adaptations[0].mentions,
       },
     });
+    expect(approvalBinding.campaignRowId).not.toBe(omnipostXCampaignSeed.id);
 
     await restartedRepository.recordApproval({
       userId: ownerId,

--- a/__tests__/integration/scheduler-persistence.test.ts
+++ b/__tests__/integration/scheduler-persistence.test.ts
@@ -16,6 +16,7 @@ function testJob(userId: string, suffix: string): ScheduledJob {
   return {
     id: `scheduler-job-${suffix}`,
     idempotencyKey: `scheduler-idempotency-${suffix}`,
+    requestFingerprint: `scheduler-request-${suffix}`,
     type: 'standalone',
     contentId: `content-${suffix}`,
     platformId: 'twitter',
@@ -129,7 +130,15 @@ describePostgres('scheduler persistence, idempotency, and leases', () => {
     ]);
 
     expect([...first, ...second]).toHaveLength(1);
-    expect([...first, ...second][0]).toMatchObject({ status: 'processing', attempts: 1 });
+    const claimed = [...first, ...second][0];
+    expect(claimed).toMatchObject({ status: 'processing', attempts: 0 });
+    const claimingQueue =
+      claimed.leaseToken === 'database-lease-a'
+        ? new PrismaJobQueue(firstClient)
+        : new PrismaJobQueue(secondClient);
+    await expect(
+      claimingQueue.markClaimAttempt(claimed.id, claimed.leaseToken!, dueAt)
+    ).resolves.toMatchObject({ attempts: 1, lastAttemptAt: dueAt.toISOString() });
     await firstClient.$disconnect();
     await secondClient.$disconnect();
   });

--- a/__tests__/integration/scheduler-persistence.test.ts
+++ b/__tests__/integration/scheduler-persistence.test.ts
@@ -52,7 +52,7 @@ describePostgres('scheduler persistence, idempotency, and leases', () => {
         {
           id: ownerId,
           username: `scheduler-owner-${suffix}`,
-          email: `scheduler-${suffix}@example.test`,
+          email: `Scheduler-${suffix}@Example.Test`,
           passwordHash: 'not-a-real-password-hash',
         },
         {

--- a/__tests__/integration/scheduler-persistence.test.ts
+++ b/__tests__/integration/scheduler-persistence.test.ts
@@ -3,6 +3,7 @@
 import { PrismaPg } from '@prisma/adapter-pg';
 import { PrismaClient } from '@prisma/client';
 import { PrismaJobQueue } from '@/lib/scheduler/prisma-queue';
+import { DurableRateLimiter } from '@/lib/scheduler/rate-limiter';
 import type { ScheduledJob } from '@/lib/scheduler/types';
 
 const databaseUrl = process.env.DATABASE_URL;
@@ -158,6 +159,37 @@ describePostgres('scheduler persistence, idempotency, and leases', () => {
     await expect(
       claimingQueue.markClaimAttempt(claimed.id, claimed.leaseToken!, dueAt)
     ).resolves.toMatchObject({ attempts: 1, lastAttemptAt: dueAt.toISOString() });
+    await firstClient.$disconnect();
+    await secondClient.$disconnect();
+  });
+
+  test('atomically reserves shared platform quota across database clients', async () => {
+    if (!databaseUrl) throw new Error('PostgreSQL DATABASE_URL is required');
+    const platformId = `quota-${suffix}`;
+    const firstClient = new PrismaClient({
+      adapter: new PrismaPg({ connectionString: databaseUrl }),
+    });
+    const secondClient = new PrismaClient({
+      adapter: new PrismaPg({ connectionString: databaseUrl }),
+    });
+    const config = { [platformId]: { requests: 1, window: 900 } };
+
+    const reservations = await Promise.all([
+      new DurableRateLimiter(firstClient, config).reserveRequest(platformId),
+      new DurableRateLimiter(secondClient, config).reserveRequest(platformId),
+    ]);
+
+    expect(reservations.filter(reservation => reservation.allowed)).toHaveLength(1);
+    expect(reservations.filter(reservation => !reservation.allowed)).toEqual([
+      expect.objectContaining({ nextAvailableAt: expect.any(Date) }),
+    ]);
+    const rows = await firstClient.$queryRaw<Array<{ requestCount: number }>>`
+      SELECT "requestCount" FROM "SchedulerPlatformQuota" WHERE "platformId" = ${platformId}
+    `;
+    expect(rows).toEqual([{ requestCount: 1 }]);
+    await firstClient.$executeRaw`
+      DELETE FROM "SchedulerPlatformQuota" WHERE "platformId" = ${platformId}
+    `;
     await firstClient.$disconnect();
     await secondClient.$disconnect();
   });

--- a/__tests__/integration/scheduler-persistence.test.ts
+++ b/__tests__/integration/scheduler-persistence.test.ts
@@ -4,6 +4,7 @@ import { PrismaPg } from '@prisma/adapter-pg';
 import { PrismaClient } from '@prisma/client';
 import { PrismaJobQueue } from '@/lib/scheduler/prisma-queue';
 import { DurableRateLimiter } from '@/lib/scheduler/rate-limiter';
+import { ExternalIdentityEmailConflictError, resolveExternalUser } from '@/lib/auth/external-user';
 import type { ScheduledJob } from '@/lib/scheduler/types';
 
 const databaseUrl = process.env.DATABASE_URL;
@@ -119,6 +120,62 @@ describePostgres('scheduler persistence, idempotency, and leases', () => {
       restartedQueue.add({ ...original, id: `${original.id}-duplicate` })
     ).resolves.toMatchObject({ created: false, job: { id: original.id } });
     await restartedClient.$disconnect();
+  });
+
+  test('persists an external identity before using it as scheduler owner', async () => {
+    if (!setupClient) throw new Error('PostgreSQL setup client was not initialized');
+    const externalId = `mystira-subject-${suffix}`;
+    const email = `mystira-${suffix}@example.test`;
+    const resolved = await resolveExternalUser(setupClient, {
+      provider: 'mystira',
+      externalId,
+      email,
+      name: 'Mystira Scheduler User',
+    });
+
+    try {
+      expect(resolved).toMatchObject({ isNew: true, role: 'user' });
+      await expect(
+        resolveExternalUser(setupClient, {
+          provider: 'mystira',
+          externalId,
+          email,
+          name: 'Changed Display Name',
+        })
+      ).resolves.toMatchObject({ id: resolved.id, isNew: false });
+      await expect(
+        setupClient.externalIdentity.findUnique({
+          where: { provider_externalId: { provider: 'mystira', externalId } },
+        })
+      ).resolves.toMatchObject({ userId: resolved.id });
+
+      const job = testJob(resolved.id, `${suffix}-external-owner`);
+      await expect(new PrismaJobQueue(setupClient).add(job)).resolves.toMatchObject({
+        created: true,
+        job: { createdBy: resolved.id },
+      });
+    } finally {
+      await setupClient.user.delete({ where: { id: resolved.id } });
+    }
+  });
+
+  test('does not implicitly link an external identity by email', async () => {
+    if (!setupClient) throw new Error('PostgreSQL setup client was not initialized');
+    const externalId = `email-collision-${suffix}`;
+
+    await expect(
+      resolveExternalUser(setupClient, {
+        provider: 'mystira',
+        externalId,
+        email: `scheduler-${suffix}@example.test`,
+        name: 'Conflicting User',
+      })
+    ).rejects.toBeInstanceOf(ExternalIdentityEmailConflictError);
+    await expect(
+      setupClient.externalIdentity.findUnique({
+        where: { provider_externalId: { provider: 'mystira', externalId } },
+      })
+    ).resolves.toBeNull();
   });
 
   test('allows only one database client to claim a due job', async () => {

--- a/__tests__/integration/scheduler-persistence.test.ts
+++ b/__tests__/integration/scheduler-persistence.test.ts
@@ -245,6 +245,23 @@ describePostgres('scheduler persistence, idempotency, and leases', () => {
     ]);
   });
 
+  test('paginates tenant job history in PostgreSQL with an independent total', async () => {
+    if (!setupClient) throw new Error('PostgreSQL setup client was not initialized');
+    const queue = new PrismaJobQueue(setupClient);
+    const first = testJob(ownerId, `${suffix}-page-a`);
+    const second = testJob(ownerId, `${suffix}-page-b`);
+    second.scheduledTime = '2026-07-26T08:01:00.000Z';
+    await queue.add(first);
+    await queue.add(second);
+
+    await expect(
+      queue.list({ userId: ownerId, status: 'scheduled', limit: 1, offset: 1 })
+    ).resolves.toEqual({
+      jobs: [expect.objectContaining({ id: second.id })],
+      total: 2,
+    });
+  });
+
   test('creates a campaign job and its audit attempt atomically and idempotently', async () => {
     if (!setupClient) throw new Error('PostgreSQL setup client was not initialized');
     const queue = new PrismaJobQueue(setupClient);

--- a/__tests__/integration/scheduler-persistence.test.ts
+++ b/__tests__/integration/scheduler-persistence.test.ts
@@ -1,0 +1,143 @@
+/** @jest-environment node */
+
+import { PrismaPg } from '@prisma/adapter-pg';
+import { PrismaClient } from '@prisma/client';
+import { PrismaJobQueue } from '@/lib/scheduler/prisma-queue';
+import type { ScheduledJob } from '@/lib/scheduler/types';
+
+const databaseUrl = process.env.DATABASE_URL;
+const describePostgres =
+  databaseUrl?.startsWith('postgresql://') || databaseUrl?.startsWith('postgres://')
+    ? describe
+    : describe.skip;
+
+function testJob(userId: string, suffix: string): ScheduledJob {
+  const now = new Date('2026-07-26T08:00:00Z').toISOString();
+  return {
+    id: `scheduler-job-${suffix}`,
+    idempotencyKey: `scheduler-idempotency-${suffix}`,
+    type: 'standalone',
+    contentId: `content-${suffix}`,
+    platformId: 'twitter',
+    content: { text: 'PostgreSQL durable scheduler test' },
+    scheduledTime: now,
+    timezone: 'UTC',
+    status: 'scheduled',
+    attempts: 0,
+    maxAttempts: 5,
+    createdAt: now,
+    updatedAt: now,
+    createdBy: userId,
+  };
+}
+
+describePostgres('scheduler persistence, idempotency, and leases', () => {
+  const suffix = `${process.pid}-${Date.now()}`;
+  const ownerId = `scheduler-owner-${suffix}`;
+  const otherOwnerId = `scheduler-other-owner-${suffix}`;
+  let setupClient: PrismaClient | null = null;
+
+  beforeAll(async () => {
+    if (!databaseUrl) throw new Error('PostgreSQL DATABASE_URL is required');
+    setupClient = new PrismaClient({
+      adapter: new PrismaPg({ connectionString: databaseUrl }),
+    });
+    await setupClient.user.createMany({
+      data: [
+        {
+          id: ownerId,
+          username: `scheduler-owner-${suffix}`,
+          email: `scheduler-${suffix}@example.test`,
+          passwordHash: 'not-a-real-password-hash',
+        },
+        {
+          id: otherOwnerId,
+          username: `scheduler-other-owner-${suffix}`,
+          email: `scheduler-other-${suffix}@example.test`,
+          passwordHash: 'not-a-real-password-hash',
+        },
+      ],
+    });
+  });
+
+  afterAll(async () => {
+    if (setupClient) {
+      await setupClient.user.deleteMany({ where: { id: { in: [ownerId, otherOwnerId] } } });
+      await setupClient.$disconnect();
+    }
+  });
+
+  test('survives a client restart and deduplicates the same request', async () => {
+    if (!databaseUrl) throw new Error('PostgreSQL DATABASE_URL is required');
+    const firstClient = new PrismaClient({
+      adapter: new PrismaPg({ connectionString: databaseUrl }),
+    });
+    const firstQueue = new PrismaJobQueue(firstClient);
+    const original = testJob(ownerId, suffix);
+    await expect(firstQueue.add(original)).resolves.toMatchObject({ created: true });
+    await firstClient.$disconnect();
+
+    const restartedClient = new PrismaClient({
+      adapter: new PrismaPg({ connectionString: databaseUrl }),
+    });
+    const restartedQueue = new PrismaJobQueue(restartedClient);
+    await expect(restartedQueue.get(original.id)).resolves.toMatchObject({
+      id: original.id,
+      createdBy: ownerId,
+      content: original.content,
+    });
+    await expect(
+      restartedQueue.add({ ...original, id: `${original.id}-duplicate` })
+    ).resolves.toMatchObject({ created: false, job: { id: original.id } });
+    await restartedClient.$disconnect();
+  });
+
+  test('allows only one database client to claim a due job', async () => {
+    if (!databaseUrl) throw new Error('PostgreSQL DATABASE_URL is required');
+    const job = testJob(ownerId, `${suffix}-claim`);
+    if (!setupClient) throw new Error('PostgreSQL setup client was not initialized');
+    await new PrismaJobQueue(setupClient).add(job);
+
+    const firstClient = new PrismaClient({
+      adapter: new PrismaPg({ connectionString: databaseUrl }),
+    });
+    const secondClient = new PrismaClient({
+      adapter: new PrismaPg({ connectionString: databaseUrl }),
+    });
+    const dueAt = new Date('2026-07-26T08:00:00Z');
+    const [first, second] = await Promise.all([
+      new PrismaJobQueue(firstClient).claimDueJobs(
+        dueAt,
+        1,
+        'database-lease-a',
+        new Date('2026-07-26T08:02:00Z')
+      ),
+      new PrismaJobQueue(secondClient).claimDueJobs(
+        dueAt,
+        1,
+        'database-lease-b',
+        new Date('2026-07-26T08:02:00Z')
+      ),
+    ]);
+
+    expect([...first, ...second]).toHaveLength(1);
+    expect([...first, ...second][0]).toMatchObject({ status: 'processing', attempts: 1 });
+    await firstClient.$disconnect();
+    await secondClient.$disconnect();
+  });
+
+  test('does not expose jobs across tenants', async () => {
+    if (!setupClient) throw new Error('PostgreSQL setup client was not initialized');
+    const queue = new PrismaJobQueue(setupClient);
+    const otherJob = testJob(otherOwnerId, `${suffix}-other-owner`);
+    await queue.add(otherJob);
+
+    await expect(queue.get(otherJob.id, ownerId)).resolves.toBeNull();
+    await expect(queue.getAll(ownerId)).resolves.not.toContainEqual(
+      expect.objectContaining({ id: otherJob.id })
+    );
+    await expect(queue.getAll(otherOwnerId)).resolves.toEqual([
+      expect.objectContaining({ id: otherJob.id, createdBy: otherOwnerId }),
+    ]);
+  });
+});

--- a/__tests__/integration/scheduler-persistence.test.ts
+++ b/__tests__/integration/scheduler-persistence.test.ts
@@ -268,7 +268,7 @@ describePostgres('scheduler persistence, idempotency, and leases', () => {
     const campaignJob = testJob(ownerId, `${suffix}-campaign`);
     Object.assign(campaignJob, {
       type: 'campaign_post',
-      campaignId,
+      campaignId: `external-${campaignId}`,
       campaignVersion: 1,
       campaignVersionId,
       approvedContentHash: `sha256:${'c'.repeat(64)}`,

--- a/__tests__/integration/scheduler-persistence.test.ts
+++ b/__tests__/integration/scheduler-persistence.test.ts
@@ -60,6 +60,14 @@ describePostgres('scheduler persistence, idempotency, and leases', () => {
     });
   });
 
+  afterEach(async () => {
+    if (setupClient) {
+      await setupClient.schedulerJob.deleteMany({
+        where: { userId: { in: [ownerId, otherOwnerId] } },
+      });
+    }
+  });
+
   afterAll(async () => {
     if (setupClient) {
       await setupClient.user.deleteMany({ where: { id: { in: [ownerId, otherOwnerId] } } });

--- a/__tests__/integration/scheduler-persistence.test.ts
+++ b/__tests__/integration/scheduler-persistence.test.ts
@@ -36,6 +36,8 @@ describePostgres('scheduler persistence, idempotency, and leases', () => {
   const suffix = `${process.pid}-${Date.now()}`;
   const ownerId = `scheduler-owner-${suffix}`;
   const otherOwnerId = `scheduler-other-owner-${suffix}`;
+  const campaignId = `scheduler-campaign-${suffix}`;
+  const campaignVersionId = `scheduler-campaign-version-${suffix}`;
   let setupClient: PrismaClient | null = null;
 
   beforeAll(async () => {
@@ -59,10 +61,27 @@ describePostgres('scheduler persistence, idempotency, and leases', () => {
         },
       ],
     });
+    await setupClient.campaign.create({
+      data: {
+        id: campaignId,
+        userId: ownerId,
+        name: 'Scheduler atomic campaign',
+        versions: {
+          create: {
+            id: campaignVersionId,
+            version: 1,
+            snapshot: '{}',
+            snapshotHash: `sha256:${'b'.repeat(64)}`,
+            createdBy: ownerId,
+          },
+        },
+      },
+    });
   });
 
   afterEach(async () => {
     if (setupClient) {
+      await setupClient.publishAttempt.deleteMany({ where: { campaignId } });
       await setupClient.schedulerJob.deleteMany({
         where: { userId: { in: [ownerId, otherOwnerId] } },
       });
@@ -143,6 +162,42 @@ describePostgres('scheduler persistence, idempotency, and leases', () => {
     await secondClient.$disconnect();
   });
 
+  test('reclaims pre-attempt expiry but quarantines an unknown provider result', async () => {
+    if (!setupClient) throw new Error('PostgreSQL setup client was not initialized');
+    const queue = new PrismaJobQueue(setupClient);
+    const beforeAttempt = testJob(ownerId, `${suffix}-before-attempt`);
+    const afterAttempt = testJob(ownerId, `${suffix}-after-attempt`);
+    await queue.add({
+      ...beforeAttempt,
+      status: 'processing',
+      leaseToken: 'expired-before-attempt',
+      leaseExpiresAt: '2026-07-26T07:59:00.000Z',
+    });
+    await queue.add({
+      ...afterAttempt,
+      status: 'processing',
+      attempts: 1,
+      leaseToken: 'expired-after-attempt',
+      leaseExpiresAt: '2026-07-26T07:59:00.000Z',
+      attemptStartedAt: '2026-07-26T07:58:00.000Z',
+    });
+
+    await expect(
+      queue.claimDueJobs(
+        new Date('2026-07-26T08:00:00Z'),
+        1,
+        'recovery-lease',
+        new Date('2026-07-26T08:02:00Z')
+      )
+    ).resolves.toEqual([
+      expect.objectContaining({ id: beforeAttempt.id, leaseToken: 'recovery-lease' }),
+    ]);
+    await expect(queue.get(afterAttempt.id, ownerId)).resolves.toMatchObject({
+      status: 'reconciliation_required',
+      leaseToken: undefined,
+    });
+  });
+
   test('does not expose jobs across tenants', async () => {
     if (!setupClient) throw new Error('PostgreSQL setup client was not initialized');
     const queue = new PrismaJobQueue(setupClient);
@@ -156,5 +211,87 @@ describePostgres('scheduler persistence, idempotency, and leases', () => {
     await expect(queue.getAll(otherOwnerId)).resolves.toEqual([
       expect.objectContaining({ id: otherJob.id, createdBy: otherOwnerId }),
     ]);
+  });
+
+  test('creates a campaign job and its audit attempt atomically and idempotently', async () => {
+    if (!setupClient) throw new Error('PostgreSQL setup client was not initialized');
+    const queue = new PrismaJobQueue(setupClient);
+    const campaignJob = testJob(ownerId, `${suffix}-campaign`);
+    Object.assign(campaignJob, {
+      type: 'campaign_post',
+      campaignId,
+      campaignVersion: 1,
+      campaignVersionId,
+      approvedContentHash: `sha256:${'c'.repeat(64)}`,
+      variantId: 'variant-1',
+    });
+    const audit = {
+      campaignId,
+      campaignVersionId,
+      contentId: campaignJob.contentId,
+      variantId: 'variant-1',
+      platformId: campaignJob.platformId,
+      contentHash: campaignJob.approvedContentHash!,
+      requestedBy: ownerId,
+    };
+
+    await expect(queue.addCampaignJob(campaignJob, audit)).resolves.toMatchObject({
+      created: true,
+    });
+    await expect(
+      queue.addCampaignJob({ ...campaignJob, id: `${campaignJob.id}-replay` }, audit)
+    ).resolves.toMatchObject({ created: false, job: { id: campaignJob.id } });
+    await expect(
+      setupClient.publishAttempt.count({ where: { schedulerJobId: campaignJob.id } })
+    ).resolves.toBe(1);
+
+    const invalidJob = {
+      ...campaignJob,
+      id: `${campaignJob.id}-invalid`,
+      idempotencyKey: `${campaignJob.idempotencyKey}-invalid`,
+      requestFingerprint: `${campaignJob.requestFingerprint}-invalid`,
+      campaignVersionId: 'missing-campaign-version',
+    };
+    await expect(
+      queue.addCampaignJob(invalidJob, {
+        ...audit,
+        campaignVersionId: 'missing-campaign-version',
+      })
+    ).rejects.toBeDefined();
+    await expect(queue.get(invalidJob.id, ownerId)).resolves.toBeNull();
+  });
+
+  test('preserves scheduler history when its campaign is deleted', async () => {
+    if (!setupClient) throw new Error('PostgreSQL setup client was not initialized');
+    const deleteCampaignId = `${campaignId}-delete`;
+    const deleteVersionId = `${campaignVersionId}-delete`;
+    await setupClient.campaign.create({
+      data: {
+        id: deleteCampaignId,
+        userId: ownerId,
+        name: 'Deletable scheduler campaign',
+        versions: {
+          create: {
+            id: deleteVersionId,
+            version: 1,
+            snapshot: '{}',
+            snapshotHash: `sha256:${'d'.repeat(64)}`,
+            createdBy: ownerId,
+          },
+        },
+      },
+    });
+    const queue = new PrismaJobQueue(setupClient);
+    const scheduled = testJob(ownerId, `${suffix}-campaign-delete`);
+    scheduled.campaignId = deleteCampaignId;
+    scheduled.campaignVersionId = deleteVersionId;
+    await queue.add(scheduled);
+
+    await setupClient.campaign.delete({ where: { id: deleteCampaignId } });
+
+    await expect(queue.get(scheduled.id, ownerId)).resolves.toMatchObject({
+      campaignId: deleteCampaignId,
+      campaignVersionId: undefined,
+    });
   });
 });

--- a/__tests__/integration/scheduler-persistence.test.ts
+++ b/__tests__/integration/scheduler-persistence.test.ts
@@ -307,7 +307,6 @@ describePostgres('scheduler persistence, idempotency, and leases', () => {
     const queue = new PrismaJobQueue(setupClient);
     const first = testJob(ownerId, `${suffix}-page-a`);
     const second = testJob(ownerId, `${suffix}-page-b`);
-    second.scheduledTime = '2026-07-26T08:01:00.000Z';
     await queue.add(first);
     await queue.add(second);
 

--- a/__tests__/lib/scheduler-durable-queue.test.ts
+++ b/__tests__/lib/scheduler-durable-queue.test.ts
@@ -1,0 +1,126 @@
+import { ServerMemoryQueue } from '@/lib/scheduler/queue';
+import type { ScheduledJob } from '@/lib/scheduler/types';
+
+function job(overrides: Partial<ScheduledJob> = {}): ScheduledJob {
+  const now = new Date('2026-07-26T08:00:00Z').toISOString();
+  return {
+    id: 'job-1',
+    idempotencyKey: 'publish:user-1:content-1:twitter',
+    type: 'standalone',
+    contentId: 'content-1',
+    platformId: 'twitter',
+    content: { text: 'Durable scheduler test' },
+    scheduledTime: now,
+    timezone: 'UTC',
+    status: 'scheduled',
+    attempts: 0,
+    maxAttempts: 5,
+    createdAt: now,
+    updatedAt: now,
+    createdBy: 'user-1',
+    ...overrides,
+  };
+}
+
+describe('durable scheduler queue contract', () => {
+  test('deduplicates identical requests and rejects key reuse for different content', async () => {
+    const queue = new ServerMemoryQueue();
+    const first = await queue.add(job());
+    const duplicate = await queue.add(job({ id: 'job-2' }));
+
+    expect(first.created).toBe(true);
+    expect(duplicate).toEqual({ job: first.job, created: false });
+    await expect(
+      queue.add(job({ id: 'job-3', content: { text: 'Different content' } }))
+    ).rejects.toMatchObject({ code: 'IDEMPOTENCY_CONFLICT' });
+    await expect(
+      queue.add(job({ id: 'job-4', approvedContentHash: `sha256:${'a'.repeat(64)}` }))
+    ).rejects.toMatchObject({ code: 'IDEMPOTENCY_CONFLICT' });
+    await expect(queue.count()).resolves.toBe(1);
+  });
+
+  test('allows only one concurrent processor to claim a due job', async () => {
+    const queue = new ServerMemoryQueue();
+    const dueAt = new Date('2026-07-26T08:00:00Z');
+    await queue.add(job());
+
+    const [first, second] = await Promise.all([
+      queue.claimDueJobs(dueAt, 1, 'lease-a', new Date('2026-07-26T08:02:00Z')),
+      queue.claimDueJobs(dueAt, 1, 'lease-b', new Date('2026-07-26T08:02:00Z')),
+    ]);
+
+    expect([...first, ...second]).toHaveLength(1);
+    expect([...first, ...second][0]).toMatchObject({ status: 'processing', attempts: 1 });
+  });
+
+  test('requires the active lease token to complete a claim', async () => {
+    const queue = new ServerMemoryQueue();
+    const dueAt = new Date('2026-07-26T08:00:00Z');
+    await queue.add(job());
+    await queue.claimDueJobs(dueAt, 1, 'lease-a', new Date('2026-07-26T08:02:00Z'));
+
+    await expect(
+      queue.updateClaimed('job-1', 'lease-b', {
+        status: 'published',
+        publishedAt: dueAt.toISOString(),
+      })
+    ).resolves.toBe(false);
+    await expect(
+      queue.updateClaimed('job-1', 'lease-a', {
+        status: 'published',
+        publishedAt: dueAt.toISOString(),
+      })
+    ).resolves.toBe(true);
+    await expect(queue.get('job-1')).resolves.toMatchObject({
+      status: 'published',
+      leaseToken: undefined,
+      leaseExpiresAt: undefined,
+    });
+  });
+
+  test('quarantines an abandoned processing lease instead of republishing it', async () => {
+    const queue = new ServerMemoryQueue();
+    await queue.add(
+      job({
+        status: 'processing',
+        attempts: 1,
+        leaseToken: 'abandoned-lease',
+        leaseExpiresAt: '2026-07-26T07:59:00.000Z',
+      })
+    );
+
+    const claimed = await queue.claimDueJobs(
+      new Date('2026-07-26T08:00:00Z'),
+      1,
+      'new-lease',
+      new Date('2026-07-26T08:02:00Z')
+    );
+
+    expect(claimed).toEqual([]);
+    await expect(queue.get('job-1')).resolves.toMatchObject({
+      status: 'reconciliation_required',
+      attempts: 1,
+    });
+  });
+
+  test('keeps reads tenant-scoped', async () => {
+    const queue = new ServerMemoryQueue();
+    await queue.add(job({ campaignId: 'campaign-1' }));
+    await queue.add(
+      job({
+        id: 'job-2',
+        idempotencyKey: 'publish:user-2:content-2:twitter',
+        contentId: 'content-2',
+        campaignId: 'campaign-1',
+        createdBy: 'user-2',
+      })
+    );
+
+    await expect(queue.get('job-2', 'user-1')).resolves.toBeNull();
+    await expect(queue.getAll('user-1')).resolves.toEqual([
+      expect.objectContaining({ id: 'job-1', createdBy: 'user-1' }),
+    ]);
+    await expect(queue.getByStatus('scheduled', 10, 'user-1')).resolves.toHaveLength(1);
+    await expect(queue.getByCampaign('campaign-1', 'user-1')).resolves.toHaveLength(1);
+  });
+});

--- a/__tests__/lib/scheduler-durable-queue.test.ts
+++ b/__tests__/lib/scheduler-durable-queue.test.ts
@@ -108,6 +108,7 @@ describe('durable scheduler queue contract', () => {
         attempts: 1,
         leaseToken: 'abandoned-lease',
         leaseExpiresAt: '2026-07-26T07:59:00.000Z',
+        attemptStartedAt: '2026-07-26T07:58:00.000Z',
       })
     );
 
@@ -123,6 +124,33 @@ describe('durable scheduler queue contract', () => {
       status: 'reconciliation_required',
       attempts: 1,
     });
+  });
+
+  test('reclaims an expired lease when no provider attempt started', async () => {
+    const queue = new ServerMemoryQueue();
+    await queue.add(
+      job({
+        status: 'processing',
+        leaseToken: 'abandoned-before-attempt',
+        leaseExpiresAt: '2026-07-26T07:59:00.000Z',
+      })
+    );
+
+    await expect(
+      queue.claimDueJobs(
+        new Date('2026-07-26T08:00:00Z'),
+        1,
+        'recovery-lease',
+        new Date('2026-07-26T08:02:00Z')
+      )
+    ).resolves.toEqual([
+      expect.objectContaining({
+        id: 'job-1',
+        status: 'processing',
+        attempts: 0,
+        leaseToken: 'recovery-lease',
+      }),
+    ]);
   });
 
   test('keeps reads tenant-scoped', async () => {

--- a/__tests__/lib/scheduler-durable-queue.test.ts
+++ b/__tests__/lib/scheduler-durable-queue.test.ts
@@ -80,6 +80,15 @@ describe('durable scheduler queue contract', () => {
       attempts: 1,
       lastAttemptAt: dueAt.toISOString(),
     });
+    await expect(
+      queue.renewClaimLease('job-1', 'lease-b', new Date('2026-07-26T08:05:00Z'))
+    ).resolves.toBe(false);
+    await expect(
+      queue.renewClaimLease('job-1', 'lease-a', new Date('2026-07-26T08:05:00Z'))
+    ).resolves.toBe(true);
+    await expect(queue.get('job-1')).resolves.toMatchObject({
+      leaseExpiresAt: '2026-07-26T08:05:00.000Z',
+    });
 
     await expect(
       queue.updateClaimed('job-1', 'lease-b', {

--- a/__tests__/lib/scheduler-durable-queue.test.ts
+++ b/__tests__/lib/scheduler-durable-queue.test.ts
@@ -6,6 +6,7 @@ function job(overrides: Partial<ScheduledJob> = {}): ScheduledJob {
   return {
     id: 'job-1',
     idempotencyKey: 'publish:user-1:content-1:twitter',
+    requestFingerprint: 'request-fingerprint-1',
     type: 'standalone',
     contentId: 'content-1',
     platformId: 'twitter',
@@ -30,11 +31,28 @@ describe('durable scheduler queue contract', () => {
 
     expect(first.created).toBe(true);
     expect(duplicate).toEqual({ job: first.job, created: false });
+    await queue.update('job-1', { scheduledTime: '2026-07-27T08:00:00.000Z' });
+    await expect(queue.add(job({ id: 'job-replay' }))).resolves.toMatchObject({
+      created: false,
+      job: { id: 'job-1' },
+    });
     await expect(
-      queue.add(job({ id: 'job-3', content: { text: 'Different content' } }))
+      queue.add(
+        job({
+          id: 'job-3',
+          requestFingerprint: 'request-fingerprint-different-content',
+          content: { text: 'Different content' },
+        })
+      )
     ).rejects.toMatchObject({ code: 'IDEMPOTENCY_CONFLICT' });
     await expect(
-      queue.add(job({ id: 'job-4', approvedContentHash: `sha256:${'a'.repeat(64)}` }))
+      queue.add(
+        job({
+          id: 'job-4',
+          requestFingerprint: 'request-fingerprint-different-approval',
+          approvedContentHash: `sha256:${'a'.repeat(64)}`,
+        })
+      )
     ).rejects.toMatchObject({ code: 'IDEMPOTENCY_CONFLICT' });
     await expect(queue.count()).resolves.toBe(1);
   });
@@ -50,7 +68,7 @@ describe('durable scheduler queue contract', () => {
     ]);
 
     expect([...first, ...second]).toHaveLength(1);
-    expect([...first, ...second][0]).toMatchObject({ status: 'processing', attempts: 1 });
+    expect([...first, ...second][0]).toMatchObject({ status: 'processing', attempts: 0 });
   });
 
   test('requires the active lease token to complete a claim', async () => {
@@ -58,6 +76,10 @@ describe('durable scheduler queue contract', () => {
     const dueAt = new Date('2026-07-26T08:00:00Z');
     await queue.add(job());
     await queue.claimDueJobs(dueAt, 1, 'lease-a', new Date('2026-07-26T08:02:00Z'));
+    await expect(queue.markClaimAttempt('job-1', 'lease-a', dueAt)).resolves.toMatchObject({
+      attempts: 1,
+      lastAttemptAt: dueAt.toISOString(),
+    });
 
     await expect(
       queue.updateClaimed('job-1', 'lease-b', {
@@ -122,5 +144,20 @@ describe('durable scheduler queue contract', () => {
     ]);
     await expect(queue.getByStatus('scheduled', 10, 'user-1')).resolves.toHaveLength(1);
     await expect(queue.getByCampaign('campaign-1', 'user-1')).resolves.toHaveLength(1);
+  });
+
+  test('does not let a lifecycle mutation overwrite a processing claim', async () => {
+    const queue = new ServerMemoryQueue();
+    const dueAt = new Date('2026-07-26T08:00:00Z');
+    await queue.add(job());
+    await queue.claimDueJobs(dueAt, 1, 'lease-a', new Date('2026-07-26T08:02:00Z'));
+
+    await expect(
+      queue.updateIfStatus('job-1', ['scheduled', 'failed'], { status: 'cancelled' }, 'user-1')
+    ).resolves.toBe(false);
+    await expect(queue.get('job-1', 'user-1')).resolves.toMatchObject({
+      status: 'processing',
+      leaseToken: 'lease-a',
+    });
   });
 });

--- a/__tests__/lib/scheduler-persistence-contract.test.ts
+++ b/__tests__/lib/scheduler-persistence-contract.test.ts
@@ -1,0 +1,24 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+describe('scheduler persistence migration', () => {
+  test('creates a forward-only tenant-owned queue with idempotency and lease indexes', () => {
+    const migration = readFileSync(
+      path.join(
+        process.cwd(),
+        'prisma',
+        'migrations',
+        '20260726080500_scheduler_jobs',
+        'migration.sql'
+      ),
+      'utf8'
+    );
+
+    expect(migration).toContain('CREATE TABLE "SchedulerJob"');
+    expect(migration).toContain('SchedulerJob_userId_idempotencyKey_key');
+    expect(migration).toContain('SchedulerJob_status_scheduledAt_idx');
+    expect(migration).toContain('SchedulerJob_leaseExpiresAt_idx');
+    expect(migration).toContain('REFERENCES "User"("id")');
+    expect(migration).not.toContain('DROP TABLE');
+  });
+});

--- a/__tests__/lib/scheduler-persistence-contract.test.ts
+++ b/__tests__/lib/scheduler-persistence-contract.test.ts
@@ -16,9 +16,11 @@ describe('scheduler persistence migration', () => {
 
     expect(migration).toContain('CREATE TABLE "SchedulerJob"');
     expect(migration).toContain('SchedulerJob_userId_idempotencyKey_key');
+    expect(migration).toContain('"requestFingerprint" TEXT NOT NULL');
     expect(migration).toContain('SchedulerJob_status_scheduledAt_idx');
     expect(migration).toContain('SchedulerJob_leaseExpiresAt_idx');
     expect(migration).toContain('REFERENCES "User"("id")');
+    expect(migration).toContain('PublishAttempt_schedulerJobId_key');
     expect(migration).not.toContain('DROP TABLE');
   });
 });

--- a/__tests__/lib/scheduler-persistence-contract.test.ts
+++ b/__tests__/lib/scheduler-persistence-contract.test.ts
@@ -24,4 +24,21 @@ describe('scheduler persistence migration', () => {
     expect(migration).toContain('ON DELETE SET NULL ON UPDATE CASCADE');
     expect(migration).not.toContain('DROP TABLE');
   });
+
+  test('creates shared PostgreSQL scheduler quota state', () => {
+    const migration = readFileSync(
+      path.join(
+        process.cwd(),
+        'prisma',
+        'migrations',
+        '20260726102500_scheduler_platform_quotas',
+        'migration.sql'
+      ),
+      'utf8'
+    );
+
+    expect(migration).toContain('CREATE TABLE "SchedulerPlatformQuota"');
+    expect(migration).toContain('"platformId" TEXT NOT NULL');
+    expect(migration).not.toContain('DROP TABLE');
+  });
 });

--- a/__tests__/lib/scheduler-persistence-contract.test.ts
+++ b/__tests__/lib/scheduler-persistence-contract.test.ts
@@ -21,6 +21,7 @@ describe('scheduler persistence migration', () => {
     expect(migration).toContain('SchedulerJob_leaseExpiresAt_idx');
     expect(migration).toContain('REFERENCES "User"("id")');
     expect(migration).toContain('PublishAttempt_schedulerJobId_key');
+    expect(migration).toContain('ON DELETE SET NULL ON UPDATE CASCADE');
     expect(migration).not.toContain('DROP TABLE');
   });
 });

--- a/__tests__/lib/scheduler-publisher.test.ts
+++ b/__tests__/lib/scheduler-publisher.test.ts
@@ -1,0 +1,96 @@
+import type { ScheduledJob } from '@/lib/scheduler/types';
+
+const mockReserveRequest = jest.fn();
+const mockProviderPublish = jest.fn();
+const mockValidateContent = jest.fn();
+
+jest.mock('@/lib/scheduler/rate-limiter', () => ({
+  getRateLimiter: () => ({
+    canProcess: jest.fn(),
+    reserveRequest: mockReserveRequest,
+    setBackoff: jest.fn(),
+    getRemaining: jest.fn(),
+    getStatus: jest.fn(),
+  }),
+}));
+
+jest.mock('@/lib/scheduler/adapters', () => ({
+  getAdapter: () => ({
+    validateContent: mockValidateContent,
+    publish: mockProviderPublish,
+  }),
+}));
+
+jest.mock('@/lib/scheduler/retry-handler', () => ({
+  getRetryHandler: () => ({ classifyError: jest.fn() }),
+}));
+
+import { Publisher } from '@/lib/scheduler/publisher';
+
+const job: ScheduledJob = {
+  id: 'publisher-boundary-job',
+  idempotencyKey: 'publisher-boundary-key',
+  requestFingerprint: 'publisher-boundary-fingerprint',
+  type: 'standalone',
+  contentId: 'publisher-boundary-content',
+  platformId: 'twitter',
+  content: { text: 'content' },
+  scheduledTime: '2026-07-26T08:00:00.000Z',
+  timezone: 'UTC',
+  status: 'processing',
+  attempts: 0,
+  maxAttempts: 5,
+  createdAt: '2026-07-26T08:00:00.000Z',
+  updatedAt: '2026-07-26T08:00:00.000Z',
+};
+
+describe('scheduler publisher request boundary', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockReserveRequest.mockResolvedValue({ allowed: true, nextAvailableAt: null });
+    mockProviderPublish.mockResolvedValue({ id: 'post-1', url: 'https://x.com/post-1' });
+  });
+
+  test('does not reserve quota for locally invalid content', async () => {
+    mockValidateContent.mockReturnValue({ valid: false, errors: ['too long'], warnings: [] });
+
+    await expect(new Publisher().publish(job)).resolves.toMatchObject({
+      success: false,
+      error: { code: 'VALIDATION_FAILED' },
+    });
+    expect(mockReserveRequest).not.toHaveBeenCalled();
+    expect(mockProviderPublish).not.toHaveBeenCalled();
+  });
+
+  test('marks the attempt immediately before invoking the provider', async () => {
+    mockValidateContent.mockReturnValue({ valid: true, errors: [], warnings: [] });
+    const order: string[] = [];
+    mockProviderPublish.mockImplementation(async () => {
+      order.push('provider');
+      return { id: 'post-1', url: 'https://x.com/post-1' };
+    });
+
+    const result = await new Publisher().publish(job, {
+      quotaReserved: true,
+      beforeProviderCall: async () => {
+        order.push('attempt');
+        return true;
+      },
+    });
+
+    expect(result.success).toBe(true);
+    expect(order).toEqual(['attempt', 'provider']);
+  });
+
+  test('does not invoke the provider when attempt marking loses the lease', async () => {
+    mockValidateContent.mockReturnValue({ valid: true, errors: [], warnings: [] });
+
+    await expect(
+      new Publisher().publish(job, {
+        quotaReserved: true,
+        beforeProviderCall: async () => false,
+      })
+    ).resolves.toMatchObject({ success: false, error: { code: 'LEASE_LOST' } });
+    expect(mockProviderPublish).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/lib/scheduler-rate-limiter.test.ts
+++ b/__tests__/lib/scheduler-rate-limiter.test.ts
@@ -1,0 +1,17 @@
+import { RateLimiter } from '@/lib/scheduler/rate-limiter';
+
+describe('scheduler rate-limit deferral', () => {
+  test('reports the latest reset without consuming another request', async () => {
+    const limiter = new RateLimiter({
+      twitter: { requests: 1, window: 900, daily: 1 },
+    });
+    await limiter.recordRequest('twitter');
+
+    await expect(limiter.canProcess('twitter')).resolves.toBe(false);
+    const nextAvailableAt = await limiter.getNextAvailableAt('twitter');
+
+    expect(nextAvailableAt).not.toBeNull();
+    expect(nextAvailableAt!.getTime()).toBeGreaterThan(Date.now());
+    await expect(limiter.getRemaining('twitter')).resolves.toEqual({ window: 0, daily: 0 });
+  });
+});

--- a/__tests__/lib/scheduler-scheduling.test.ts
+++ b/__tests__/lib/scheduler-scheduling.test.ts
@@ -2,7 +2,7 @@
 
 import type { PrismaClient } from '@prisma/client';
 import { PrismaJobQueue, SchedulerQueueError } from '@/lib/scheduler/prisma-queue';
-import type { JobQueue } from '@/lib/scheduler/types';
+import type { JobQueue, ScheduleJobResult } from '@/lib/scheduler/types';
 
 jest.mock('@/lib/scheduler/queue', () => ({
   generateJobId: jest.fn(),
@@ -101,5 +101,60 @@ describe('scheduler request idempotency', () => {
         idempotencyContent: { text: 'Different request' },
       })
     ).rejects.toBeInstanceOf(SchedulerQueueError);
+  });
+
+  test('starts lease renewal only after the provider attempt is marked', async () => {
+    const order: string[] = [];
+    jest.mocked(getPublisher).mockReturnValue({
+      validate: () => ({ valid: true, errors: [] }),
+      publish: async (
+        _job: ScheduleJobResult['job'],
+        options: { quotaReserved?: boolean; beforeProviderCall?: () => Promise<boolean> }
+      ) => {
+        order.push('publisher-ready');
+        const proceed = await options?.beforeProviderCall?.();
+        if (!proceed) throw new Error('attempt was not marked');
+        order.push('provider');
+        return { success: true, result: { id: 'post-1' } };
+      },
+    } as unknown as ReturnType<typeof getPublisher>);
+    const scheduler = new Scheduler();
+    Object.assign(scheduler, {
+      startLeaseHeartbeat: () => {
+        order.push('heartbeat');
+        return async () => undefined;
+      },
+    });
+    const publishWithLeaseHeartbeat = (
+      scheduler as unknown as {
+        publishWithLeaseHeartbeat: (
+          job: ScheduleJobResult['job'],
+          leaseToken: string,
+          beforeProviderCall: () => Promise<boolean>
+        ) => Promise<unknown>;
+      }
+    ).publishWithLeaseHeartbeat.bind(scheduler);
+
+    await publishWithLeaseHeartbeat(
+      {
+        ...(await scheduler.scheduleWithResult({ ...input, idempotencyKey: 'heartbeat-key' })).job,
+        leaseToken: 'lease-1',
+      },
+      'lease-1',
+      async () => {
+        order.push('mark-start');
+        await Promise.resolve();
+        order.push('mark-complete');
+        return true;
+      }
+    );
+
+    expect(order).toEqual([
+      'publisher-ready',
+      'mark-start',
+      'mark-complete',
+      'heartbeat',
+      'provider',
+    ]);
   });
 });

--- a/__tests__/lib/scheduler-scheduling.test.ts
+++ b/__tests__/lib/scheduler-scheduling.test.ts
@@ -1,0 +1,65 @@
+/** @jest-environment node */
+
+import type { JobQueue } from '@/lib/scheduler/types';
+
+jest.mock('@/lib/scheduler/queue', () => ({
+  generateJobId: jest.fn(),
+  getQueue: jest.fn(),
+}));
+jest.mock('@/lib/scheduler/rate-limiter', () => ({ getRateLimiter: jest.fn() }));
+jest.mock('@/lib/scheduler/retry-handler', () => ({ getRetryHandler: jest.fn() }));
+jest.mock('@/lib/scheduler/publisher', () => ({ getPublisher: jest.fn() }));
+
+import { generateJobId, getQueue } from '@/lib/scheduler/queue';
+import { getPublisher } from '@/lib/scheduler/publisher';
+import { getRateLimiter } from '@/lib/scheduler/rate-limiter';
+import { getRetryHandler } from '@/lib/scheduler/retry-handler';
+import { Scheduler } from '@/lib/scheduler/scheduler';
+
+describe('scheduler request idempotency', () => {
+  const add = jest.fn(async job => ({ job, created: true }));
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.mocked(getQueue).mockReturnValue({ add } as unknown as JobQueue);
+    jest.mocked(getRateLimiter).mockReturnValue({} as ReturnType<typeof getRateLimiter>);
+    jest.mocked(getRetryHandler).mockReturnValue({} as ReturnType<typeof getRetryHandler>);
+    jest.mocked(getPublisher).mockReturnValue({
+      validate: () => ({ valid: true, errors: [] }),
+    } as unknown as ReturnType<typeof getPublisher>);
+  });
+
+  const input = {
+    type: 'standalone' as const,
+    contentId: 'content-1',
+    platformId: 'twitter',
+    content: { text: 'Publish this again intentionally' },
+    scheduledTime: '2026-07-26T14:00:00.000Z',
+    timezone: 'UTC',
+    createdBy: 'user-1',
+  };
+
+  test('creates a unique server key for each request that omits one', async () => {
+    jest.mocked(generateJobId).mockReturnValueOnce('job-1').mockReturnValueOnce('job-2');
+    const scheduler = new Scheduler();
+
+    const first = await scheduler.scheduleWithResult(input);
+    const second = await scheduler.scheduleWithResult(input);
+
+    expect(first.job.idempotencyKey).toBe('scheduler:v1:job-1');
+    expect(second.job.idempotencyKey).toBe('scheduler:v1:job-2');
+    expect(first.job.requestFingerprint).toBe(second.job.requestFingerprint);
+  });
+
+  test('preserves a caller-supplied key for durable replay', async () => {
+    jest.mocked(generateJobId).mockReturnValue('job-with-client-key');
+    const scheduler = new Scheduler();
+
+    const result = await scheduler.scheduleWithResult({
+      ...input,
+      idempotencyKey: 'client-request-key',
+    });
+
+    expect(result.job.idempotencyKey).toBe('client-request-key');
+  });
+});

--- a/__tests__/lib/scheduler-scheduling.test.ts
+++ b/__tests__/lib/scheduler-scheduling.test.ts
@@ -1,5 +1,7 @@
 /** @jest-environment node */
 
+import type { PrismaClient } from '@prisma/client';
+import { PrismaJobQueue, SchedulerQueueError } from '@/lib/scheduler/prisma-queue';
 import type { JobQueue } from '@/lib/scheduler/types';
 
 jest.mock('@/lib/scheduler/queue', () => ({
@@ -61,5 +63,43 @@ describe('scheduler request idempotency', () => {
     });
 
     expect(result.job.idempotencyKey).toBe('client-request-key');
+  });
+
+  test('returns a matching durable replay before mutable campaign validation', async () => {
+    const durableQueue = new PrismaJobQueue({} as PrismaClient);
+    jest.mocked(getQueue).mockReturnValue(durableQueue);
+    jest.mocked(generateJobId).mockReturnValue('campaign-job');
+    jest.spyOn(durableQueue, 'add').mockImplementation(async job => ({ job, created: true }));
+    const scheduler = new Scheduler();
+    const campaignInput = {
+      ...input,
+      type: 'campaign_post' as const,
+      campaignId: 'campaign-1',
+      campaignVersion: 1,
+      campaignVersionId: 'version-row-1',
+      approvedContentHash: `sha256:${'a'.repeat(64)}`,
+      variantId: 'variant-1',
+      content: { text: 'Canonical approved content' },
+      idempotencyContent: { text: 'Original client content' },
+      idempotencyKey: 'campaign-request-key',
+    };
+    const created = await scheduler.scheduleWithResult(campaignInput);
+    jest.spyOn(durableQueue, 'getByIdempotencyKey').mockResolvedValue(created.job);
+
+    await expect(
+      scheduler.findIdempotentReplay({
+        ...campaignInput,
+        campaignVersionId: undefined,
+        content: campaignInput.idempotencyContent,
+      })
+    ).resolves.toEqual({ job: created.job, created: false });
+    await expect(
+      scheduler.findIdempotentReplay({
+        ...campaignInput,
+        campaignVersionId: undefined,
+        content: { text: 'Different request' },
+        idempotencyContent: { text: 'Different request' },
+      })
+    ).rejects.toBeInstanceOf(SchedulerQueueError);
   });
 });

--- a/app/api/auth/callback/[provider]/route.ts
+++ b/app/api/auth/callback/[provider]/route.ts
@@ -12,51 +12,21 @@ import { Errors, withErrorHandling } from '../../../_utils/errors';
 import { withRateLimit, RateLimitPresets } from '../../../_utils/rateLimit';
 import { authService } from '../../../../../lib/auth/auth-service';
 import {
+  ExternalIdentityEmailConflictError,
+  resolveExternalUser,
+} from '../../../../../lib/auth/external-user';
+import {
   handleAuthCallback,
   initiateExternalAuth,
 } from '../../../../../lib/auth/identity-provider';
+import { prisma } from '../../../../../lib/db/prisma';
 
 const OAUTH_STATE_COOKIE_PREFIX = 'oauth-state-';
-
-interface ExternalUserRecord {
-  id: string;
-  username: string;
-  email: string;
-  role: string;
-  provider: string;
-  externalId: string;
-}
 
 interface StoredOAuthState {
   state: string;
   redirect: string;
   codeVerifier: string;
-}
-
-/**
- * In-memory store for users created via external providers.
- * In production this should be backed by a database.
- */
-const externalUsers = new Map<string, ExternalUserRecord>();
-
-/**
- * Find an existing user by external provider + external ID, or by email.
- */
-function findExistingUser(
-  provider: string,
-  externalId: string,
-  email: string
-): { id: string; username: string; role: string; isNew: false } | null {
-  for (const user of externalUsers.values()) {
-    if (user.provider === provider && user.externalId === externalId) {
-      return { id: user.id, username: user.username, role: user.role, isNew: false };
-    }
-    if (user.email === email) {
-      return { id: user.id, username: user.username, role: user.role, isNew: false };
-    }
-  }
-
-  return null;
 }
 
 function getPublicOrigin(request: Request, fallbackUrl: URL): string {
@@ -183,31 +153,23 @@ async function handleCallback(
   }
 
   const { externalId, email, name } = authResult.user;
-  const existingUser = findExistingUser(provider, externalId, email);
-  let userId: string;
-  let username: string;
-  let role: string;
-  let isNewUser = false;
-
-  if (existingUser) {
-    userId = existingUser.id;
-    username = existingUser.username;
-    role = existingUser.role;
-  } else {
-    userId = `user-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`;
-    username = name.replace(/\s+/g, '').toLowerCase() || email.split('@')[0];
-    role = 'user';
-    isNewUser = true;
-
-    externalUsers.set(userId, {
-      id: userId,
-      username,
-      email,
-      role,
-      provider,
-      externalId,
-    });
+  if (!prisma) {
+    return Errors.internalServerError('Database is not available');
   }
+
+  let localUser;
+  try {
+    localUser = await resolveExternalUser(prisma, { provider, externalId, email, name });
+  } catch (error) {
+    if (error instanceof ExternalIdentityEmailConflictError) {
+      const loginUrl = new URL('/login', publicOrigin);
+      loginUrl.searchParams.set('error', error.message);
+      return NextResponse.redirect(loginUrl);
+    }
+    throw error;
+  }
+
+  const { id: userId, username, role, isNew: isNewUser } = localUser;
 
   const token = authService.generateToken({ id: userId, username, role });
 

--- a/app/api/auth/route.ts
+++ b/app/api/auth/route.ts
@@ -109,6 +109,7 @@ async function handleRegister(request: Request): Promise<NextResponse> {
     if (emailError) {
       return Errors.badRequest(emailError);
     }
+    const normalizedEmail = (email as string).trim().toLowerCase();
 
     const passwordError = validateString(password, 'Password');
     if (passwordError) {
@@ -145,7 +146,7 @@ async function handleRegister(request: Request): Promise<NextResponse> {
 
     // Check if email already exists
     const existingByEmail = await userModel.findUnique({
-      where: { email },
+      where: { email: normalizedEmail },
     });
     if (existingByEmail) {
       return Errors.badRequest('Email already exists');
@@ -169,7 +170,7 @@ async function handleRegister(request: Request): Promise<NextResponse> {
     const dbUser = await userModel.create({
       data: {
         username,
-        email,
+        email: normalizedEmail,
         passwordHash,
         role: 'user',
       },

--- a/app/api/auth/route.ts
+++ b/app/api/auth/route.ts
@@ -131,6 +131,9 @@ async function handleRegister(request: Request): Promise<NextResponse> {
       findUnique: (args: {
         where: { username?: string; email?: string };
       }) => Promise<{ id: string; username: string; email: string; role: string } | null>;
+      findFirst: (args: {
+        where: { email: { equals: string; mode: 'insensitive' } };
+      }) => Promise<{ id: string; username: string; email: string; role: string } | null>;
       create: (args: {
         data: { username: string; email: string; passwordHash: string; role: string };
       }) => Promise<{ id: string; username: string; email: string; role: string }>;
@@ -145,8 +148,8 @@ async function handleRegister(request: Request): Promise<NextResponse> {
     }
 
     // Check if email already exists
-    const existingByEmail = await userModel.findUnique({
-      where: { email: normalizedEmail },
+    const existingByEmail = await userModel.findFirst({
+      where: { email: { equals: normalizedEmail, mode: 'insensitive' } },
     });
     if (existingByEmail) {
       return Errors.badRequest('Email already exists');

--- a/app/api/queue/approve/route.ts
+++ b/app/api/queue/approve/route.ts
@@ -72,6 +72,7 @@ function toPublishJob(item: QueueItem): ScheduledJob {
 
   return {
     id: `queue-${platformId}-${contentId}`,
+    idempotencyKey: `queue-approve:${platformId}:${contentId}`,
     type: 'standalone',
     contentId,
     platformId,

--- a/app/api/queue/approve/route.ts
+++ b/app/api/queue/approve/route.ts
@@ -73,6 +73,7 @@ function toPublishJob(item: QueueItem): ScheduledJob {
   return {
     id: `queue-${platformId}-${contentId}`,
     idempotencyKey: `queue-approve:${platformId}:${contentId}`,
+    requestFingerprint: `queue-approve:${platformId}:${contentId}`,
     type: 'standalone',
     contentId,
     platformId,

--- a/app/api/scheduler/[id]/route.ts
+++ b/app/api/scheduler/[id]/route.ts
@@ -71,7 +71,7 @@ async function getOwnedJob(
   userId: string
 ): Promise<{ job: ScheduledJob } | NextResponse> {
   const scheduler = getScheduler();
-  const job = await scheduler.getJob(jobId);
+  const job = await scheduler.getJob(jobId, userId);
 
   if (!job) {
     return Errors.notFound('Job not found') as NextResponse;
@@ -143,7 +143,7 @@ export const PATCH = withRateLimit(
 
     // Handle retry action
     if (action === 'retry') {
-      const retried = await scheduler.retry(idValidation.data.id);
+      const retried = await scheduler.retry(idValidation.data.id, authResult.userId);
       if (!retried) {
         return Errors.notFound('Job not found');
       }
@@ -154,7 +154,8 @@ export const PATCH = withRateLimit(
     if (scheduledTime) {
       const rescheduled = await scheduler.reschedule(
         idValidation.data.id,
-        new Date(scheduledTime).toISOString()
+        new Date(scheduledTime).toISOString(),
+        authResult.userId
       );
       if (!rescheduled) {
         return Errors.notFound('Job not found');
@@ -187,7 +188,7 @@ export const DELETE = withRateLimit(
     if (isJobError(result)) return result;
 
     const scheduler = getScheduler();
-    const cancelled = await scheduler.cancel(idValidation.data.id);
+    const cancelled = await scheduler.cancel(idValidation.data.id, authResult.userId);
 
     if (!cancelled) {
       return Errors.internalServerError('Failed to cancel job');

--- a/app/api/scheduler/route.ts
+++ b/app/api/scheduler/route.ts
@@ -212,24 +212,15 @@ export const POST = withRateLimit(
           platformId: data.platformId,
           contentHash: data.contentHash,
         });
-        await recordPublishAttempt({
-          userId: currentUserId,
-          campaignId: data.campaignId,
-          version: data.campaignVersion,
-          contentId: data.contentId,
-          variantId: data.variantId,
-          platformId: data.platformId,
-          contentHash: data.contentHash,
-        });
       } catch (error) {
         return campaignErrorResponse(error) ?? Errors.internalServerError();
       }
     }
 
     const scheduler = getScheduler();
-    let job;
+    let scheduled;
     try {
-      job = await scheduler.schedule({
+      scheduled = await scheduler.scheduleWithResult({
         type: data.type,
         campaignId: data.campaignId,
         campaignVersion: data.campaignVersion,
@@ -252,7 +243,33 @@ export const POST = withRateLimit(
       throw error;
     }
 
-    return NextResponse.json({ job }, { status: 201 });
+    if (
+      data.type === 'campaign_post' &&
+      data.campaignId &&
+      data.campaignVersion &&
+      data.contentHash &&
+      data.variantId
+    ) {
+      try {
+        await recordPublishAttempt({
+          userId: currentUserId,
+          campaignId: data.campaignId,
+          version: data.campaignVersion,
+          contentId: data.contentId,
+          variantId: data.variantId,
+          platformId: data.platformId,
+          contentHash: data.contentHash,
+          schedulerJobId: scheduled.job.id,
+        });
+      } catch (error) {
+        if (scheduled.created) {
+          await scheduler.cancel(scheduled.job.id, currentUserId);
+        }
+        return campaignErrorResponse(error) ?? Errors.internalServerError();
+      }
+    }
+
+    return NextResponse.json({ job: scheduled.job }, { status: scheduled.created ? 201 : 200 });
   }),
   '/api/scheduler',
   RateLimitPresets.GENERAL

--- a/app/api/scheduler/route.ts
+++ b/app/api/scheduler/route.ts
@@ -103,7 +103,7 @@ function getComingSoonPlatformName(platformId: string): string | undefined {
 
 function isIdempotencyConflict(error: unknown): boolean {
   return (
-    error instanceof SchedulerQueueError ||
+    (error instanceof SchedulerQueueError && error.code === 'IDEMPOTENCY_CONFLICT') ||
     (typeof error === 'object' &&
       error !== null &&
       'code' in error &&

--- a/app/api/scheduler/route.ts
+++ b/app/api/scheduler/route.ts
@@ -144,22 +144,18 @@ export const GET = withRateLimit(
     const { status, campaignId, limit, offset } = validation.data;
     const scheduler = getScheduler();
 
-    let jobs;
-    if (campaignId) {
-      jobs = await scheduler.getJobsByCampaign(campaignId, currentUserId);
-    } else if (status) {
-      jobs = await scheduler.getJobsByStatus(status as JobStatus, limit + offset, currentUserId);
-    } else {
-      jobs = await scheduler.getAllJobs(currentUserId);
-    }
-
-    // Apply pagination
-    const paginated = jobs.slice(offset, offset + limit);
+    const result = await scheduler.listJobs({
+      userId: currentUserId,
+      status: status as JobStatus | undefined,
+      campaignId,
+      limit,
+      offset,
+    });
 
     return NextResponse.json({
-      jobs: paginated,
-      count: paginated.length,
-      total: jobs.length,
+      jobs: result.jobs,
+      count: result.jobs.length,
+      total: result.total,
     });
   }),
   '/api/scheduler',

--- a/app/api/scheduler/route.ts
+++ b/app/api/scheduler/route.ts
@@ -190,6 +190,38 @@ export const POST = withRateLimit(
       return Errors.badRequest(`${comingSoonPlatformName} publishing is coming soon`);
     }
 
+    const scheduler = getScheduler();
+    const requestScheduleInput = {
+      type: data.type,
+      campaignId: data.campaignId,
+      campaignVersion: data.campaignVersion,
+      approvedContentHash: data.contentHash,
+      variantId: data.variantId,
+      contentId: data.contentId,
+      platformId: data.platformId,
+      content: data.content,
+      idempotencyContent: data.content,
+      scheduledTime: data.scheduledTime,
+      timezone: data.timezone,
+      maxAttempts: data.maxAttempts,
+      createdBy: currentUserId,
+      idempotencyKey: data.idempotencyKey,
+    };
+
+    if (data.type === 'campaign_post' && data.idempotencyKey) {
+      try {
+        const replay = await scheduler.findIdempotentReplay(requestScheduleInput);
+        if (replay) {
+          return NextResponse.json({ job: replay.job }, { status: 200 });
+        }
+      } catch (error) {
+        if (isIdempotencyConflict(error)) {
+          return Errors.conflict('Idempotency key already identifies another scheduler request');
+        }
+        throw error;
+      }
+    }
+
     let approvalBinding: Awaited<ReturnType<typeof assertApprovedForQueue>> | undefined;
     if (
       data.type === 'campaign_post' &&
@@ -213,24 +245,13 @@ export const POST = withRateLimit(
       }
     }
 
-    const scheduler = getScheduler();
     let scheduled;
     try {
       const scheduleInput = {
-        type: data.type,
-        campaignId: data.campaignId,
-        campaignVersion: data.campaignVersion,
+        ...requestScheduleInput,
         campaignVersionId: approvalBinding?.versionId,
         approvedContentHash: approvalBinding?.contentHash,
-        variantId: data.variantId,
-        contentId: data.contentId,
-        platformId: data.platformId,
         content: approvalBinding?.content ?? data.content,
-        scheduledTime: data.scheduledTime,
-        timezone: data.timezone,
-        maxAttempts: data.maxAttempts,
-        createdBy: currentUserId,
-        idempotencyKey: data.idempotencyKey,
       };
       scheduled = approvalBinding
         ? await scheduler.scheduleCampaignWithAudit(scheduleInput, {

--- a/app/api/scheduler/route.ts
+++ b/app/api/scheduler/route.ts
@@ -234,7 +234,7 @@ export const POST = withRateLimit(
       };
       scheduled = approvalBinding
         ? await scheduler.scheduleCampaignWithAudit(scheduleInput, {
-            campaignId: data.campaignId!,
+            campaignId: approvalBinding.campaignRowId,
             campaignVersionId: approvalBinding.versionId,
             contentId: data.contentId,
             variantId: data.variantId!,

--- a/app/api/scheduler/route.ts
+++ b/app/api/scheduler/route.ts
@@ -14,7 +14,7 @@ import { Errors, withErrorHandling } from '@/app/api/_utils/errors';
 import { withRateLimit, RateLimitPresets } from '@/app/api/_utils/rateLimit';
 import { sanitizeText, validateAndSanitize } from '@/app/api/_utils/sanitize';
 import { platforms } from '@/lib/config/platforms';
-import { assertApprovedForQueue, recordPublishAttempt } from '@/lib/campaigns/repository';
+import { assertApprovedForQueue } from '@/lib/campaigns/repository';
 import { campaignErrorResponse } from '@/app/api/campaigns/_errors';
 
 // ── Zod Schemas ──────────────────────────────────────────────────────────
@@ -220,7 +220,7 @@ export const POST = withRateLimit(
     const scheduler = getScheduler();
     let scheduled;
     try {
-      scheduled = await scheduler.scheduleWithResult({
+      const scheduleInput = {
         type: data.type,
         campaignId: data.campaignId,
         campaignVersion: data.campaignVersion,
@@ -235,38 +235,23 @@ export const POST = withRateLimit(
         maxAttempts: data.maxAttempts,
         createdBy: currentUserId,
         idempotencyKey: data.idempotencyKey,
-      });
+      };
+      scheduled = approvalBinding
+        ? await scheduler.scheduleCampaignWithAudit(scheduleInput, {
+            campaignId: data.campaignId!,
+            campaignVersionId: approvalBinding.versionId,
+            contentId: data.contentId,
+            variantId: data.variantId!,
+            platformId: data.platformId,
+            contentHash: approvalBinding.contentHash,
+            requestedBy: currentUserId,
+          })
+        : await scheduler.scheduleWithResult(scheduleInput);
     } catch (error) {
       if (isIdempotencyConflict(error)) {
         return Errors.conflict('Idempotency key already identifies another scheduler request');
       }
       throw error;
-    }
-
-    if (
-      data.type === 'campaign_post' &&
-      data.campaignId &&
-      data.campaignVersion &&
-      data.contentHash &&
-      data.variantId
-    ) {
-      try {
-        await recordPublishAttempt({
-          userId: currentUserId,
-          campaignId: data.campaignId,
-          version: data.campaignVersion,
-          contentId: data.contentId,
-          variantId: data.variantId,
-          platformId: data.platformId,
-          contentHash: data.contentHash,
-          schedulerJobId: scheduled.job.id,
-        });
-      } catch (error) {
-        if (scheduled.created) {
-          await scheduler.cancel(scheduled.job.id, currentUserId);
-        }
-        return campaignErrorResponse(error) ?? Errors.internalServerError();
-      }
     }
 
     return NextResponse.json({ job: scheduled.job }, { status: scheduled.created ? 201 : 200 });

--- a/app/api/scheduler/route.ts
+++ b/app/api/scheduler/route.ts
@@ -7,6 +7,7 @@
 import { NextResponse } from 'next/server';
 import { z } from 'zod';
 import { getScheduler } from '@/lib/scheduler';
+import { SchedulerQueueError } from '@/lib/scheduler/prisma-queue';
 import type { JobStatus } from '@/lib/scheduler/types';
 import { isAuthenticated, getCurrentUserId } from '@/app/api/_utils/auth';
 import { Errors, withErrorHandling } from '@/app/api/_utils/errors';
@@ -20,7 +21,16 @@ import { campaignErrorResponse } from '@/app/api/campaigns/_errors';
 
 const listJobsQuerySchema = z.object({
   status: z
-    .enum(['pending', 'scheduled', 'processing', 'published', 'failed', 'dead', 'cancelled'])
+    .enum([
+      'pending',
+      'scheduled',
+      'processing',
+      'published',
+      'failed',
+      'dead',
+      'reconciliation_required',
+      'cancelled',
+    ])
     .optional(),
   campaignId: z.string().min(1).optional(),
   limit: z.coerce.number().int().min(1).max(500).default(100),
@@ -69,6 +79,7 @@ const createJobSchema = z
     }),
     timezone: z.string().optional(),
     maxAttempts: z.number().int().min(1).max(20).optional(),
+    idempotencyKey: z.string().min(8).max(200).optional(),
   })
   .superRefine((value, context) => {
     if (value.type !== 'campaign_post') return;
@@ -88,6 +99,16 @@ function getComingSoonPlatformName(platformId: string): string | undefined {
   const platform = platforms.find(p => p.slug === normalizedPlatformId);
 
   return platform?.comingSoon ? platform.name : undefined;
+}
+
+function isIdempotencyConflict(error: unknown): boolean {
+  return (
+    error instanceof SchedulerQueueError ||
+    (typeof error === 'object' &&
+      error !== null &&
+      'code' in error &&
+      error.code === 'IDEMPOTENCY_CONFLICT')
+  );
 }
 
 // ── Route Handlers ───────────────────────────────────────────────────────
@@ -125,23 +146,20 @@ export const GET = withRateLimit(
 
     let jobs;
     if (campaignId) {
-      jobs = await scheduler.getJobsByCampaign(campaignId);
+      jobs = await scheduler.getJobsByCampaign(campaignId, currentUserId);
     } else if (status) {
-      jobs = await scheduler.getJobsByStatus(status as JobStatus, limit + offset);
+      jobs = await scheduler.getJobsByStatus(status as JobStatus, limit + offset, currentUserId);
     } else {
-      jobs = await scheduler.getAllJobs();
+      jobs = await scheduler.getAllJobs(currentUserId);
     }
 
-    // Filter jobs by current user
-    const userJobs = jobs.filter(job => job.createdBy === currentUserId);
-
     // Apply pagination
-    const paginated = userJobs.slice(offset, offset + limit);
+    const paginated = jobs.slice(offset, offset + limit);
 
     return NextResponse.json({
       jobs: paginated,
       count: paginated.length,
-      total: userJobs.length,
+      total: jobs.length,
     });
   }),
   '/api/scheduler',
@@ -209,21 +227,30 @@ export const POST = withRateLimit(
     }
 
     const scheduler = getScheduler();
-    const job = await scheduler.schedule({
-      type: data.type,
-      campaignId: data.campaignId,
-      campaignVersion: data.campaignVersion,
-      campaignVersionId: approvalBinding?.versionId,
-      approvedContentHash: approvalBinding?.contentHash,
-      variantId: data.variantId,
-      contentId: data.contentId,
-      platformId: data.platformId,
-      content: approvalBinding?.content ?? data.content,
-      scheduledTime: data.scheduledTime,
-      timezone: data.timezone,
-      maxAttempts: data.maxAttempts,
-      createdBy: currentUserId,
-    });
+    let job;
+    try {
+      job = await scheduler.schedule({
+        type: data.type,
+        campaignId: data.campaignId,
+        campaignVersion: data.campaignVersion,
+        campaignVersionId: approvalBinding?.versionId,
+        approvedContentHash: approvalBinding?.contentHash,
+        variantId: data.variantId,
+        contentId: data.contentId,
+        platformId: data.platformId,
+        content: approvalBinding?.content ?? data.content,
+        scheduledTime: data.scheduledTime,
+        timezone: data.timezone,
+        maxAttempts: data.maxAttempts,
+        createdBy: currentUserId,
+        idempotencyKey: data.idempotencyKey,
+      });
+    } catch (error) {
+      if (isIdempotencyConflict(error)) {
+        return Errors.conflict('Idempotency key already identifies another scheduler request');
+      }
+      throw error;
+    }
 
     return NextResponse.json({ job }, { status: 201 });
   }),

--- a/app/api/scheduler/stats/route.ts
+++ b/app/api/scheduler/stats/route.ts
@@ -18,6 +18,7 @@ const JOB_STATUSES: JobStatus[] = [
   'published',
   'failed',
   'dead',
+  'reconciliation_required',
   'cancelled',
 ];
 
@@ -40,8 +41,7 @@ export const GET = withRateLimit(
     const scheduler = getScheduler();
 
     // Get all jobs and filter by user
-    const allJobs = await scheduler.getAllJobs();
-    const userJobs = allJobs.filter(job => job.createdBy === currentUserId);
+    const userJobs = await scheduler.getAllJobs(currentUserId);
 
     // Calculate user-specific stats dynamically from JobStatus enum
     const userStats: Record<string, number> = {

--- a/lib/auth/external-user.ts
+++ b/lib/auth/external-user.ts
@@ -1,0 +1,108 @@
+import { createHash, randomBytes } from 'crypto';
+import bcrypt from 'bcryptjs';
+import { Prisma, type PrismaClient } from '@prisma/client';
+
+export interface ExternalUserInput {
+  provider: string;
+  externalId: string;
+  email: string;
+  name: string;
+}
+
+export interface ResolvedExternalUser {
+  id: string;
+  username: string;
+  role: string;
+  isNew: boolean;
+}
+
+export class ExternalIdentityEmailConflictError extends Error {
+  constructor() {
+    super('An account with this email already exists and must be linked explicitly');
+    this.name = 'ExternalIdentityEmailConflictError';
+  }
+}
+
+function identityKey(provider: string, externalId: string) {
+  return { provider_externalId: { provider, externalId } };
+}
+
+function stableUsername(name: string, email: string, provider: string, externalId: string): string {
+  const preferred = name.trim() || email.split('@')[0] || 'user';
+  const base =
+    preferred
+      .normalize('NFKD')
+      .toLowerCase()
+      .replace(/[^a-z0-9_-]+/g, '-')
+      .replace(/^-+|-+$/g, '')
+      .slice(0, 16) || 'user';
+  const suffix = createHash('sha256')
+    .update(`${provider}\0${externalId}`)
+    .digest('hex')
+    .slice(0, 10);
+  return `${base}-${suffix}`;
+}
+
+async function findIdentity(client: PrismaClient, provider: string, externalId: string) {
+  return client.externalIdentity.findUnique({
+    where: identityKey(provider, externalId),
+    select: {
+      user: { select: { id: true, username: true, role: true } },
+    },
+  });
+}
+
+/** Resolve one provider subject to a durable local owner before signing a session. */
+export async function resolveExternalUser(
+  client: PrismaClient,
+  input: ExternalUserInput
+): Promise<ResolvedExternalUser> {
+  const provider = input.provider.trim().toLowerCase();
+  const externalId = input.externalId.trim();
+  const email = input.email.trim().toLowerCase();
+  if (!provider || !externalId || !email) {
+    throw new Error('External identity is missing a provider, subject, or email');
+  }
+
+  const existing = await findIdentity(client, provider, externalId);
+  if (existing) {
+    return { ...existing.user, isNew: false };
+  }
+
+  // Linking solely by an email claim could attach an attacker-controlled
+  // provider identity to a local password account. Require an explicit linking
+  // flow instead.
+  if (await client.user.findUnique({ where: { email }, select: { id: true } })) {
+    throw new ExternalIdentityEmailConflictError();
+  }
+
+  const username = stableUsername(input.name, email, provider, externalId);
+  const passwordHash = await bcrypt.hash(randomBytes(32).toString('base64url'), 10);
+
+  try {
+    const created = await client.user.create({
+      data: {
+        username,
+        email,
+        passwordHash,
+        role: 'user',
+        externalIdentities: { create: { provider, externalId } },
+      },
+      select: { id: true, username: true, role: true },
+    });
+    return { ...created, isNew: true };
+  } catch (error) {
+    // A concurrent callback for the same provider subject may win the unique
+    // constraint. Resolve that durable winner rather than minting two owners.
+    if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2002') {
+      const winner = await findIdentity(client, provider, externalId);
+      if (winner) {
+        return { ...winner.user, isNew: false };
+      }
+      if (await client.user.findUnique({ where: { email }, select: { id: true } })) {
+        throw new ExternalIdentityEmailConflictError();
+      }
+    }
+    throw error;
+  }
+}

--- a/lib/auth/external-user.ts
+++ b/lib/auth/external-user.ts
@@ -52,6 +52,13 @@ async function findIdentity(client: PrismaClient, provider: string, externalId: 
   });
 }
 
+async function findEmailOwner(client: PrismaClient, email: string) {
+  return client.user.findFirst({
+    where: { email: { equals: email, mode: 'insensitive' } },
+    select: { id: true },
+  });
+}
+
 /** Resolve one provider subject to a durable local owner before signing a session. */
 export async function resolveExternalUser(
   client: PrismaClient,
@@ -72,7 +79,7 @@ export async function resolveExternalUser(
   // Linking solely by an email claim could attach an attacker-controlled
   // provider identity to a local password account. Require an explicit linking
   // flow instead.
-  if (await client.user.findUnique({ where: { email }, select: { id: true } })) {
+  if (await findEmailOwner(client, email)) {
     throw new ExternalIdentityEmailConflictError();
   }
 
@@ -99,7 +106,7 @@ export async function resolveExternalUser(
       if (winner) {
         return { ...winner.user, isNew: false };
       }
-      if (await client.user.findUnique({ where: { email }, select: { id: true } })) {
+      if (await findEmailOwner(client, email)) {
         throw new ExternalIdentityEmailConflictError();
       }
     }

--- a/lib/campaigns/repository.ts
+++ b/lib/campaigns/repository.ts
@@ -433,6 +433,7 @@ export async function recordPublishAttempt(input: {
   variantId: string;
   platformId: string;
   contentHash: string;
+  schedulerJobId: string;
 }) {
   const client = getClient();
   const campaign = await ownedCampaign(client, input.campaignId, input.userId);
@@ -453,8 +454,9 @@ export async function recordPublishAttempt(input: {
       'Publish attempt content hash does not match its campaign version'
     );
   }
-  return client.publishAttempt.create({
-    data: {
+  return client.publishAttempt.upsert({
+    where: { schedulerJobId: input.schedulerJobId },
+    create: {
       campaignId: campaign.id,
       campaignVersionId: version.id,
       contentId: input.contentId,
@@ -462,7 +464,9 @@ export async function recordPublishAttempt(input: {
       platformId: input.platformId,
       contentHash: input.contentHash,
       requestedBy: input.userId,
+      schedulerJobId: input.schedulerJobId,
     },
+    update: {},
   });
 }
 

--- a/lib/campaigns/repository.ts
+++ b/lib/campaigns/repository.ts
@@ -433,7 +433,6 @@ export async function recordPublishAttempt(input: {
   variantId: string;
   platformId: string;
   contentHash: string;
-  schedulerJobId: string;
 }) {
   const client = getClient();
   const campaign = await ownedCampaign(client, input.campaignId, input.userId);
@@ -454,9 +453,8 @@ export async function recordPublishAttempt(input: {
       'Publish attempt content hash does not match its campaign version'
     );
   }
-  return client.publishAttempt.upsert({
-    where: { schedulerJobId: input.schedulerJobId },
-    create: {
+  return client.publishAttempt.create({
+    data: {
       campaignId: campaign.id,
       campaignVersionId: version.id,
       contentId: input.contentId,
@@ -464,9 +462,7 @@ export async function recordPublishAttempt(input: {
       platformId: input.platformId,
       contentHash: input.contentHash,
       requestedBy: input.userId,
-      schedulerJobId: input.schedulerJobId,
     },
-    update: {},
   });
 }
 

--- a/lib/campaigns/repository.ts
+++ b/lib/campaigns/repository.ts
@@ -319,6 +319,7 @@ export async function assertApprovedForQueue(input: {
   platformId: string;
   contentHash: string;
 }): Promise<{
+  campaignRowId: string;
   versionId: string;
   contentHash: string;
   content: ScheduledJob['content'];
@@ -370,6 +371,7 @@ export async function assertApprovedForQueue(input: {
   }
 
   return {
+    campaignRowId: campaign.id,
     versionId: version.id,
     contentHash: approval.contentHash,
     content: {

--- a/lib/scheduler/index.ts
+++ b/lib/scheduler/index.ts
@@ -14,6 +14,7 @@ export type {
   SchedulerConfig,
   CreateJobInput,
   JobQueue,
+  ClaimedJobUpdate,
   PlatformAdapter,
   PlatformPublishResult,
   ValidationResult,
@@ -26,6 +27,7 @@ export { RATE_LIMITS, DEFAULT_SCHEDULER_CONFIG } from './types';
 
 // Queue
 export { getQueue, generateJobId, InMemoryQueue } from './queue';
+export { PrismaJobQueue, SchedulerQueueError } from './prisma-queue';
 
 // Rate Limiter
 export { getRateLimiter, RateLimiter } from './rate-limiter';

--- a/lib/scheduler/prisma-queue.ts
+++ b/lib/scheduler/prisma-queue.ts
@@ -1,0 +1,349 @@
+import type { Prisma, PrismaClient, SchedulerJob as StoredSchedulerJob } from '@prisma/client';
+import { z } from 'zod';
+import type { ClaimedJobUpdate, JobQueue, JobStatus, ScheduledJob } from './types';
+
+const jobStatusSchema = z.enum([
+  'pending',
+  'scheduled',
+  'processing',
+  'published',
+  'failed',
+  'dead',
+  'reconciliation_required',
+  'cancelled',
+]);
+
+const jobTypeSchema = z.enum(['campaign_post', 'series_promotion', 'standalone']);
+
+const contentSchema = z.object({
+  text: z.string(),
+  mediaUrls: z.array(z.string()).optional(),
+  hashtags: z.array(z.string()).optional(),
+  mentions: z.array(z.string()).optional(),
+  tiktokPrivacyLevel: z.string().optional(),
+  isThread: z.boolean().optional(),
+  threadParts: z
+    .array(
+      z.object({
+        order: z.number().int(),
+        text: z.string(),
+        mediaUrls: z.array(z.string()).optional(),
+      })
+    )
+    .optional(),
+});
+
+export class SchedulerQueueError extends Error {
+  constructor(
+    readonly code: 'TENANT_REQUIRED' | 'IDEMPOTENCY_CONFLICT' | 'CORRUPT_JOB',
+    message: string
+  ) {
+    super(message);
+    this.name = 'SchedulerQueueError';
+  }
+}
+
+function parseStoredJob(row: StoredSchedulerJob): ScheduledJob {
+  try {
+    return {
+      id: row.id,
+      idempotencyKey: row.idempotencyKey,
+      type: jobTypeSchema.parse(row.type),
+      campaignId: row.campaignId ?? undefined,
+      campaignVersion: row.campaignVersion ?? undefined,
+      campaignVersionId: row.campaignVersionId ?? undefined,
+      approvedContentHash: row.approvedContentHash ?? undefined,
+      variantId: row.variantId ?? undefined,
+      contentId: row.contentId,
+      platformId: row.platformId,
+      content: contentSchema.parse(JSON.parse(row.content)),
+      scheduledTime: row.scheduledAt.toISOString(),
+      timezone: row.timezone,
+      status: jobStatusSchema.parse(row.status),
+      attempts: row.attempts,
+      maxAttempts: row.maxAttempts,
+      lastAttemptAt: row.lastAttemptAt?.toISOString(),
+      nextRetryAt: row.nextRetryAt?.toISOString(),
+      leaseToken: row.leaseToken ?? undefined,
+      leaseExpiresAt: row.leaseExpiresAt?.toISOString(),
+      publishedAt: row.publishedAt?.toISOString(),
+      publishedUrl: row.publishedUrl ?? undefined,
+      platformPostId: row.platformPostId ?? undefined,
+      error: row.error ?? undefined,
+      createdAt: row.createdAt.toISOString(),
+      updatedAt: row.updatedAt.toISOString(),
+      createdBy: row.userId,
+    };
+  } catch (error) {
+    throw new SchedulerQueueError(
+      'CORRUPT_JOB',
+      `Scheduler job ${row.id} could not be decoded: ${error instanceof Error ? error.message : 'invalid data'}`
+    );
+  }
+}
+
+function createData(job: ScheduledJob): Prisma.SchedulerJobUncheckedCreateInput {
+  if (!job.createdBy) {
+    throw new SchedulerQueueError('TENANT_REQUIRED', 'Durable scheduler jobs require an owner');
+  }
+  return {
+    id: job.id,
+    userId: job.createdBy,
+    idempotencyKey: job.idempotencyKey,
+    type: job.type,
+    campaignId: job.campaignId,
+    campaignVersion: job.campaignVersion,
+    campaignVersionId: job.campaignVersionId,
+    approvedContentHash: job.approvedContentHash,
+    variantId: job.variantId,
+    contentId: job.contentId,
+    platformId: job.platformId,
+    content: JSON.stringify(job.content),
+    scheduledAt: new Date(job.scheduledTime),
+    timezone: job.timezone,
+    status: job.status,
+    attempts: job.attempts,
+    maxAttempts: job.maxAttempts,
+    lastAttemptAt: job.lastAttemptAt ? new Date(job.lastAttemptAt) : undefined,
+    nextRetryAt: job.nextRetryAt ? new Date(job.nextRetryAt) : undefined,
+    leaseToken: job.leaseToken,
+    leaseExpiresAt: job.leaseExpiresAt ? new Date(job.leaseExpiresAt) : undefined,
+    publishedAt: job.publishedAt ? new Date(job.publishedAt) : undefined,
+    publishedUrl: job.publishedUrl,
+    platformPostId: job.platformPostId,
+    error: job.error,
+    createdAt: new Date(job.createdAt),
+    updatedAt: new Date(job.updatedAt),
+  };
+}
+
+function sameIdempotentRequest(row: StoredSchedulerJob, job: ScheduledJob): boolean {
+  return (
+    row.type === job.type &&
+    row.contentId === job.contentId &&
+    row.platformId === job.platformId &&
+    row.campaignId === (job.campaignId ?? null) &&
+    row.campaignVersion === (job.campaignVersion ?? null) &&
+    row.campaignVersionId === (job.campaignVersionId ?? null) &&
+    row.approvedContentHash === (job.approvedContentHash ?? null) &&
+    row.variantId === (job.variantId ?? null) &&
+    row.scheduledAt.toISOString() === new Date(job.scheduledTime).toISOString() &&
+    row.content === JSON.stringify(job.content) &&
+    row.timezone === job.timezone &&
+    row.maxAttempts === job.maxAttempts
+  );
+}
+
+function hasOwn<T extends object>(value: T, key: keyof T): boolean {
+  return Object.prototype.hasOwnProperty.call(value, key);
+}
+
+function updateData(updates: Partial<ScheduledJob>): Prisma.SchedulerJobUncheckedUpdateInput {
+  const data: Prisma.SchedulerJobUncheckedUpdateInput = {};
+  if (hasOwn(updates, 'status')) data.status = updates.status;
+  if (hasOwn(updates, 'scheduledTime')) {
+    data.scheduledAt = updates.scheduledTime ? new Date(updates.scheduledTime) : undefined;
+  }
+  if (hasOwn(updates, 'attempts')) data.attempts = updates.attempts;
+  if (hasOwn(updates, 'lastAttemptAt')) {
+    data.lastAttemptAt = updates.lastAttemptAt ? new Date(updates.lastAttemptAt) : null;
+  }
+  if (hasOwn(updates, 'nextRetryAt')) {
+    data.nextRetryAt = updates.nextRetryAt ? new Date(updates.nextRetryAt) : null;
+  }
+  if (hasOwn(updates, 'leaseToken')) data.leaseToken = updates.leaseToken ?? null;
+  if (hasOwn(updates, 'leaseExpiresAt')) {
+    data.leaseExpiresAt = updates.leaseExpiresAt ? new Date(updates.leaseExpiresAt) : null;
+  }
+  if (hasOwn(updates, 'publishedAt')) {
+    data.publishedAt = updates.publishedAt ? new Date(updates.publishedAt) : null;
+  }
+  if (hasOwn(updates, 'publishedUrl')) data.publishedUrl = updates.publishedUrl ?? null;
+  if (hasOwn(updates, 'platformPostId')) data.platformPostId = updates.platformPostId ?? null;
+  if (hasOwn(updates, 'error')) data.error = updates.error ?? null;
+  if (hasOwn(updates, 'content')) data.content = JSON.stringify(updates.content);
+  if (hasOwn(updates, 'timezone')) data.timezone = updates.timezone;
+  if (hasOwn(updates, 'maxAttempts')) data.maxAttempts = updates.maxAttempts;
+  return data;
+}
+
+export class PrismaJobQueue implements JobQueue {
+  constructor(private readonly client: PrismaClient) {}
+
+  async add(job: ScheduledJob): Promise<{ job: ScheduledJob; created: boolean }> {
+    if (!job.createdBy) {
+      throw new SchedulerQueueError('TENANT_REQUIRED', 'Durable scheduler jobs require an owner');
+    }
+    const existing = await this.client.schedulerJob.findUnique({
+      where: {
+        userId_idempotencyKey: {
+          userId: job.createdBy,
+          idempotencyKey: job.idempotencyKey,
+        },
+      },
+    });
+    if (existing) {
+      if (!sameIdempotentRequest(existing, job)) {
+        throw new SchedulerQueueError(
+          'IDEMPOTENCY_CONFLICT',
+          'The idempotency key already identifies a different scheduler request'
+        );
+      }
+      return { job: parseStoredJob(existing), created: false };
+    }
+
+    try {
+      const created = await this.client.schedulerJob.create({ data: createData(job) });
+      return { job: parseStoredJob(created), created: true };
+    } catch (error) {
+      const winner = await this.client.schedulerJob.findUnique({
+        where: {
+          userId_idempotencyKey: {
+            userId: job.createdBy,
+            idempotencyKey: job.idempotencyKey,
+          },
+        },
+      });
+      if (!winner) throw error;
+      if (!sameIdempotentRequest(winner, job)) {
+        throw new SchedulerQueueError(
+          'IDEMPOTENCY_CONFLICT',
+          'The idempotency key already identifies a different scheduler request'
+        );
+      }
+      return { job: parseStoredJob(winner), created: false };
+    }
+  }
+
+  async get(id: string, userId?: string): Promise<ScheduledJob | null> {
+    const row = await this.client.schedulerJob.findFirst({ where: { id, userId } });
+    return row ? parseStoredJob(row) : null;
+  }
+
+  async update(id: string, updates: Partial<ScheduledJob>): Promise<void> {
+    await this.client.schedulerJob.updateMany({ where: { id }, data: updateData(updates) });
+  }
+
+  async remove(id: string): Promise<void> {
+    await this.client.schedulerJob.deleteMany({ where: { id } });
+  }
+
+  async getDueJobs(before: Date, limit: number): Promise<ScheduledJob[]> {
+    const rows = await this.client.schedulerJob.findMany({
+      where: {
+        OR: [
+          { status: 'scheduled', scheduledAt: { lte: before } },
+          { status: 'failed', nextRetryAt: { lte: before } },
+        ],
+      },
+      orderBy: [{ scheduledAt: 'asc' }, { createdAt: 'asc' }],
+      take: limit,
+    });
+    return rows.map(parseStoredJob);
+  }
+
+  async claimDueJobs(
+    before: Date,
+    limit: number,
+    leaseToken: string,
+    leaseExpiresAt: Date
+  ): Promise<ScheduledJob[]> {
+    await this.client.schedulerJob.updateMany({
+      where: { status: 'processing', leaseExpiresAt: { lte: before } },
+      data: {
+        status: 'reconciliation_required',
+        leaseToken: null,
+        leaseExpiresAt: null,
+        errorCode: 'LEASE_EXPIRED_UNKNOWN_RESULT',
+        error: 'Processing lease expired before the provider result was recorded',
+      },
+    });
+
+    const candidates = await this.client.schedulerJob.findMany({
+      where: {
+        OR: [
+          { status: 'scheduled', scheduledAt: { lte: before } },
+          { status: 'failed', nextRetryAt: { lte: before } },
+        ],
+      },
+      orderBy: [{ scheduledAt: 'asc' }, { createdAt: 'asc' }],
+      take: Math.max(limit * 4, limit),
+    });
+
+    const claimed: ScheduledJob[] = [];
+    for (const candidate of candidates) {
+      if (claimed.length >= limit) break;
+      const dueGuard =
+        candidate.status === 'scheduled'
+          ? { id: candidate.id, status: 'scheduled', scheduledAt: { lte: before } }
+          : { id: candidate.id, status: 'failed', nextRetryAt: { lte: before } };
+      const claim = await this.client.schedulerJob.updateMany({
+        where: dueGuard,
+        data: {
+          status: 'processing',
+          attempts: { increment: 1 },
+          lastAttemptAt: before,
+          leaseToken,
+          leaseExpiresAt,
+          errorCode: null,
+          error: null,
+        },
+      });
+      if (claim.count !== 1) continue;
+      const row = await this.client.schedulerJob.findUnique({ where: { id: candidate.id } });
+      if (row) claimed.push(parseStoredJob(row));
+    }
+    return claimed;
+  }
+
+  async updateClaimed(id: string, leaseToken: string, updates: ClaimedJobUpdate): Promise<boolean> {
+    const result = await this.client.schedulerJob.updateMany({
+      where: { id, status: 'processing', leaseToken },
+      data: {
+        ...updateData(updates),
+        leaseToken: null,
+        leaseExpiresAt: null,
+      },
+    });
+    return result.count === 1;
+  }
+
+  async getByStatus(status: JobStatus, limit?: number, userId?: string): Promise<ScheduledJob[]> {
+    const rows = await this.client.schedulerJob.findMany({
+      where: { status, userId },
+      orderBy: [{ scheduledAt: 'asc' }, { createdAt: 'asc' }],
+      take: limit,
+    });
+    return rows.map(parseStoredJob);
+  }
+
+  async getByCampaign(campaignId: string, userId?: string): Promise<ScheduledJob[]> {
+    const rows = await this.client.schedulerJob.findMany({
+      where: { campaignId, userId },
+      orderBy: [{ scheduledAt: 'asc' }, { createdAt: 'asc' }],
+    });
+    return rows.map(parseStoredJob);
+  }
+
+  async getAll(userId?: string): Promise<ScheduledJob[]> {
+    const rows = await this.client.schedulerJob.findMany({
+      where: { userId },
+      orderBy: [{ scheduledAt: 'asc' }, { createdAt: 'asc' }],
+    });
+    return rows.map(parseStoredJob);
+  }
+
+  async count(): Promise<number> {
+    return this.client.schedulerJob.count();
+  }
+
+  async clear(userId?: string): Promise<void> {
+    if (!userId) {
+      throw new SchedulerQueueError(
+        'TENANT_REQUIRED',
+        'Durable scheduler cleanup requires an owner'
+      );
+    }
+    await this.client.schedulerJob.deleteMany({ where: { userId } });
+  }
+}

--- a/lib/scheduler/prisma-queue.ts
+++ b/lib/scheduler/prisma-queue.ts
@@ -235,7 +235,6 @@ export class PrismaJobQueue implements JobQueue {
   ): Promise<{ job: ScheduledJob; created: boolean }> {
     if (
       job.createdBy !== audit.requestedBy ||
-      job.campaignId !== audit.campaignId ||
       job.campaignVersionId !== audit.campaignVersionId ||
       job.contentId !== audit.contentId ||
       job.variantId !== audit.variantId ||
@@ -249,6 +248,16 @@ export class PrismaJobQueue implements JobQueue {
     }
 
     return this.client.$transaction(async transaction => {
+      const approvedVersion = await transaction.campaignVersion.findFirst({
+        where: { id: audit.campaignVersionId, campaignId: audit.campaignId },
+        select: { id: true },
+      });
+      if (!approvedVersion) {
+        throw new SchedulerQueueError(
+          'IDEMPOTENCY_CONFLICT',
+          'Campaign audit binding does not match the approved campaign version'
+        );
+      }
       const persisted = await this.addUsing(transaction, job);
       await transaction.publishAttempt.upsert({
         where: { schedulerJobId: persisted.job.id },

--- a/lib/scheduler/prisma-queue.ts
+++ b/lib/scheduler/prisma-queue.ts
@@ -48,6 +48,7 @@ function parseStoredJob(row: StoredSchedulerJob): ScheduledJob {
     return {
       id: row.id,
       idempotencyKey: row.idempotencyKey,
+      requestFingerprint: row.requestFingerprint,
       type: jobTypeSchema.parse(row.type),
       campaignId: row.campaignId ?? undefined,
       campaignVersion: row.campaignVersion ?? undefined,
@@ -90,6 +91,7 @@ function createData(job: ScheduledJob): Prisma.SchedulerJobUncheckedCreateInput 
     id: job.id,
     userId: job.createdBy,
     idempotencyKey: job.idempotencyKey,
+    requestFingerprint: job.requestFingerprint,
     type: job.type,
     campaignId: job.campaignId,
     campaignVersion: job.campaignVersion,
@@ -118,20 +120,7 @@ function createData(job: ScheduledJob): Prisma.SchedulerJobUncheckedCreateInput 
 }
 
 function sameIdempotentRequest(row: StoredSchedulerJob, job: ScheduledJob): boolean {
-  return (
-    row.type === job.type &&
-    row.contentId === job.contentId &&
-    row.platformId === job.platformId &&
-    row.campaignId === (job.campaignId ?? null) &&
-    row.campaignVersion === (job.campaignVersion ?? null) &&
-    row.campaignVersionId === (job.campaignVersionId ?? null) &&
-    row.approvedContentHash === (job.approvedContentHash ?? null) &&
-    row.variantId === (job.variantId ?? null) &&
-    row.scheduledAt.toISOString() === new Date(job.scheduledTime).toISOString() &&
-    row.content === JSON.stringify(job.content) &&
-    row.timezone === job.timezone &&
-    row.maxAttempts === job.maxAttempts
-  );
+  return row.requestFingerprint === job.requestFingerprint;
 }
 
 function hasOwn<T extends object>(value: T, key: keyof T): boolean {
@@ -224,6 +213,19 @@ export class PrismaJobQueue implements JobQueue {
     await this.client.schedulerJob.updateMany({ where: { id }, data: updateData(updates) });
   }
 
+  async updateIfStatus(
+    id: string,
+    statuses: JobStatus[],
+    updates: Partial<ScheduledJob>,
+    userId?: string
+  ): Promise<boolean> {
+    const result = await this.client.schedulerJob.updateMany({
+      where: { id, userId, status: { in: statuses } },
+      data: updateData(updates),
+    });
+    return result.count === 1;
+  }
+
   async remove(id: string): Promise<void> {
     await this.client.schedulerJob.deleteMany({ where: { id } });
   }
@@ -281,8 +283,6 @@ export class PrismaJobQueue implements JobQueue {
         where: dueGuard,
         data: {
           status: 'processing',
-          attempts: { increment: 1 },
-          lastAttemptAt: before,
           leaseToken,
           leaseExpiresAt,
           errorCode: null,
@@ -294,6 +294,22 @@ export class PrismaJobQueue implements JobQueue {
       if (row) claimed.push(parseStoredJob(row));
     }
     return claimed;
+  }
+
+  async markClaimAttempt(
+    id: string,
+    leaseToken: string,
+    attemptedAt: Date
+  ): Promise<ScheduledJob | null> {
+    const result = await this.client.schedulerJob.updateMany({
+      where: { id, status: 'processing', leaseToken },
+      data: { attempts: { increment: 1 }, lastAttemptAt: attemptedAt },
+    });
+    if (result.count !== 1) return null;
+    const row = await this.client.schedulerJob.findFirst({
+      where: { id, status: 'processing', leaseToken },
+    });
+    return row ? parseStoredJob(row) : null;
   }
 
   async updateClaimed(id: string, leaseToken: string, updates: ClaimedJobUpdate): Promise<boolean> {

--- a/lib/scheduler/prisma-queue.ts
+++ b/lib/scheduler/prisma-queue.ts
@@ -408,6 +408,19 @@ export class PrismaJobQueue implements JobQueue {
     return row ? parseStoredJob(row) : null;
   }
 
+  async renewClaimLease(id: string, leaseToken: string, leaseExpiresAt: Date): Promise<boolean> {
+    const result = await this.client.schedulerJob.updateMany({
+      where: {
+        id,
+        status: 'processing',
+        leaseToken,
+        attemptStartedAt: { not: null },
+      },
+      data: { leaseExpiresAt },
+    });
+    return result.count === 1;
+  }
+
   async updateClaimed(id: string, leaseToken: string, updates: ClaimedJobUpdate): Promise<boolean> {
     const result = await this.client.schedulerJob.updateMany({
       where: { id, status: 'processing', leaseToken },

--- a/lib/scheduler/prisma-queue.ts
+++ b/lib/scheduler/prisma-queue.ts
@@ -282,6 +282,13 @@ export class PrismaJobQueue implements JobQueue {
     return row ? parseStoredJob(row) : null;
   }
 
+  async getByIdempotencyKey(userId: string, idempotencyKey: string): Promise<ScheduledJob | null> {
+    const row = await this.client.schedulerJob.findUnique({
+      where: { userId_idempotencyKey: { userId, idempotencyKey } },
+    });
+    return row ? parseStoredJob(row) : null;
+  }
+
   async update(id: string, updates: Partial<ScheduledJob>): Promise<void> {
     await this.client.schedulerJob.updateMany({ where: { id }, data: updateData(updates) });
   }

--- a/lib/scheduler/prisma-queue.ts
+++ b/lib/scheduler/prisma-queue.ts
@@ -311,7 +311,7 @@ export class PrismaJobQueue implements JobQueue {
           { status: 'failed', nextRetryAt: { lte: before } },
         ],
       },
-      orderBy: [{ scheduledAt: 'asc' }, { createdAt: 'asc' }],
+      orderBy: [{ scheduledAt: 'asc' }, { createdAt: 'asc' }, { id: 'asc' }],
       take: limit,
     });
     return rows.map(parseStoredJob);
@@ -375,7 +375,7 @@ export class PrismaJobQueue implements JobQueue {
           { status: 'failed', nextRetryAt: { lte: before } },
         ],
       },
-      orderBy: [{ scheduledAt: 'asc' }, { createdAt: 'asc' }],
+      orderBy: [{ scheduledAt: 'asc' }, { createdAt: 'asc' }, { id: 'asc' }],
       take: Math.max(limit * 4, limit),
     });
 
@@ -453,7 +453,7 @@ export class PrismaJobQueue implements JobQueue {
   async getByStatus(status: JobStatus, limit?: number, userId?: string): Promise<ScheduledJob[]> {
     const rows = await this.client.schedulerJob.findMany({
       where: { status, userId },
-      orderBy: [{ scheduledAt: 'asc' }, { createdAt: 'asc' }],
+      orderBy: [{ scheduledAt: 'asc' }, { createdAt: 'asc' }, { id: 'asc' }],
       take: limit,
     });
     return rows.map(parseStoredJob);
@@ -462,7 +462,7 @@ export class PrismaJobQueue implements JobQueue {
   async getByCampaign(campaignId: string, userId?: string): Promise<ScheduledJob[]> {
     const rows = await this.client.schedulerJob.findMany({
       where: { campaignId, userId },
-      orderBy: [{ scheduledAt: 'asc' }, { createdAt: 'asc' }],
+      orderBy: [{ scheduledAt: 'asc' }, { createdAt: 'asc' }, { id: 'asc' }],
     });
     return rows.map(parseStoredJob);
   }
@@ -470,7 +470,7 @@ export class PrismaJobQueue implements JobQueue {
   async getAll(userId?: string): Promise<ScheduledJob[]> {
     const rows = await this.client.schedulerJob.findMany({
       where: { userId },
-      orderBy: [{ scheduledAt: 'asc' }, { createdAt: 'asc' }],
+      orderBy: [{ scheduledAt: 'asc' }, { createdAt: 'asc' }, { id: 'asc' }],
     });
     return rows.map(parseStoredJob);
   }
@@ -484,7 +484,7 @@ export class PrismaJobQueue implements JobQueue {
     const [rows, total] = await this.client.$transaction([
       this.client.schedulerJob.findMany({
         where,
-        orderBy: [{ scheduledAt: 'asc' }, { createdAt: 'asc' }],
+        orderBy: [{ scheduledAt: 'asc' }, { createdAt: 'asc' }, { id: 'asc' }],
         skip: options.offset,
         take: options.limit,
       }),

--- a/lib/scheduler/prisma-queue.ts
+++ b/lib/scheduler/prisma-queue.ts
@@ -1,6 +1,13 @@
 import type { Prisma, PrismaClient, SchedulerJob as StoredSchedulerJob } from '@prisma/client';
 import { z } from 'zod';
-import type { ClaimedJobUpdate, JobQueue, JobStatus, ScheduledJob } from './types';
+import type {
+  ClaimedJobUpdate,
+  JobQueue,
+  JobStatus,
+  ScheduledJob,
+  ListJobsOptions,
+  ListJobsResult,
+} from './types';
 
 export interface CampaignPublishAuditInput {
   campaignId: string;
@@ -457,6 +464,24 @@ export class PrismaJobQueue implements JobQueue {
       orderBy: [{ scheduledAt: 'asc' }, { createdAt: 'asc' }],
     });
     return rows.map(parseStoredJob);
+  }
+
+  async list(options: ListJobsOptions): Promise<ListJobsResult> {
+    const where = {
+      userId: options.userId,
+      status: options.status,
+      campaignId: options.campaignId,
+    };
+    const [rows, total] = await this.client.$transaction([
+      this.client.schedulerJob.findMany({
+        where,
+        orderBy: [{ scheduledAt: 'asc' }, { createdAt: 'asc' }],
+        skip: options.offset,
+        take: options.limit,
+      }),
+      this.client.schedulerJob.count({ where }),
+    ]);
+    return { jobs: rows.map(parseStoredJob), total };
   }
 
   async count(): Promise<number> {

--- a/lib/scheduler/prisma-queue.ts
+++ b/lib/scheduler/prisma-queue.ts
@@ -2,6 +2,16 @@ import type { Prisma, PrismaClient, SchedulerJob as StoredSchedulerJob } from '@
 import { z } from 'zod';
 import type { ClaimedJobUpdate, JobQueue, JobStatus, ScheduledJob } from './types';
 
+export interface CampaignPublishAuditInput {
+  campaignId: string;
+  campaignVersionId: string;
+  contentId: string;
+  variantId: string;
+  platformId: string;
+  contentHash: string;
+  requestedBy: string;
+}
+
 const jobStatusSchema = z.enum([
   'pending',
   'scheduled',
@@ -67,6 +77,7 @@ function parseStoredJob(row: StoredSchedulerJob): ScheduledJob {
       nextRetryAt: row.nextRetryAt?.toISOString(),
       leaseToken: row.leaseToken ?? undefined,
       leaseExpiresAt: row.leaseExpiresAt?.toISOString(),
+      attemptStartedAt: row.attemptStartedAt?.toISOString(),
       publishedAt: row.publishedAt?.toISOString(),
       publishedUrl: row.publishedUrl ?? undefined,
       platformPostId: row.platformPostId ?? undefined,
@@ -110,6 +121,7 @@ function createData(job: ScheduledJob): Prisma.SchedulerJobUncheckedCreateInput 
     nextRetryAt: job.nextRetryAt ? new Date(job.nextRetryAt) : undefined,
     leaseToken: job.leaseToken,
     leaseExpiresAt: job.leaseExpiresAt ? new Date(job.leaseExpiresAt) : undefined,
+    attemptStartedAt: job.attemptStartedAt ? new Date(job.attemptStartedAt) : undefined,
     publishedAt: job.publishedAt ? new Date(job.publishedAt) : undefined,
     publishedUrl: job.publishedUrl,
     platformPostId: job.platformPostId,
@@ -144,6 +156,9 @@ function updateData(updates: Partial<ScheduledJob>): Prisma.SchedulerJobUnchecke
   if (hasOwn(updates, 'leaseExpiresAt')) {
     data.leaseExpiresAt = updates.leaseExpiresAt ? new Date(updates.leaseExpiresAt) : null;
   }
+  if (hasOwn(updates, 'attemptStartedAt')) {
+    data.attemptStartedAt = updates.attemptStartedAt ? new Date(updates.attemptStartedAt) : null;
+  }
   if (hasOwn(updates, 'publishedAt')) {
     data.publishedAt = updates.publishedAt ? new Date(updates.publishedAt) : null;
   }
@@ -159,11 +174,14 @@ function updateData(updates: Partial<ScheduledJob>): Prisma.SchedulerJobUnchecke
 export class PrismaJobQueue implements JobQueue {
   constructor(private readonly client: PrismaClient) {}
 
-  async add(job: ScheduledJob): Promise<{ job: ScheduledJob; created: boolean }> {
+  private async addUsing(
+    client: PrismaClient | Prisma.TransactionClient,
+    job: ScheduledJob
+  ): Promise<{ job: ScheduledJob; created: boolean }> {
     if (!job.createdBy) {
       throw new SchedulerQueueError('TENANT_REQUIRED', 'Durable scheduler jobs require an owner');
     }
-    const existing = await this.client.schedulerJob.findUnique({
+    const existing = await client.schedulerJob.findUnique({
       where: {
         userId_idempotencyKey: {
           userId: job.createdBy,
@@ -181,27 +199,66 @@ export class PrismaJobQueue implements JobQueue {
       return { job: parseStoredJob(existing), created: false };
     }
 
-    try {
-      const created = await this.client.schedulerJob.create({ data: createData(job) });
-      return { job: parseStoredJob(created), created: true };
-    } catch (error) {
-      const winner = await this.client.schedulerJob.findUnique({
-        where: {
-          userId_idempotencyKey: {
-            userId: job.createdBy,
-            idempotencyKey: job.idempotencyKey,
-          },
+    const persisted = await client.schedulerJob.upsert({
+      where: {
+        userId_idempotencyKey: {
+          userId: job.createdBy,
+          idempotencyKey: job.idempotencyKey,
         },
-      });
-      if (!winner) throw error;
-      if (!sameIdempotentRequest(winner, job)) {
-        throw new SchedulerQueueError(
-          'IDEMPOTENCY_CONFLICT',
-          'The idempotency key already identifies a different scheduler request'
-        );
-      }
-      return { job: parseStoredJob(winner), created: false };
+      },
+      create: createData(job),
+      update: {},
+    });
+    if (!sameIdempotentRequest(persisted, job)) {
+      throw new SchedulerQueueError(
+        'IDEMPOTENCY_CONFLICT',
+        'The idempotency key already identifies a different scheduler request'
+      );
     }
+    return { job: parseStoredJob(persisted), created: persisted.id === job.id };
+  }
+
+  async add(job: ScheduledJob): Promise<{ job: ScheduledJob; created: boolean }> {
+    return this.addUsing(this.client, job);
+  }
+
+  async addCampaignJob(
+    job: ScheduledJob,
+    audit: CampaignPublishAuditInput
+  ): Promise<{ job: ScheduledJob; created: boolean }> {
+    if (
+      job.createdBy !== audit.requestedBy ||
+      job.campaignId !== audit.campaignId ||
+      job.campaignVersionId !== audit.campaignVersionId ||
+      job.contentId !== audit.contentId ||
+      job.variantId !== audit.variantId ||
+      job.platformId !== audit.platformId ||
+      job.approvedContentHash !== audit.contentHash
+    ) {
+      throw new SchedulerQueueError(
+        'IDEMPOTENCY_CONFLICT',
+        'Campaign audit binding does not match the scheduler request'
+      );
+    }
+
+    return this.client.$transaction(async transaction => {
+      const persisted = await this.addUsing(transaction, job);
+      await transaction.publishAttempt.upsert({
+        where: { schedulerJobId: persisted.job.id },
+        create: {
+          campaignId: audit.campaignId,
+          campaignVersionId: audit.campaignVersionId,
+          contentId: audit.contentId,
+          variantId: audit.variantId,
+          platformId: audit.platformId,
+          contentHash: audit.contentHash,
+          requestedBy: audit.requestedBy,
+          schedulerJobId: persisted.job.id,
+        },
+        update: {},
+      });
+      return persisted;
+    });
   }
 
   async get(id: string, userId?: string): Promise<ScheduledJob | null> {
@@ -251,7 +308,41 @@ export class PrismaJobQueue implements JobQueue {
     leaseExpiresAt: Date
   ): Promise<ScheduledJob[]> {
     await this.client.schedulerJob.updateMany({
-      where: { status: 'processing', leaseExpiresAt: { lte: before } },
+      where: {
+        status: 'processing',
+        leaseExpiresAt: { lte: before },
+        attemptStartedAt: null,
+        nextRetryAt: null,
+      },
+      data: {
+        status: 'scheduled',
+        leaseToken: null,
+        leaseExpiresAt: null,
+        errorCode: 'LEASE_EXPIRED_BEFORE_ATTEMPT',
+        error: 'Processing lease expired before a provider request started',
+      },
+    });
+    await this.client.schedulerJob.updateMany({
+      where: {
+        status: 'processing',
+        leaseExpiresAt: { lte: before },
+        attemptStartedAt: null,
+        nextRetryAt: { not: null },
+      },
+      data: {
+        status: 'failed',
+        leaseToken: null,
+        leaseExpiresAt: null,
+        errorCode: 'LEASE_EXPIRED_BEFORE_ATTEMPT',
+        error: 'Processing lease expired before a provider request started',
+      },
+    });
+    await this.client.schedulerJob.updateMany({
+      where: {
+        status: 'processing',
+        leaseExpiresAt: { lte: before },
+        attemptStartedAt: { not: null },
+      },
       data: {
         status: 'reconciliation_required',
         leaseToken: null,
@@ -285,6 +376,7 @@ export class PrismaJobQueue implements JobQueue {
           status: 'processing',
           leaseToken,
           leaseExpiresAt,
+          attemptStartedAt: null,
           errorCode: null,
           error: null,
         },
@@ -303,7 +395,11 @@ export class PrismaJobQueue implements JobQueue {
   ): Promise<ScheduledJob | null> {
     const result = await this.client.schedulerJob.updateMany({
       where: { id, status: 'processing', leaseToken },
-      data: { attempts: { increment: 1 }, lastAttemptAt: attemptedAt },
+      data: {
+        attempts: { increment: 1 },
+        lastAttemptAt: attemptedAt,
+        attemptStartedAt: attemptedAt,
+      },
     });
     if (result.count !== 1) return null;
     const row = await this.client.schedulerJob.findFirst({
@@ -319,6 +415,7 @@ export class PrismaJobQueue implements JobQueue {
         ...updateData(updates),
         leaseToken: null,
         leaseExpiresAt: null,
+        attemptStartedAt: null,
       },
     });
     return result.count === 1;

--- a/lib/scheduler/publisher.ts
+++ b/lib/scheduler/publisher.ts
@@ -73,7 +73,7 @@ export class Publisher {
    */
   async publish(
     job: ScheduledJob,
-    options: { quotaReserved?: boolean } = {}
+    options: { quotaReserved?: boolean; beforeProviderCall?: () => Promise<boolean> } = {}
   ): Promise<PublishResultWithMeta> {
     const startTime = Date.now();
 
@@ -92,19 +92,6 @@ export class Publisher {
       };
     }
 
-    // Check rate limits
-    const quota = options.quotaReserved
-      ? { allowed: true }
-      : await this.rateLimiter.reserveRequest(job.platformId);
-    if (!quota.allowed) {
-      return {
-        success: false,
-        error: new PublishError('Rate limit exceeded', 'RATE_LIMITED', true),
-        duration: Date.now() - startTime,
-        rateLimited: true,
-      };
-    }
-
     // Validate content
     const validation = adapter.validateContent(job.content);
     if (!validation.valid) {
@@ -120,7 +107,32 @@ export class Publisher {
       };
     }
 
+    // Reserve shared capacity only after all local validation succeeds.
+    const quota = options.quotaReserved
+      ? { allowed: true }
+      : await this.rateLimiter.reserveRequest(job.platformId);
+    if (!quota.allowed) {
+      return {
+        success: false,
+        error: new PublishError('Rate limit exceeded', 'RATE_LIMITED', true),
+        duration: Date.now() - startTime,
+        rateLimited: true,
+      };
+    }
+
     try {
+      if (options.beforeProviderCall && !(await options.beforeProviderCall())) {
+        return {
+          success: false,
+          error: new PublishError(
+            'The scheduler processing lease changed before the provider call',
+            'LEASE_LOST',
+            false
+          ),
+          duration: Date.now() - startTime,
+          rateLimited: false,
+        };
+      }
       // Publish
       const result = await adapter.publish(job.content);
 

--- a/lib/scheduler/publisher.ts
+++ b/lib/scheduler/publisher.ts
@@ -71,7 +71,10 @@ export class Publisher {
   /**
    * Publish a job to its platform
    */
-  async publish(job: ScheduledJob): Promise<PublishResultWithMeta> {
+  async publish(
+    job: ScheduledJob,
+    options: { quotaReserved?: boolean } = {}
+  ): Promise<PublishResultWithMeta> {
     const startTime = Date.now();
 
     // Get adapter
@@ -90,8 +93,10 @@ export class Publisher {
     }
 
     // Check rate limits
-    const canProceed = await this.rateLimiter.canProcess(job.platformId);
-    if (!canProceed) {
+    const quota = options.quotaReserved
+      ? { allowed: true }
+      : await this.rateLimiter.reserveRequest(job.platformId);
+    if (!quota.allowed) {
       return {
         success: false,
         error: new PublishError('Rate limit exceeded', 'RATE_LIMITED', true),
@@ -118,9 +123,6 @@ export class Publisher {
     try {
       // Publish
       const result = await adapter.publish(job.content);
-
-      // Record the request
-      await this.rateLimiter.recordRequest(job.platformId);
 
       return {
         success: true,

--- a/lib/scheduler/queue.ts
+++ b/lib/scheduler/queue.ts
@@ -3,10 +3,57 @@
  * In-memory queue for development, with interface for Redis/DB backends
  */
 
-import { JobQueue, ScheduledJob, JobStatus } from './types';
+import prisma from '@/lib/db/prisma';
 import { generateJobId as generateSecureJobId } from '@/lib/utils/id';
+import { PrismaJobQueue, SchedulerQueueError } from './prisma-queue';
+import type { ClaimedJobUpdate, JobQueue, ScheduledJob, JobStatus } from './types';
 
 const STORAGE_KEY = 'scheduler-jobs';
+
+function sameIdempotentRequest(existing: ScheduledJob, candidate: ScheduledJob): boolean {
+  return (
+    existing.type === candidate.type &&
+    existing.contentId === candidate.contentId &&
+    existing.platformId === candidate.platformId &&
+    existing.campaignId === candidate.campaignId &&
+    existing.campaignVersion === candidate.campaignVersion &&
+    existing.campaignVersionId === candidate.campaignVersionId &&
+    existing.approvedContentHash === candidate.approvedContentHash &&
+    existing.variantId === candidate.variantId &&
+    new Date(existing.scheduledTime).toISOString() ===
+      new Date(candidate.scheduledTime).toISOString() &&
+    JSON.stringify(existing.content) === JSON.stringify(candidate.content) &&
+    existing.timezone === candidate.timezone &&
+    existing.maxAttempts === candidate.maxAttempts
+  );
+}
+
+function findIdempotentJob(
+  jobs: Map<string, ScheduledJob>,
+  candidate: ScheduledJob
+): ScheduledJob | undefined {
+  return Array.from(jobs.values()).find(
+    job => job.createdBy === candidate.createdBy && job.idempotencyKey === candidate.idempotencyKey
+  );
+}
+
+function addToMemoryQueue(
+  jobs: Map<string, ScheduledJob>,
+  job: ScheduledJob
+): { job: ScheduledJob; created: boolean } {
+  const existing = findIdempotentJob(jobs, job);
+  if (existing) {
+    if (!sameIdempotentRequest(existing, job)) {
+      throw new SchedulerQueueError(
+        'IDEMPOTENCY_CONFLICT',
+        'The idempotency key already identifies a different scheduler request'
+      );
+    }
+    return { job: existing, created: false };
+  }
+  jobs.set(job.id, job);
+  return { job, created: true };
+}
 
 /**
  * Load jobs from localStorage
@@ -65,15 +112,17 @@ export class InMemoryQueue implements JobQueue {
     saveToStorage(this.jobs);
   }
 
-  async add(job: ScheduledJob): Promise<void> {
+  async add(job: ScheduledJob): Promise<{ job: ScheduledJob; created: boolean }> {
     this.ensureInitialized();
-    this.jobs.set(job.id, job);
+    const result = addToMemoryQueue(this.jobs, job);
     this.persist();
+    return result;
   }
 
-  async get(id: string): Promise<ScheduledJob | null> {
+  async get(id: string, userId?: string): Promise<ScheduledJob | null> {
     this.ensureInitialized();
-    return this.jobs.get(id) || null;
+    const job = this.jobs.get(id);
+    return job && (!userId || job.createdBy === userId) ? job : null;
   }
 
   async update(id: string, updates: Partial<ScheduledJob>): Promise<void> {
@@ -120,12 +169,76 @@ export class InMemoryQueue implements JobQueue {
     );
   }
 
-  async getByStatus(status: JobStatus, limit?: number): Promise<ScheduledJob[]> {
+  async claimDueJobs(
+    before: Date,
+    limit: number,
+    leaseToken: string,
+    leaseExpiresAt: Date
+  ): Promise<ScheduledJob[]> {
+    this.ensureInitialized();
+    for (const job of this.jobs.values()) {
+      if (
+        job.status === 'processing' &&
+        job.leaseExpiresAt &&
+        new Date(job.leaseExpiresAt) <= before
+      ) {
+        this.jobs.set(job.id, {
+          ...job,
+          status: 'reconciliation_required',
+          leaseToken: undefined,
+          leaseExpiresAt: undefined,
+          error: 'Processing lease expired before the provider result was recorded',
+          updatedAt: before.toISOString(),
+        });
+      }
+    }
+
+    const candidates = await this.getDueJobs(before, limit * 4);
+    const claimed: ScheduledJob[] = [];
+    for (const candidate of candidates) {
+      if (claimed.length >= limit) break;
+      const current = this.jobs.get(candidate.id);
+      if (!current || !['scheduled', 'failed'].includes(current.status)) continue;
+      const updated: ScheduledJob = {
+        ...current,
+        status: 'processing',
+        attempts: current.attempts + 1,
+        lastAttemptAt: before.toISOString(),
+        leaseToken,
+        leaseExpiresAt: leaseExpiresAt.toISOString(),
+        error: undefined,
+        updatedAt: before.toISOString(),
+      };
+      this.jobs.set(current.id, updated);
+      claimed.push(updated);
+    }
+    this.persist();
+    return claimed;
+  }
+
+  async updateClaimed(id: string, leaseToken: string, updates: ClaimedJobUpdate): Promise<boolean> {
+    this.ensureInitialized();
+    const current = this.jobs.get(id);
+    if (!current || current.status !== 'processing' || current.leaseToken !== leaseToken) {
+      return false;
+    }
+    this.jobs.set(id, {
+      ...current,
+      ...updates,
+      leaseToken: undefined,
+      leaseExpiresAt: undefined,
+      updatedAt: new Date().toISOString(),
+    });
+    this.persist();
+    return true;
+  }
+
+  async getByStatus(status: JobStatus, limit?: number, userId?: string): Promise<ScheduledJob[]> {
     this.ensureInitialized();
     const filtered: ScheduledJob[] = [];
 
     for (const job of this.jobs.values()) {
-      if (job.status === status) {
+      if (job.status === status && (!userId || job.createdBy === userId)) {
         filtered.push(job);
         if (limit && filtered.length >= limit) break;
       }
@@ -136,12 +249,12 @@ export class InMemoryQueue implements JobQueue {
     );
   }
 
-  async getByCampaign(campaignId: string): Promise<ScheduledJob[]> {
+  async getByCampaign(campaignId: string, userId?: string): Promise<ScheduledJob[]> {
     this.ensureInitialized();
     const filtered: ScheduledJob[] = [];
 
     for (const job of this.jobs.values()) {
-      if (job.campaignId === campaignId) {
+      if (job.campaignId === campaignId && (!userId || job.createdBy === userId)) {
         filtered.push(job);
       }
     }
@@ -151,11 +264,11 @@ export class InMemoryQueue implements JobQueue {
     );
   }
 
-  async getAll(): Promise<ScheduledJob[]> {
+  async getAll(userId?: string): Promise<ScheduledJob[]> {
     this.ensureInitialized();
-    return Array.from(this.jobs.values()).sort(
-      (a, b) => new Date(a.scheduledTime).getTime() - new Date(b.scheduledTime).getTime()
-    );
+    return Array.from(this.jobs.values())
+      .filter(job => !userId || job.createdBy === userId)
+      .sort((a, b) => new Date(a.scheduledTime).getTime() - new Date(b.scheduledTime).getTime());
   }
 
   async count(): Promise<number> {
@@ -163,22 +276,29 @@ export class InMemoryQueue implements JobQueue {
     return this.jobs.size;
   }
 
-  async clear(): Promise<void> {
-    this.jobs.clear();
+  async clear(userId?: string): Promise<void> {
+    if (userId) {
+      for (const [id, job] of this.jobs.entries()) {
+        if (job.createdBy === userId) this.jobs.delete(id);
+      }
+    } else {
+      this.jobs.clear();
+    }
     this.persist();
   }
 }
 
 // Server-side in-memory queue (no localStorage)
-class ServerMemoryQueue implements JobQueue {
+export class ServerMemoryQueue implements JobQueue {
   private readonly jobs: Map<string, ScheduledJob> = new Map();
 
-  async add(job: ScheduledJob): Promise<void> {
-    this.jobs.set(job.id, job);
+  async add(job: ScheduledJob): Promise<{ job: ScheduledJob; created: boolean }> {
+    return addToMemoryQueue(this.jobs, job);
   }
 
-  async get(id: string): Promise<ScheduledJob | null> {
-    return this.jobs.get(id) || null;
+  async get(id: string, userId?: string): Promise<ScheduledJob | null> {
+    const job = this.jobs.get(id);
+    return job && (!userId || job.createdBy === userId) ? job : null;
   }
 
   async update(id: string, updates: Partial<ScheduledJob>): Promise<void> {
@@ -218,11 +338,71 @@ class ServerMemoryQueue implements JobQueue {
     );
   }
 
-  async getByStatus(status: JobStatus, limit?: number): Promise<ScheduledJob[]> {
+  async claimDueJobs(
+    before: Date,
+    limit: number,
+    leaseToken: string,
+    leaseExpiresAt: Date
+  ): Promise<ScheduledJob[]> {
+    for (const job of this.jobs.values()) {
+      if (
+        job.status === 'processing' &&
+        job.leaseExpiresAt &&
+        new Date(job.leaseExpiresAt) <= before
+      ) {
+        this.jobs.set(job.id, {
+          ...job,
+          status: 'reconciliation_required',
+          leaseToken: undefined,
+          leaseExpiresAt: undefined,
+          error: 'Processing lease expired before the provider result was recorded',
+          updatedAt: before.toISOString(),
+        });
+      }
+    }
+
+    const candidates = await this.getDueJobs(before, limit * 4);
+    const claimed: ScheduledJob[] = [];
+    for (const candidate of candidates) {
+      if (claimed.length >= limit) break;
+      const current = this.jobs.get(candidate.id);
+      if (!current || !['scheduled', 'failed'].includes(current.status)) continue;
+      const updated: ScheduledJob = {
+        ...current,
+        status: 'processing',
+        attempts: current.attempts + 1,
+        lastAttemptAt: before.toISOString(),
+        leaseToken,
+        leaseExpiresAt: leaseExpiresAt.toISOString(),
+        error: undefined,
+        updatedAt: before.toISOString(),
+      };
+      this.jobs.set(current.id, updated);
+      claimed.push(updated);
+    }
+    return claimed;
+  }
+
+  async updateClaimed(id: string, leaseToken: string, updates: ClaimedJobUpdate): Promise<boolean> {
+    const current = this.jobs.get(id);
+    if (!current || current.status !== 'processing' || current.leaseToken !== leaseToken) {
+      return false;
+    }
+    this.jobs.set(id, {
+      ...current,
+      ...updates,
+      leaseToken: undefined,
+      leaseExpiresAt: undefined,
+      updatedAt: new Date().toISOString(),
+    });
+    return true;
+  }
+
+  async getByStatus(status: JobStatus, limit?: number, userId?: string): Promise<ScheduledJob[]> {
     const filtered: ScheduledJob[] = [];
 
     for (const job of this.jobs.values()) {
-      if (job.status === status) {
+      if (job.status === status && (!userId || job.createdBy === userId)) {
         filtered.push(job);
         if (limit && filtered.length >= limit) break;
       }
@@ -233,11 +413,11 @@ class ServerMemoryQueue implements JobQueue {
     );
   }
 
-  async getByCampaign(campaignId: string): Promise<ScheduledJob[]> {
+  async getByCampaign(campaignId: string, userId?: string): Promise<ScheduledJob[]> {
     const filtered: ScheduledJob[] = [];
 
     for (const job of this.jobs.values()) {
-      if (job.campaignId === campaignId) {
+      if (job.campaignId === campaignId && (!userId || job.createdBy === userId)) {
         filtered.push(job);
       }
     }
@@ -247,29 +427,42 @@ class ServerMemoryQueue implements JobQueue {
     );
   }
 
-  async getAll(): Promise<ScheduledJob[]> {
-    return Array.from(this.jobs.values());
+  async getAll(userId?: string): Promise<ScheduledJob[]> {
+    return Array.from(this.jobs.values()).filter(job => !userId || job.createdBy === userId);
   }
 
   async count(): Promise<number> {
     return this.jobs.size;
   }
 
-  async clear(): Promise<void> {
-    this.jobs.clear();
+  async clear(userId?: string): Promise<void> {
+    if (userId) {
+      for (const [id, job] of this.jobs.entries()) {
+        if (job.createdBy === userId) this.jobs.delete(id);
+      }
+    } else {
+      this.jobs.clear();
+    }
   }
 }
 
 // Singleton instances
 let clientQueue: InMemoryQueue | null = null;
 let serverQueue: ServerMemoryQueue | null = null;
+let durableQueue: PrismaJobQueue | null = null;
 
 /**
  * Get the appropriate queue instance
  */
 export function getQueue(): JobQueue {
   if (globalThis.window === undefined) {
-    // Server-side: use memory-only queue
+    if (prisma) {
+      durableQueue ??= new PrismaJobQueue(prisma);
+      return durableQueue;
+    }
+    if (process.env.NODE_ENV === 'production') {
+      throw new Error('Durable scheduler persistence is not configured');
+    }
     serverQueue ??= new ServerMemoryQueue();
     return serverQueue;
   }

--- a/lib/scheduler/queue.ts
+++ b/lib/scheduler/queue.ts
@@ -6,7 +6,14 @@
 import prisma from '@/lib/db/prisma';
 import { generateJobId as generateSecureJobId } from '@/lib/utils/id';
 import { PrismaJobQueue, SchedulerQueueError } from './prisma-queue';
-import type { ClaimedJobUpdate, JobQueue, ScheduledJob, JobStatus } from './types';
+import type {
+  ClaimedJobUpdate,
+  JobQueue,
+  ScheduledJob,
+  JobStatus,
+  ListJobsOptions,
+  ListJobsResult,
+} from './types';
 
 const STORAGE_KEY = 'scheduler-jobs';
 
@@ -322,6 +329,15 @@ export class InMemoryQueue implements JobQueue {
       .sort((a, b) => new Date(a.scheduledTime).getTime() - new Date(b.scheduledTime).getTime());
   }
 
+  async list(options: ListJobsOptions): Promise<ListJobsResult> {
+    const jobs = (await this.getAll(options.userId)).filter(
+      job =>
+        (!options.status || job.status === options.status) &&
+        (!options.campaignId || job.campaignId === options.campaignId)
+    );
+    return { jobs: jobs.slice(options.offset, options.offset + options.limit), total: jobs.length };
+  }
+
   async count(): Promise<number> {
     this.ensureInitialized();
     return this.jobs.size;
@@ -539,6 +555,17 @@ export class ServerMemoryQueue implements JobQueue {
 
   async getAll(userId?: string): Promise<ScheduledJob[]> {
     return Array.from(this.jobs.values()).filter(job => !userId || job.createdBy === userId);
+  }
+
+  async list(options: ListJobsOptions): Promise<ListJobsResult> {
+    const jobs = (await this.getAll(options.userId))
+      .filter(
+        job =>
+          (!options.status || job.status === options.status) &&
+          (!options.campaignId || job.campaignId === options.campaignId)
+      )
+      .sort((a, b) => new Date(a.scheduledTime).getTime() - new Date(b.scheduledTime).getTime());
+    return { jobs: jobs.slice(options.offset, options.offset + options.limit), total: jobs.length };
   }
 
   async count(): Promise<number> {

--- a/lib/scheduler/queue.ts
+++ b/lib/scheduler/queue.ts
@@ -246,6 +246,26 @@ export class InMemoryQueue implements JobQueue {
     return updated;
   }
 
+  async renewClaimLease(id: string, leaseToken: string, leaseExpiresAt: Date): Promise<boolean> {
+    this.ensureInitialized();
+    const current = this.jobs.get(id);
+    if (
+      !current ||
+      current.status !== 'processing' ||
+      current.leaseToken !== leaseToken ||
+      !current.attemptStartedAt
+    ) {
+      return false;
+    }
+    this.jobs.set(id, {
+      ...current,
+      leaseExpiresAt: leaseExpiresAt.toISOString(),
+      updatedAt: new Date().toISOString(),
+    });
+    this.persist();
+    return true;
+  }
+
   async updateClaimed(id: string, leaseToken: string, updates: ClaimedJobUpdate): Promise<boolean> {
     this.ensureInitialized();
     const current = this.jobs.get(id);
@@ -452,6 +472,24 @@ export class ServerMemoryQueue implements JobQueue {
     };
     this.jobs.set(id, updated);
     return updated;
+  }
+
+  async renewClaimLease(id: string, leaseToken: string, leaseExpiresAt: Date): Promise<boolean> {
+    const current = this.jobs.get(id);
+    if (
+      !current ||
+      current.status !== 'processing' ||
+      current.leaseToken !== leaseToken ||
+      !current.attemptStartedAt
+    ) {
+      return false;
+    }
+    this.jobs.set(id, {
+      ...current,
+      leaseExpiresAt: leaseExpiresAt.toISOString(),
+      updatedAt: new Date().toISOString(),
+    });
+    return true;
   }
 
   async updateClaimed(id: string, leaseToken: string, updates: ClaimedJobUpdate): Promise<boolean> {

--- a/lib/scheduler/queue.ts
+++ b/lib/scheduler/queue.ts
@@ -11,21 +11,7 @@ import type { ClaimedJobUpdate, JobQueue, ScheduledJob, JobStatus } from './type
 const STORAGE_KEY = 'scheduler-jobs';
 
 function sameIdempotentRequest(existing: ScheduledJob, candidate: ScheduledJob): boolean {
-  return (
-    existing.type === candidate.type &&
-    existing.contentId === candidate.contentId &&
-    existing.platformId === candidate.platformId &&
-    existing.campaignId === candidate.campaignId &&
-    existing.campaignVersion === candidate.campaignVersion &&
-    existing.campaignVersionId === candidate.campaignVersionId &&
-    existing.approvedContentHash === candidate.approvedContentHash &&
-    existing.variantId === candidate.variantId &&
-    new Date(existing.scheduledTime).toISOString() ===
-      new Date(candidate.scheduledTime).toISOString() &&
-    JSON.stringify(existing.content) === JSON.stringify(candidate.content) &&
-    existing.timezone === candidate.timezone &&
-    existing.maxAttempts === candidate.maxAttempts
-  );
+  return existing.requestFingerprint === candidate.requestFingerprint;
 }
 
 function findIdempotentJob(
@@ -138,6 +124,22 @@ export class InMemoryQueue implements JobQueue {
     }
   }
 
+  async updateIfStatus(
+    id: string,
+    statuses: JobStatus[],
+    updates: Partial<ScheduledJob>,
+    userId?: string
+  ): Promise<boolean> {
+    this.ensureInitialized();
+    const job = this.jobs.get(id);
+    if (!job || (userId && job.createdBy !== userId) || !statuses.includes(job.status)) {
+      return false;
+    }
+    this.jobs.set(id, { ...job, ...updates, updatedAt: new Date().toISOString() });
+    this.persist();
+    return true;
+  }
+
   async remove(id: string): Promise<void> {
     this.ensureInitialized();
     this.jobs.delete(id);
@@ -202,8 +204,6 @@ export class InMemoryQueue implements JobQueue {
       const updated: ScheduledJob = {
         ...current,
         status: 'processing',
-        attempts: current.attempts + 1,
-        lastAttemptAt: before.toISOString(),
         leaseToken,
         leaseExpiresAt: leaseExpiresAt.toISOString(),
         error: undefined,
@@ -214,6 +214,27 @@ export class InMemoryQueue implements JobQueue {
     }
     this.persist();
     return claimed;
+  }
+
+  async markClaimAttempt(
+    id: string,
+    leaseToken: string,
+    attemptedAt: Date
+  ): Promise<ScheduledJob | null> {
+    this.ensureInitialized();
+    const current = this.jobs.get(id);
+    if (!current || current.status !== 'processing' || current.leaseToken !== leaseToken) {
+      return null;
+    }
+    const updated = {
+      ...current,
+      attempts: current.attempts + 1,
+      lastAttemptAt: attemptedAt.toISOString(),
+      updatedAt: attemptedAt.toISOString(),
+    };
+    this.jobs.set(id, updated);
+    this.persist();
+    return updated;
   }
 
   async updateClaimed(id: string, leaseToken: string, updates: ClaimedJobUpdate): Promise<boolean> {
@@ -312,6 +333,20 @@ export class ServerMemoryQueue implements JobQueue {
     }
   }
 
+  async updateIfStatus(
+    id: string,
+    statuses: JobStatus[],
+    updates: Partial<ScheduledJob>,
+    userId?: string
+  ): Promise<boolean> {
+    const job = this.jobs.get(id);
+    if (!job || (userId && job.createdBy !== userId) || !statuses.includes(job.status)) {
+      return false;
+    }
+    this.jobs.set(id, { ...job, ...updates, updatedAt: new Date().toISOString() });
+    return true;
+  }
+
   async remove(id: string): Promise<void> {
     this.jobs.delete(id);
   }
@@ -370,8 +405,6 @@ export class ServerMemoryQueue implements JobQueue {
       const updated: ScheduledJob = {
         ...current,
         status: 'processing',
-        attempts: current.attempts + 1,
-        lastAttemptAt: before.toISOString(),
         leaseToken,
         leaseExpiresAt: leaseExpiresAt.toISOString(),
         error: undefined,
@@ -381,6 +414,25 @@ export class ServerMemoryQueue implements JobQueue {
       claimed.push(updated);
     }
     return claimed;
+  }
+
+  async markClaimAttempt(
+    id: string,
+    leaseToken: string,
+    attemptedAt: Date
+  ): Promise<ScheduledJob | null> {
+    const current = this.jobs.get(id);
+    if (!current || current.status !== 'processing' || current.leaseToken !== leaseToken) {
+      return null;
+    }
+    const updated = {
+      ...current,
+      attempts: current.attempts + 1,
+      lastAttemptAt: attemptedAt.toISOString(),
+      updatedAt: attemptedAt.toISOString(),
+    };
+    this.jobs.set(id, updated);
+    return updated;
   }
 
   async updateClaimed(id: string, leaseToken: string, updates: ClaimedJobUpdate): Promise<boolean> {

--- a/lib/scheduler/queue.ts
+++ b/lib/scheduler/queue.ts
@@ -186,10 +186,17 @@ export class InMemoryQueue implements JobQueue {
       ) {
         this.jobs.set(job.id, {
           ...job,
-          status: 'reconciliation_required',
+          status: job.attemptStartedAt
+            ? 'reconciliation_required'
+            : job.nextRetryAt
+              ? 'failed'
+              : 'scheduled',
           leaseToken: undefined,
           leaseExpiresAt: undefined,
-          error: 'Processing lease expired before the provider result was recorded',
+          attemptStartedAt: undefined,
+          error: job.attemptStartedAt
+            ? 'Processing lease expired before the provider result was recorded'
+            : 'Processing lease expired before a provider request started',
           updatedAt: before.toISOString(),
         });
       }
@@ -206,6 +213,7 @@ export class InMemoryQueue implements JobQueue {
         status: 'processing',
         leaseToken,
         leaseExpiresAt: leaseExpiresAt.toISOString(),
+        attemptStartedAt: undefined,
         error: undefined,
         updatedAt: before.toISOString(),
       };
@@ -230,6 +238,7 @@ export class InMemoryQueue implements JobQueue {
       ...current,
       attempts: current.attempts + 1,
       lastAttemptAt: attemptedAt.toISOString(),
+      attemptStartedAt: attemptedAt.toISOString(),
       updatedAt: attemptedAt.toISOString(),
     };
     this.jobs.set(id, updated);
@@ -248,6 +257,7 @@ export class InMemoryQueue implements JobQueue {
       ...updates,
       leaseToken: undefined,
       leaseExpiresAt: undefined,
+      attemptStartedAt: undefined,
       updatedAt: new Date().toISOString(),
     });
     this.persist();
@@ -387,10 +397,17 @@ export class ServerMemoryQueue implements JobQueue {
       ) {
         this.jobs.set(job.id, {
           ...job,
-          status: 'reconciliation_required',
+          status: job.attemptStartedAt
+            ? 'reconciliation_required'
+            : job.nextRetryAt
+              ? 'failed'
+              : 'scheduled',
           leaseToken: undefined,
           leaseExpiresAt: undefined,
-          error: 'Processing lease expired before the provider result was recorded',
+          attemptStartedAt: undefined,
+          error: job.attemptStartedAt
+            ? 'Processing lease expired before the provider result was recorded'
+            : 'Processing lease expired before a provider request started',
           updatedAt: before.toISOString(),
         });
       }
@@ -407,6 +424,7 @@ export class ServerMemoryQueue implements JobQueue {
         status: 'processing',
         leaseToken,
         leaseExpiresAt: leaseExpiresAt.toISOString(),
+        attemptStartedAt: undefined,
         error: undefined,
         updatedAt: before.toISOString(),
       };
@@ -429,6 +447,7 @@ export class ServerMemoryQueue implements JobQueue {
       ...current,
       attempts: current.attempts + 1,
       lastAttemptAt: attemptedAt.toISOString(),
+      attemptStartedAt: attemptedAt.toISOString(),
       updatedAt: attemptedAt.toISOString(),
     };
     this.jobs.set(id, updated);
@@ -445,6 +464,7 @@ export class ServerMemoryQueue implements JobQueue {
       ...updates,
       leaseToken: undefined,
       leaseExpiresAt: undefined,
+      attemptStartedAt: undefined,
       updatedAt: new Date().toISOString(),
     });
     return true;

--- a/lib/scheduler/rate-limiter.ts
+++ b/lib/scheduler/rate-limiter.ts
@@ -3,7 +3,14 @@
  * Tracks and enforces rate limits per platform
  */
 
+import type { Prisma, PrismaClient } from '@prisma/client';
+import prisma from '@/lib/db/prisma';
 import { PlatformRateLimit, RateLimitConfig, RATE_LIMITS } from './types';
+
+export interface RateLimitReservation {
+  allowed: boolean;
+  nextAvailableAt: Date | null;
+}
 
 const STORAGE_KEY = 'scheduler-rate-limits';
 
@@ -159,6 +166,18 @@ export class RateLimiter {
     return true;
   }
 
+  /** Atomically reserve capacity before a provider request starts. */
+  async reserveRequest(platformId: string): Promise<RateLimitReservation> {
+    if (!(await this.canProcess(platformId))) {
+      return {
+        allowed: false,
+        nextAvailableAt: await this.getNextAvailableAt(platformId),
+      };
+    }
+    await this.recordRequest(platformId);
+    return { allowed: true, nextAvailableAt: null };
+  }
+
   /** Earliest time all active local quota/backoff constraints have reset. */
   async getNextAvailableAt(platformId: string): Promise<Date | null> {
     const limit = this.getOrCreateLimit(platformId);
@@ -279,6 +298,224 @@ export class RateLimiter {
   }
 }
 
+interface StoredQuota {
+  platformId: string;
+  windowStart: Date;
+  windowDuration: number;
+  requestCount: number;
+  requestLimit: number;
+  dailyCount: number | null;
+  dailyLimit: number | null;
+  dailyResetAt: Date | null;
+  backoffUntil: Date | null;
+}
+
+type QuotaState = StoredQuota;
+
+/** PostgreSQL-backed quota reservations shared by every scheduler worker. */
+export class DurableRateLimiter extends RateLimiter {
+  constructor(
+    private readonly client: PrismaClient,
+    private readonly durableConfigs: Record<string, RateLimitConfig> = RATE_LIMITS
+  ) {
+    super(durableConfigs);
+  }
+
+  private configFor(platformId: string): RateLimitConfig {
+    return this.durableConfigs[platformId] || { requests: 100, window: 3600 };
+  }
+
+  private nextDailyReset(now: Date): Date {
+    const reset = new Date(now);
+    reset.setUTCDate(reset.getUTCDate() + 1);
+    reset.setUTCHours(0, 0, 0, 0);
+    return reset;
+  }
+
+  private normalize(platformId: string, stored: StoredQuota | null, now: Date): QuotaState {
+    const config = this.configFor(platformId);
+    const state: QuotaState = stored
+      ? {
+          platformId: stored.platformId,
+          windowStart: stored.windowStart,
+          windowDuration: config.window,
+          requestCount: stored.requestCount,
+          requestLimit: config.requests,
+          dailyCount: config.daily ? (stored.dailyCount ?? 0) : null,
+          dailyLimit: config.daily ?? null,
+          dailyResetAt: config.daily ? (stored.dailyResetAt ?? this.nextDailyReset(now)) : null,
+          backoffUntil: stored.backoffUntil,
+        }
+      : {
+          platformId,
+          windowStart: now,
+          windowDuration: config.window,
+          requestCount: 0,
+          requestLimit: config.requests,
+          dailyCount: config.daily ? 0 : null,
+          dailyLimit: config.daily ?? null,
+          dailyResetAt: config.daily ? this.nextDailyReset(now) : null,
+          backoffUntil: null,
+        };
+
+    if (now.getTime() >= state.windowStart.getTime() + state.windowDuration * 1000) {
+      state.windowStart = now;
+      state.requestCount = 0;
+    }
+    if (state.dailyResetAt && now >= state.dailyResetAt) {
+      state.dailyCount = 0;
+      state.dailyResetAt = this.nextDailyReset(now);
+    }
+    if (state.backoffUntil && now >= state.backoffUntil) state.backoffUntil = null;
+    return state;
+  }
+
+  private nextAvailableAt(state: QuotaState): Date | null {
+    const resets: Date[] = [];
+    if (state.backoffUntil) resets.push(state.backoffUntil);
+    if (state.requestCount >= state.requestLimit) {
+      resets.push(new Date(state.windowStart.getTime() + state.windowDuration * 1000));
+    }
+    if (
+      state.dailyLimit &&
+      state.dailyCount !== null &&
+      state.dailyCount >= state.dailyLimit &&
+      state.dailyResetAt
+    ) {
+      resets.push(state.dailyResetAt);
+    }
+    return resets.length ? new Date(Math.max(...resets.map(reset => reset.getTime()))) : null;
+  }
+
+  private async lockPlatform(tx: Prisma.TransactionClient, platformId: string): Promise<void> {
+    await tx.$queryRaw`SELECT pg_advisory_xact_lock(hashtext(${'scheduler-quota:' + platformId}))`;
+  }
+
+  private async save(tx: Prisma.TransactionClient, state: QuotaState): Promise<void> {
+    await tx.$executeRaw`
+      INSERT INTO "SchedulerPlatformQuota" (
+        "platformId", "windowStart", "windowDuration", "requestCount", "requestLimit",
+        "dailyCount", "dailyLimit", "dailyResetAt", "backoffUntil", "updatedAt"
+      ) VALUES (
+        ${state.platformId}, ${state.windowStart}, ${state.windowDuration},
+        ${state.requestCount}, ${state.requestLimit}, ${state.dailyCount},
+        ${state.dailyLimit}, ${state.dailyResetAt}, ${state.backoffUntil}, NOW()
+      )
+      ON CONFLICT ("platformId") DO UPDATE SET
+        "windowStart" = EXCLUDED."windowStart",
+        "windowDuration" = EXCLUDED."windowDuration",
+        "requestCount" = EXCLUDED."requestCount",
+        "requestLimit" = EXCLUDED."requestLimit",
+        "dailyCount" = EXCLUDED."dailyCount",
+        "dailyLimit" = EXCLUDED."dailyLimit",
+        "dailyResetAt" = EXCLUDED."dailyResetAt",
+        "backoffUntil" = EXCLUDED."backoffUntil",
+        "updatedAt" = NOW()
+    `;
+  }
+
+  private async find(
+    client: Prisma.TransactionClient | PrismaClient,
+    platformId: string
+  ): Promise<StoredQuota | null> {
+    const rows = await client.$queryRaw<StoredQuota[]>`
+      SELECT "platformId", "windowStart", "windowDuration", "requestCount", "requestLimit",
+             "dailyCount", "dailyLimit", "dailyResetAt", "backoffUntil"
+      FROM "SchedulerPlatformQuota"
+      WHERE "platformId" = ${platformId}
+    `;
+    return rows[0] ?? null;
+  }
+
+  override async reserveRequest(platformId: string): Promise<RateLimitReservation> {
+    return this.client.$transaction(async tx => {
+      await this.lockPlatform(tx, platformId);
+      const now = new Date();
+      const state = this.normalize(platformId, await this.find(tx, platformId), now);
+      const nextAvailableAt = this.nextAvailableAt(state);
+      if (nextAvailableAt) {
+        await this.save(tx, state);
+        return { allowed: false, nextAvailableAt };
+      }
+      state.requestCount += 1;
+      if (state.dailyCount !== null) state.dailyCount += 1;
+      await this.save(tx, state);
+      return { allowed: true, nextAvailableAt: null };
+    });
+  }
+
+  private async readState(platformId: string): Promise<QuotaState> {
+    const now = new Date();
+    return this.normalize(platformId, await this.find(this.client, platformId), now);
+  }
+
+  override async canProcess(platformId: string): Promise<boolean> {
+    return this.nextAvailableAt(await this.readState(platformId)) === null;
+  }
+
+  override async getNextAvailableAt(platformId: string): Promise<Date | null> {
+    return this.nextAvailableAt(await this.readState(platformId));
+  }
+
+  override async recordRequest(platformId: string): Promise<void> {
+    const reservation = await this.reserveRequest(platformId);
+    if (!reservation.allowed) throw new Error(`Rate limit exceeded for ${platformId}`);
+  }
+
+  override async setBackoff(platformId: string, durationSeconds: number): Promise<void> {
+    await this.client.$transaction(async tx => {
+      await this.lockPlatform(tx, platformId);
+      const now = new Date();
+      const state = this.normalize(platformId, await this.find(tx, platformId), now);
+      const requested = new Date(now.getTime() + durationSeconds * 1000);
+      if (!state.backoffUntil || requested > state.backoffUntil) state.backoffUntil = requested;
+      await this.save(tx, state);
+    });
+  }
+
+  override async getRemaining(platformId: string): Promise<{ window: number; daily?: number }> {
+    const state = await this.readState(platformId);
+    return {
+      window: Math.max(0, state.requestLimit - state.requestCount),
+      daily:
+        state.dailyLimit && state.dailyCount !== null
+          ? Math.max(0, state.dailyLimit - state.dailyCount)
+          : undefined,
+    };
+  }
+
+  override async getStatus(): Promise<
+    Record<string, { remaining: number; resetAt: string; isBackingOff: boolean }>
+  > {
+    const entries = await Promise.all(
+      Object.keys(this.durableConfigs).map(async platformId => {
+        const state = await this.readState(platformId);
+        return [
+          platformId,
+          {
+            remaining: Math.max(0, state.requestLimit - state.requestCount),
+            resetAt: new Date(
+              state.windowStart.getTime() + state.windowDuration * 1000
+            ).toISOString(),
+            isBackingOff: state.backoffUntil !== null,
+          },
+        ] as const;
+      })
+    );
+    return Object.fromEntries(entries);
+  }
+
+  override async reset(platformId: string): Promise<void> {
+    await this.client.$executeRaw`
+      DELETE FROM "SchedulerPlatformQuota" WHERE "platformId" = ${platformId}
+    `;
+  }
+
+  override async resetAll(): Promise<void> {
+    await this.client.$executeRaw`DELETE FROM "SchedulerPlatformQuota"`;
+  }
+}
+
 // Singleton instance
 let rateLimiter: RateLimiter | null = null;
 
@@ -286,6 +523,6 @@ let rateLimiter: RateLimiter | null = null;
  * Get the rate limiter instance
  */
 export function getRateLimiter(): RateLimiter {
-  rateLimiter ??= new RateLimiter();
+  rateLimiter ??= prisma ? new DurableRateLimiter(prisma) : new RateLimiter();
   return rateLimiter;
 }

--- a/lib/scheduler/rate-limiter.ts
+++ b/lib/scheduler/rate-limiter.ts
@@ -159,6 +159,30 @@ export class RateLimiter {
     return true;
   }
 
+  /** Earliest time all active local quota/backoff constraints have reset. */
+  async getNextAvailableAt(platformId: string): Promise<Date | null> {
+    const limit = this.getOrCreateLimit(platformId);
+    this.checkWindowReset(limit);
+    const resetTimes: number[] = [];
+
+    if (limit.isBackingOff && limit.backoffUntil) {
+      resetTimes.push(new Date(limit.backoffUntil).getTime());
+    }
+    if (limit.requestCount >= limit.requestLimit) {
+      resetTimes.push(new Date(limit.windowStart).getTime() + limit.windowDuration * 1000);
+    }
+    if (
+      limit.dailyLimit &&
+      limit.dailyCount !== undefined &&
+      limit.dailyCount >= limit.dailyLimit &&
+      limit.dailyResetAt
+    ) {
+      resetTimes.push(new Date(limit.dailyResetAt).getTime());
+    }
+
+    return resetTimes.length > 0 ? new Date(Math.max(...resetTimes)) : null;
+  }
+
   /**
    * Record a request for rate limiting
    */

--- a/lib/scheduler/rate-limiter.ts
+++ b/lib/scheduler/rate-limiter.ts
@@ -388,7 +388,11 @@ export class DurableRateLimiter extends RateLimiter {
   }
 
   private async lockPlatform(tx: Prisma.TransactionClient, platformId: string): Promise<void> {
-    await tx.$queryRaw`SELECT pg_advisory_xact_lock(hashtext(${'scheduler-quota:' + platformId}))`;
+    // Keep PostgreSQL's void lock result out of Prisma's result decoder.
+    await tx.$queryRaw<Array<{ locked: number }>>`
+      SELECT 1 AS "locked"
+      FROM (SELECT pg_advisory_xact_lock(hashtext(${'scheduler-quota:' + platformId}))) AS acquired
+    `;
   }
 
   private async save(tx: Prisma.TransactionClient, state: QuotaState): Promise<void> {

--- a/lib/scheduler/scheduler.ts
+++ b/lib/scheduler/scheduler.ts
@@ -232,6 +232,28 @@ export class Scheduler {
       );
       if (!job) break;
 
+      const validation = this.publisher.validate(job);
+      if (!validation.valid) {
+        const rejected = await this.queue.updateClaimed(job.id, leaseToken, {
+          status: 'dead',
+          error: `Content validation failed: ${validation.errors.join(', ')}`,
+          updatedAt: now.toISOString(),
+        });
+        results.push({
+          jobId: job.id,
+          status: 'failure',
+          error: {
+            code: rejected ? 'VALIDATION_FAILED' : 'LEASE_LOST',
+            message: rejected
+              ? `Content validation failed: ${validation.errors.join(', ')}`
+              : 'The scheduler processing lease changed before validation was recorded',
+            retryable: false,
+          },
+          executedAt: now.toISOString(),
+        });
+        continue;
+      }
+
       const quota = await this.rateLimiter.reserveRequest(job.platformId);
       if (!quota.allowed) {
         const nextAvailableAt =
@@ -257,22 +279,7 @@ export class Scheduler {
         continue;
       }
 
-      const attemptedJob = await this.queue.markClaimAttempt(job.id, leaseToken, now);
-      if (!attemptedJob) {
-        results.push({
-          jobId: job.id,
-          status: 'failure',
-          error: {
-            code: 'LEASE_LOST',
-            message: 'The scheduler processing lease changed before the attempt was recorded',
-            retryable: false,
-          },
-          executedAt: now.toISOString(),
-        });
-        continue;
-      }
-
-      const result = await this.processJob(attemptedJob, leaseToken);
+      const result = await this.processJob(job, leaseToken);
       results.push(result);
     }
 
@@ -284,9 +291,15 @@ export class Scheduler {
    */
   private async processJob(job: ScheduledJob, leaseToken: string): Promise<JobResult> {
     const now = new Date().toISOString();
+    let attemptedJob = job;
 
     // Attempt to publish
-    const publishResult = await this.publishWithLeaseHeartbeat(job, leaseToken);
+    const publishResult = await this.publishWithLeaseHeartbeat(job, leaseToken, async () => {
+      const marked = await this.queue.markClaimAttempt(job.id, leaseToken, new Date());
+      if (!marked) return false;
+      attemptedJob = marked;
+      return true;
+    });
 
     if (publishResult.success && publishResult.result) {
       const completed = await this.queue.updateClaimed(job.id, leaseToken, {
@@ -326,16 +339,17 @@ export class Scheduler {
     }
 
     // Failure - handle retry
-    return this.handleFailure(job, leaseToken, publishResult.error!);
+    return this.handleFailure(attemptedJob, leaseToken, publishResult.error!);
   }
 
   private async publishWithLeaseHeartbeat(
     job: ScheduledJob,
-    leaseToken: string
+    leaseToken: string,
+    beforeProviderCall: () => Promise<boolean>
   ): Promise<Awaited<ReturnType<Publisher['publish']>>> {
     const stopHeartbeat = this.startLeaseHeartbeat(job.id, leaseToken);
     try {
-      return await this.publisher.publish(job, { quotaReserved: true });
+      return await this.publisher.publish(job, { quotaReserved: true, beforeProviderCall });
     } finally {
       await stopHeartbeat();
     }

--- a/lib/scheduler/scheduler.ts
+++ b/lib/scheduler/scheduler.ts
@@ -370,11 +370,20 @@ export class Scheduler {
     leaseToken: string,
     beforeProviderCall: () => Promise<boolean>
   ): Promise<Awaited<ReturnType<Publisher['publish']>>> {
-    const stopHeartbeat = this.startLeaseHeartbeat(job.id, leaseToken);
+    let stopHeartbeat: (() => Promise<void>) | undefined;
     try {
-      return await this.publisher.publish(job, { quotaReserved: true, beforeProviderCall });
+      return await this.publisher.publish(job, {
+        quotaReserved: true,
+        beforeProviderCall: async () => {
+          const marked = await beforeProviderCall();
+          if (marked) {
+            stopHeartbeat = this.startLeaseHeartbeat(job.id, leaseToken);
+          }
+          return marked;
+        },
+      });
     } finally {
-      await stopHeartbeat();
+      await stopHeartbeat?.();
     }
   }
 

--- a/lib/scheduler/scheduler.ts
+++ b/lib/scheduler/scheduler.ts
@@ -21,6 +21,7 @@ import { getQueue, generateJobId } from './queue';
 import { getRateLimiter, RateLimiter } from './rate-limiter';
 import { getRetryHandler, RetryHandler } from './retry-handler';
 import { getPublisher, Publisher } from './publisher';
+import { CampaignPublishAuditInput, PrismaJobQueue } from './prisma-queue';
 
 function deriveRequestFingerprint(
   input: CreateJobInput,
@@ -71,7 +72,7 @@ export class Scheduler {
     return (await this.scheduleWithResult(input)).job;
   }
 
-  async scheduleWithResult(input: CreateJobInput): Promise<ScheduleJobResult> {
+  private createValidatedJob(input: CreateJobInput): ScheduledJob {
     const now = new Date().toISOString();
     const timezone = input.timezone || Intl.DateTimeFormat().resolvedOptions().timeZone;
     const maxAttempts = input.maxAttempts || this.config.maxRetries;
@@ -106,15 +107,34 @@ export class Scheduler {
       throw new Error(`Content validation failed: ${validation.errors.join(', ')}`);
     }
 
-    const persisted = await this.queue.add(job);
-    if (persisted.created) {
+    return job;
+  }
+
+  private async emitCreated(result: ScheduleJobResult): Promise<ScheduleJobResult> {
+    if (result.created) {
       await this.emitEvent('job.scheduled', {
-        jobId: persisted.job.id,
-        campaignId: persisted.job.campaignId,
+        jobId: result.job.id,
+        campaignId: result.job.campaignId,
       });
     }
+    return result;
+  }
 
-    return persisted;
+  async scheduleWithResult(input: CreateJobInput): Promise<ScheduleJobResult> {
+    const job = this.createValidatedJob(input);
+    return this.emitCreated(await this.queue.add(job));
+  }
+
+  async scheduleCampaignWithAudit(
+    input: CreateJobInput,
+    audit: CampaignPublishAuditInput
+  ): Promise<ScheduleJobResult> {
+    if (!(this.queue instanceof PrismaJobQueue)) {
+      throw new Error('Campaign scheduling requires durable PostgreSQL persistence');
+    }
+
+    const job = this.createValidatedJob(input);
+    return this.emitCreated(await this.queue.addCampaignJob(job, audit));
   }
 
   /**

--- a/lib/scheduler/scheduler.ts
+++ b/lib/scheduler/scheduler.ts
@@ -79,10 +79,11 @@ export class Scheduler {
     const timezone = input.timezone || Intl.DateTimeFormat().resolvedOptions().timeZone;
     const maxAttempts = input.maxAttempts || this.config.maxRetries;
     const requestFingerprint = deriveRequestFingerprint(input, timezone, maxAttempts);
+    const id = generateJobId();
 
     const job: ScheduledJob = {
-      id: generateJobId(),
-      idempotencyKey: input.idempotencyKey ?? `scheduler:v1:${requestFingerprint}`,
+      id,
+      idempotencyKey: input.idempotencyKey ?? `scheduler:v1:${id}`,
       requestFingerprint,
       type: input.type,
       campaignId: input.campaignId,

--- a/lib/scheduler/scheduler.ts
+++ b/lib/scheduler/scheduler.ts
@@ -14,6 +14,7 @@ import {
   WebhookEvent,
   WebhookEventType,
   JobQueue,
+  ScheduleJobResult,
 } from './types';
 import { createHash } from 'node:crypto';
 import { getQueue, generateJobId } from './queue';
@@ -21,7 +22,11 @@ import { getRateLimiter, RateLimiter } from './rate-limiter';
 import { getRetryHandler, RetryHandler } from './retry-handler';
 import { getPublisher, Publisher } from './publisher';
 
-function deriveIdempotencyKey(input: CreateJobInput): string {
+function deriveRequestFingerprint(
+  input: CreateJobInput,
+  timezone: string,
+  maxAttempts: number
+): string {
   const identity = JSON.stringify({
     type: input.type,
     campaignId: input.campaignId ?? null,
@@ -33,10 +38,10 @@ function deriveIdempotencyKey(input: CreateJobInput): string {
     platformId: input.platformId,
     content: input.content,
     scheduledTime: new Date(input.scheduledTime).toISOString(),
-    timezone: input.timezone ?? null,
-    maxAttempts: input.maxAttempts ?? null,
+    timezone,
+    maxAttempts,
   });
-  return `scheduler:v1:${createHash('sha256').update(identity).digest('hex')}`;
+  return createHash('sha256').update(identity).digest('hex');
 }
 
 /**
@@ -63,11 +68,19 @@ export class Scheduler {
    * Schedule a new job
    */
   async schedule(input: CreateJobInput): Promise<ScheduledJob> {
+    return (await this.scheduleWithResult(input)).job;
+  }
+
+  async scheduleWithResult(input: CreateJobInput): Promise<ScheduleJobResult> {
     const now = new Date().toISOString();
+    const timezone = input.timezone || Intl.DateTimeFormat().resolvedOptions().timeZone;
+    const maxAttempts = input.maxAttempts || this.config.maxRetries;
+    const requestFingerprint = deriveRequestFingerprint(input, timezone, maxAttempts);
 
     const job: ScheduledJob = {
       id: generateJobId(),
-      idempotencyKey: input.idempotencyKey ?? deriveIdempotencyKey(input),
+      idempotencyKey: input.idempotencyKey ?? `scheduler:v1:${requestFingerprint}`,
+      requestFingerprint,
       type: input.type,
       campaignId: input.campaignId,
       campaignVersion: input.campaignVersion,
@@ -78,10 +91,10 @@ export class Scheduler {
       platformId: input.platformId,
       content: input.content,
       scheduledTime: input.scheduledTime,
-      timezone: input.timezone || Intl.DateTimeFormat().resolvedOptions().timeZone,
+      timezone,
       status: 'scheduled',
       attempts: 0,
-      maxAttempts: input.maxAttempts || this.config.maxRetries,
+      maxAttempts,
       createdAt: now,
       updatedAt: now,
       createdBy: input.createdBy,
@@ -101,7 +114,7 @@ export class Scheduler {
       });
     }
 
-    return persisted.job;
+    return persisted;
   }
 
   /**
@@ -136,12 +149,12 @@ export class Scheduler {
       throw new Error(`Cannot cancel job in status: ${job.status}`);
     }
 
-    await this.queue.update(jobId, {
-      status: 'cancelled',
-      updatedAt: new Date().toISOString(),
-    });
-
-    return true;
+    return this.queue.updateIfStatus(
+      jobId,
+      ['scheduled', 'failed'],
+      { status: 'cancelled', updatedAt: new Date().toISOString() },
+      userId
+    );
   }
 
   /**
@@ -162,12 +175,18 @@ export class Scheduler {
       throw new Error(`Cannot reschedule job in status: ${job.status}`);
     }
 
-    await this.queue.update(jobId, {
-      scheduledTime: newScheduledTime,
-      status: 'scheduled',
-      nextRetryAt: undefined,
-      updatedAt: new Date().toISOString(),
-    });
+    const updated = await this.queue.updateIfStatus(
+      jobId,
+      ['scheduled', 'failed', 'cancelled'],
+      {
+        scheduledTime: newScheduledTime,
+        status: 'scheduled',
+        nextRetryAt: undefined,
+        updatedAt: new Date().toISOString(),
+      },
+      userId
+    );
+    if (!updated) return null;
 
     return this.queue.get(jobId, userId);
   }
@@ -191,7 +210,47 @@ export class Scheduler {
       );
       if (!job) break;
 
-      const result = await this.processJob(job, leaseToken);
+      if (!(await this.rateLimiter.canProcess(job.platformId))) {
+        const nextAvailableAt =
+          (await this.rateLimiter.getNextAvailableAt(job.platformId)) ??
+          new Date(now.getTime() + this.config.checkInterval);
+        const deferred = await this.queue.updateClaimed(job.id, leaseToken, {
+          status: 'failed',
+          error: 'Platform rate limit is active; no provider request was attempted',
+          nextRetryAt: nextAvailableAt.toISOString(),
+          updatedAt: now.toISOString(),
+        });
+        results.push({
+          jobId: job.id,
+          status: 'failure',
+          error: {
+            code: deferred ? 'RATE_LIMITED' : 'LEASE_LOST',
+            message: deferred
+              ? 'Platform rate limit is active; job deferred without consuming an attempt'
+              : 'The scheduler processing lease changed before rate-limit deferral was recorded',
+            retryable: deferred,
+          },
+          executedAt: now.toISOString(),
+        });
+        continue;
+      }
+
+      const attemptedJob = await this.queue.markClaimAttempt(job.id, leaseToken, now);
+      if (!attemptedJob) {
+        results.push({
+          jobId: job.id,
+          status: 'failure',
+          error: {
+            code: 'LEASE_LOST',
+            message: 'The scheduler processing lease changed before the attempt was recorded',
+            retryable: false,
+          },
+          executedAt: now.toISOString(),
+        });
+        continue;
+      }
+
+      const result = await this.processJob(attemptedJob, leaseToken);
       results.push(result);
     }
 
@@ -353,14 +412,20 @@ export class Scheduler {
     }
 
     // Reset for retry
-    await this.queue.update(jobId, {
-      status: 'scheduled',
-      scheduledTime: new Date().toISOString(),
-      nextRetryAt: undefined,
-      error: undefined,
-      attempts: 0,
-      updatedAt: new Date().toISOString(),
-    });
+    const updated = await this.queue.updateIfStatus(
+      jobId,
+      ['failed', 'dead'],
+      {
+        status: 'scheduled',
+        scheduledTime: new Date().toISOString(),
+        nextRetryAt: undefined,
+        error: undefined,
+        attempts: 0,
+        updatedAt: new Date().toISOString(),
+      },
+      userId
+    );
+    if (!updated) return null;
 
     return this.queue.get(jobId, userId);
   }

--- a/lib/scheduler/scheduler.ts
+++ b/lib/scheduler/scheduler.ts
@@ -15,6 +15,8 @@ import {
   WebhookEventType,
   JobQueue,
   ScheduleJobResult,
+  ListJobsOptions,
+  ListJobsResult,
 } from './types';
 import { createHash } from 'node:crypto';
 import { getQueue, generateJobId } from './queue';
@@ -503,6 +505,10 @@ export class Scheduler {
    */
   async getAllJobs(userId?: string): Promise<ScheduledJob[]> {
     return this.queue.getAll(userId);
+  }
+
+  async listJobs(options: ListJobsOptions): Promise<ListJobsResult> {
+    return this.queue.list(options);
   }
 
   /**

--- a/lib/scheduler/scheduler.ts
+++ b/lib/scheduler/scheduler.ts
@@ -230,10 +230,10 @@ export class Scheduler {
       );
       if (!job) break;
 
-      if (!(await this.rateLimiter.canProcess(job.platformId))) {
+      const quota = await this.rateLimiter.reserveRequest(job.platformId);
+      if (!quota.allowed) {
         const nextAvailableAt =
-          (await this.rateLimiter.getNextAvailableAt(job.platformId)) ??
-          new Date(now.getTime() + this.config.checkInterval);
+          quota.nextAvailableAt ?? new Date(now.getTime() + this.config.checkInterval);
         const deferred = await this.queue.updateClaimed(job.id, leaseToken, {
           status: 'failed',
           error: 'Platform rate limit is active; no provider request was attempted',
@@ -333,7 +333,7 @@ export class Scheduler {
   ): Promise<Awaited<ReturnType<Publisher['publish']>>> {
     const stopHeartbeat = this.startLeaseHeartbeat(job.id, leaseToken);
     try {
-      return await this.publisher.publish(job);
+      return await this.publisher.publish(job, { quotaReserved: true });
     } finally {
       await stopHeartbeat();
     }

--- a/lib/scheduler/scheduler.ts
+++ b/lib/scheduler/scheduler.ts
@@ -284,7 +284,7 @@ export class Scheduler {
     const now = new Date().toISOString();
 
     // Attempt to publish
-    const publishResult = await this.publisher.publish(job);
+    const publishResult = await this.publishWithLeaseHeartbeat(job, leaseToken);
 
     if (publishResult.success && publishResult.result) {
       const completed = await this.queue.updateClaimed(job.id, leaseToken, {
@@ -325,6 +325,47 @@ export class Scheduler {
 
     // Failure - handle retry
     return this.handleFailure(job, leaseToken, publishResult.error!);
+  }
+
+  private async publishWithLeaseHeartbeat(
+    job: ScheduledJob,
+    leaseToken: string
+  ): Promise<Awaited<ReturnType<Publisher['publish']>>> {
+    const stopHeartbeat = this.startLeaseHeartbeat(job.id, leaseToken);
+    try {
+      return await this.publisher.publish(job);
+    } finally {
+      await stopHeartbeat();
+    }
+  }
+
+  private startLeaseHeartbeat(jobId: string, leaseToken: string): () => Promise<void> {
+    const heartbeatInterval = Math.max(100, Math.floor(this.config.leaseDuration / 3));
+    let stopped = false;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    let activeRenewal: Promise<void> = Promise.resolve();
+
+    const renew = (): void => {
+      activeRenewal = this.queue
+        .renewClaimLease(jobId, leaseToken, new Date(Date.now() + this.config.leaseDuration))
+        .then(renewed => {
+          if (!renewed) stopped = true;
+        })
+        .catch(error => {
+          console.error(`Failed to renew scheduler lease for ${jobId}:`, error);
+        })
+        .finally(() => {
+          if (!stopped) timer = setTimeout(renew, heartbeatInterval);
+        });
+    };
+
+    timer = setTimeout(renew, heartbeatInterval);
+    return async () => {
+      stopped = true;
+      if (timer) clearTimeout(timer);
+      await activeRenewal;
+      if (timer) clearTimeout(timer);
+    };
   }
 
   /**

--- a/lib/scheduler/scheduler.ts
+++ b/lib/scheduler/scheduler.ts
@@ -15,10 +15,29 @@ import {
   WebhookEventType,
   JobQueue,
 } from './types';
+import { createHash } from 'node:crypto';
 import { getQueue, generateJobId } from './queue';
 import { getRateLimiter, RateLimiter } from './rate-limiter';
 import { getRetryHandler, RetryHandler } from './retry-handler';
 import { getPublisher, Publisher } from './publisher';
+
+function deriveIdempotencyKey(input: CreateJobInput): string {
+  const identity = JSON.stringify({
+    type: input.type,
+    campaignId: input.campaignId ?? null,
+    campaignVersion: input.campaignVersion ?? null,
+    campaignVersionId: input.campaignVersionId ?? null,
+    approvedContentHash: input.approvedContentHash ?? null,
+    variantId: input.variantId ?? null,
+    contentId: input.contentId,
+    platformId: input.platformId,
+    content: input.content,
+    scheduledTime: new Date(input.scheduledTime).toISOString(),
+    timezone: input.timezone ?? null,
+    maxAttempts: input.maxAttempts ?? null,
+  });
+  return `scheduler:v1:${createHash('sha256').update(identity).digest('hex')}`;
+}
 
 /**
  * Scheduler Service
@@ -48,6 +67,7 @@ export class Scheduler {
 
     const job: ScheduledJob = {
       id: generateJobId(),
+      idempotencyKey: input.idempotencyKey ?? deriveIdempotencyKey(input),
       type: input.type,
       campaignId: input.campaignId,
       campaignVersion: input.campaignVersion,
@@ -73,10 +93,15 @@ export class Scheduler {
       throw new Error(`Content validation failed: ${validation.errors.join(', ')}`);
     }
 
-    await this.queue.add(job);
-    await this.emitEvent('job.scheduled', { jobId: job.id, campaignId: job.campaignId });
+    const persisted = await this.queue.add(job);
+    if (persisted.created) {
+      await this.emitEvent('job.scheduled', {
+        jobId: persisted.job.id,
+        campaignId: persisted.job.campaignId,
+      });
+    }
 
-    return job;
+    return persisted.job;
   }
 
   /**
@@ -100,8 +125,8 @@ export class Scheduler {
   /**
    * Cancel a scheduled job
    */
-  async cancel(jobId: string): Promise<boolean> {
-    const job = await this.queue.get(jobId);
+  async cancel(jobId: string, userId?: string): Promise<boolean> {
+    const job = await this.queue.get(jobId, userId);
 
     if (!job) {
       return false;
@@ -122,8 +147,12 @@ export class Scheduler {
   /**
    * Reschedule a job to a new time
    */
-  async reschedule(jobId: string, newScheduledTime: string): Promise<ScheduledJob | null> {
-    const job = await this.queue.get(jobId);
+  async reschedule(
+    jobId: string,
+    newScheduledTime: string,
+    userId?: string
+  ): Promise<ScheduledJob | null> {
+    const job = await this.queue.get(jobId, userId);
 
     if (!job) {
       return null;
@@ -140,26 +169,29 @@ export class Scheduler {
       updatedAt: new Date().toISOString(),
     });
 
-    return this.queue.get(jobId);
+    return this.queue.get(jobId, userId);
   }
 
   /**
    * Process due jobs
    */
   async processDueJobs(): Promise<JobResult[]> {
-    const now = new Date();
-    const dueJobs = await this.queue.getDueJobs(now, this.config.batchSize);
-
     const results: JobResult[] = [];
 
-    for (const job of dueJobs) {
-      // Check rate limits before processing
-      if (!(await this.rateLimiter.canProcess(job.platformId))) {
-        // Skip, will be picked up in next cycle
-        continue;
-      }
+    // Claim immediately before publishing so jobs later in a batch do not spend
+    // most of their lease waiting for earlier provider calls to complete.
+    for (let processed = 0; processed < this.config.batchSize; processed += 1) {
+      const now = new Date();
+      const leaseToken = generateJobId();
+      const [job] = await this.queue.claimDueJobs(
+        now,
+        1,
+        leaseToken,
+        new Date(now.getTime() + this.config.leaseDuration)
+      );
+      if (!job) break;
 
-      const result = await this.processJob(job);
+      const result = await this.processJob(job, leaseToken);
       results.push(result);
     }
 
@@ -169,39 +201,33 @@ export class Scheduler {
   /**
    * Process a single job
    */
-  private async processJob(job: ScheduledJob): Promise<JobResult> {
+  private async processJob(job: ScheduledJob, leaseToken: string): Promise<JobResult> {
     const now = new Date().toISOString();
 
-    // Update to processing status
-    await this.queue.update(job.id, {
-      status: 'processing',
-      lastAttemptAt: now,
-      attempts: job.attempts + 1,
-    });
-
-    // Refresh job from queue
-    const currentJob = await this.queue.get(job.id);
-    if (!currentJob) {
-      return {
-        jobId: job.id,
-        status: 'failure',
-        error: { code: 'NOT_FOUND', message: 'Job not found', retryable: false },
-        executedAt: now,
-      };
-    }
-
     // Attempt to publish
-    const publishResult = await this.publisher.publish(currentJob);
+    const publishResult = await this.publisher.publish(job);
 
     if (publishResult.success && publishResult.result) {
-      // Success
-      await this.queue.update(job.id, {
+      const completed = await this.queue.updateClaimed(job.id, leaseToken, {
         status: 'published',
         publishedAt: now,
         publishedUrl: publishResult.result.url,
         platformPostId: publishResult.result.id,
         updatedAt: now,
       });
+      if (!completed) {
+        return {
+          jobId: job.id,
+          status: 'failure',
+          error: {
+            code: 'UNKNOWN_PROVIDER_RESULT',
+            message:
+              'Provider accepted the request but the processing lease could not be completed',
+            retryable: false,
+          },
+          executedAt: now,
+        };
+      }
 
       await this.emitEvent('job.published', {
         jobId: job.id,
@@ -219,7 +245,7 @@ export class Scheduler {
     }
 
     // Failure - handle retry
-    return this.handleFailure(currentJob, publishResult.error!);
+    return this.handleFailure(job, leaseToken, publishResult.error!);
   }
 
   /**
@@ -227,6 +253,7 @@ export class Scheduler {
    */
   private async handleFailure(
     job: ScheduledJob,
+    leaseToken: string,
     error: Error & { code?: string; retryable?: boolean }
   ): Promise<JobResult> {
     const now = new Date().toISOString();
@@ -235,12 +262,24 @@ export class Scheduler {
 
     if (shouldRetry.retry && shouldRetry.nextRetryAt) {
       // Schedule retry
-      await this.queue.update(job.id, {
+      const updated = await this.queue.updateClaimed(job.id, leaseToken, {
         status: 'failed',
         error: shouldRetry.classification.message,
         nextRetryAt: shouldRetry.nextRetryAt.toISOString(),
         updatedAt: now,
       });
+      if (!updated) {
+        return {
+          jobId: job.id,
+          status: 'failure',
+          error: {
+            code: 'LEASE_LOST',
+            message: 'The scheduler processing lease changed before retry state was recorded',
+            retryable: false,
+          },
+          executedAt: now,
+        };
+      }
 
       await this.emitEvent('job.failed', {
         jobId: job.id,
@@ -262,11 +301,23 @@ export class Scheduler {
     }
 
     // Move to dead letter queue (no more retries)
-    await this.queue.update(job.id, {
+    const updated = await this.queue.updateClaimed(job.id, leaseToken, {
       status: 'dead',
       error: shouldRetry.classification.message,
       updatedAt: now,
     });
+    if (!updated) {
+      return {
+        jobId: job.id,
+        status: 'failure',
+        error: {
+          code: 'LEASE_LOST',
+          message: 'The scheduler processing lease changed before dead-letter state was recorded',
+          retryable: false,
+        },
+        executedAt: now,
+      };
+    }
 
     await this.emitEvent('job.dead', {
       jobId: job.id,
@@ -290,8 +341,8 @@ export class Scheduler {
   /**
    * Manually retry a failed/dead job
    */
-  async retry(jobId: string): Promise<ScheduledJob | null> {
-    const job = await this.queue.get(jobId);
+  async retry(jobId: string, userId?: string): Promise<ScheduledJob | null> {
+    const job = await this.queue.get(jobId, userId);
 
     if (!job) {
       return null;
@@ -311,35 +362,39 @@ export class Scheduler {
       updatedAt: new Date().toISOString(),
     });
 
-    return this.queue.get(jobId);
+    return this.queue.get(jobId, userId);
   }
 
   /**
    * Get job by ID
    */
-  async getJob(jobId: string): Promise<ScheduledJob | null> {
-    return this.queue.get(jobId);
+  async getJob(jobId: string, userId?: string): Promise<ScheduledJob | null> {
+    return this.queue.get(jobId, userId);
   }
 
   /**
    * Get all jobs
    */
-  async getAllJobs(): Promise<ScheduledJob[]> {
-    return this.queue.getAll();
+  async getAllJobs(userId?: string): Promise<ScheduledJob[]> {
+    return this.queue.getAll(userId);
   }
 
   /**
    * Get jobs by status
    */
-  async getJobsByStatus(status: JobStatus, limit?: number): Promise<ScheduledJob[]> {
-    return this.queue.getByStatus(status, limit);
+  async getJobsByStatus(
+    status: JobStatus,
+    limit?: number,
+    userId?: string
+  ): Promise<ScheduledJob[]> {
+    return this.queue.getByStatus(status, limit, userId);
   }
 
   /**
    * Get jobs for a campaign
    */
-  async getJobsByCampaign(campaignId: string): Promise<ScheduledJob[]> {
-    return this.queue.getByCampaign(campaignId);
+  async getJobsByCampaign(campaignId: string, userId?: string): Promise<ScheduledJob[]> {
+    return this.queue.getByCampaign(campaignId, userId);
   }
 
   /**
@@ -375,6 +430,7 @@ export class Scheduler {
           break;
         case 'failed':
         case 'dead':
+        case 'reconciliation_required':
           if (job.lastAttemptAt && new Date(job.lastAttemptAt) >= today) {
             stats.failedToday++;
           }
@@ -430,8 +486,8 @@ export class Scheduler {
   /**
    * Clear all jobs (for testing)
    */
-  async clearAll(): Promise<void> {
-    await this.queue.clear();
+  async clearAll(userId?: string): Promise<void> {
+    await this.queue.clear(userId);
   }
 }
 

--- a/lib/scheduler/scheduler.ts
+++ b/lib/scheduler/scheduler.ts
@@ -23,7 +23,7 @@ import { getQueue, generateJobId } from './queue';
 import { getRateLimiter, RateLimiter } from './rate-limiter';
 import { getRetryHandler, RetryHandler } from './retry-handler';
 import { getPublisher, Publisher } from './publisher';
-import { CampaignPublishAuditInput, PrismaJobQueue } from './prisma-queue';
+import { CampaignPublishAuditInput, PrismaJobQueue, SchedulerQueueError } from './prisma-queue';
 
 function deriveRequestFingerprint(
   input: CreateJobInput,
@@ -39,7 +39,7 @@ function deriveRequestFingerprint(
     variantId: input.variantId ?? null,
     contentId: input.contentId,
     platformId: input.platformId,
-    content: input.content,
+    content: input.idempotencyContent ?? input.content,
     scheduledTime: new Date(input.scheduledTime).toISOString(),
     timezone,
     maxAttempts,
@@ -126,6 +126,28 @@ export class Scheduler {
   async scheduleWithResult(input: CreateJobInput): Promise<ScheduleJobResult> {
     const job = this.createValidatedJob(input);
     return this.emitCreated(await this.queue.add(job));
+  }
+
+  async findIdempotentReplay(input: CreateJobInput): Promise<ScheduleJobResult | null> {
+    if (!input.createdBy || !input.idempotencyKey || !(this.queue instanceof PrismaJobQueue)) {
+      return null;
+    }
+    const existing = await this.queue.getByIdempotencyKey(input.createdBy, input.idempotencyKey);
+    if (!existing) return null;
+
+    const candidate = this.createValidatedJob({
+      ...input,
+      campaignVersionId: input.campaignVersionId ?? existing.campaignVersionId,
+      timezone: input.timezone ?? existing.timezone,
+      maxAttempts: input.maxAttempts ?? existing.maxAttempts,
+    });
+    if (candidate.requestFingerprint !== existing.requestFingerprint) {
+      throw new SchedulerQueueError(
+        'IDEMPOTENCY_CONFLICT',
+        'The idempotency key already identifies a different scheduler request'
+      );
+    }
+    return { job: existing, created: false };
   }
 
   async scheduleCampaignWithAudit(

--- a/lib/scheduler/types.ts
+++ b/lib/scheduler/types.ts
@@ -62,6 +62,7 @@ export interface ScheduledJob {
   nextRetryAt?: string;
   leaseToken?: string;
   leaseExpiresAt?: string;
+  attemptStartedAt?: string;
 
   // Results
   publishedAt?: string;

--- a/lib/scheduler/types.ts
+++ b/lib/scheduler/types.ts
@@ -27,6 +27,7 @@ export type JobType = 'campaign_post' | 'series_promotion' | 'standalone';
 export interface ScheduledJob {
   id: string;
   idempotencyKey: string;
+  requestFingerprint: string;
   type: JobType;
 
   // Reference to content
@@ -181,6 +182,11 @@ export interface ClaimedJobUpdate extends Partial<ScheduledJob> {
   status: Exclude<JobStatus, 'processing'>;
 }
 
+export interface ScheduleJobResult {
+  job: ScheduledJob;
+  created: boolean;
+}
+
 /**
  * Job queue interface
  */
@@ -188,6 +194,12 @@ export interface JobQueue {
   add(job: ScheduledJob): Promise<{ job: ScheduledJob; created: boolean }>;
   get(id: string, userId?: string): Promise<ScheduledJob | null>;
   update(id: string, updates: Partial<ScheduledJob>): Promise<void>;
+  updateIfStatus(
+    id: string,
+    statuses: JobStatus[],
+    updates: Partial<ScheduledJob>,
+    userId?: string
+  ): Promise<boolean>;
   remove(id: string): Promise<void>;
   getDueJobs(before: Date, limit: number): Promise<ScheduledJob[]>;
   claimDueJobs(
@@ -196,6 +208,7 @@ export interface JobQueue {
     leaseToken: string,
     leaseExpiresAt: Date
   ): Promise<ScheduledJob[]>;
+  markClaimAttempt(id: string, leaseToken: string, attemptedAt: Date): Promise<ScheduledJob | null>;
   updateClaimed(id: string, leaseToken: string, updates: ClaimedJobUpdate): Promise<boolean>;
   getByStatus(status: JobStatus, limit?: number, userId?: string): Promise<ScheduledJob[]>;
   getByCampaign(campaignId: string, userId?: string): Promise<ScheduledJob[]>;

--- a/lib/scheduler/types.ts
+++ b/lib/scheduler/types.ts
@@ -210,6 +210,7 @@ export interface JobQueue {
     leaseExpiresAt: Date
   ): Promise<ScheduledJob[]>;
   markClaimAttempt(id: string, leaseToken: string, attemptedAt: Date): Promise<ScheduledJob | null>;
+  renewClaimLease(id: string, leaseToken: string, leaseExpiresAt: Date): Promise<boolean>;
   updateClaimed(id: string, leaseToken: string, updates: ClaimedJobUpdate): Promise<boolean>;
   getByStatus(status: JobStatus, limit?: number, userId?: string): Promise<ScheduledJob[]>;
   getByCampaign(campaignId: string, userId?: string): Promise<ScheduledJob[]>;

--- a/lib/scheduler/types.ts
+++ b/lib/scheduler/types.ts
@@ -13,6 +13,7 @@ export type JobStatus =
   | 'published' // Successfully published
   | 'failed' // Failed, will retry
   | 'dead' // Exceeded max retries
+  | 'reconciliation_required' // Provider outcome is unknown; never auto-republish
   | 'cancelled'; // Manually cancelled
 
 /**
@@ -25,6 +26,7 @@ export type JobType = 'campaign_post' | 'series_promotion' | 'standalone';
  */
 export interface ScheduledJob {
   id: string;
+  idempotencyKey: string;
   type: JobType;
 
   // Reference to content
@@ -57,6 +59,8 @@ export interface ScheduledJob {
   maxAttempts: number;
   lastAttemptAt?: string;
   nextRetryAt?: string;
+  leaseToken?: string;
+  leaseExpiresAt?: string;
 
   // Results
   publishedAt?: string;
@@ -139,6 +143,7 @@ export interface SchedulerConfig {
   batchSize: number; // Max jobs to process per cycle
   maxRetries: number; // Default max retry attempts
   retryDelays: number[]; // Backoff delays in seconds
+  leaseDuration: number; // Processing lease duration (ms)
 }
 
 /**
@@ -149,6 +154,7 @@ export const DEFAULT_SCHEDULER_CONFIG: SchedulerConfig = {
   batchSize: 50,
   maxRetries: 5,
   retryDelays: [60, 300, 900, 3600, 14400], // 1m, 5m, 15m, 1h, 4h
+  leaseDuration: 2 * 60 * 1000,
 };
 
 /**
@@ -168,22 +174,34 @@ export interface CreateJobInput {
   timezone?: string;
   maxAttempts?: number;
   createdBy?: string;
+  idempotencyKey?: string;
+}
+
+export interface ClaimedJobUpdate extends Partial<ScheduledJob> {
+  status: Exclude<JobStatus, 'processing'>;
 }
 
 /**
  * Job queue interface
  */
 export interface JobQueue {
-  add(job: ScheduledJob): Promise<void>;
-  get(id: string): Promise<ScheduledJob | null>;
+  add(job: ScheduledJob): Promise<{ job: ScheduledJob; created: boolean }>;
+  get(id: string, userId?: string): Promise<ScheduledJob | null>;
   update(id: string, updates: Partial<ScheduledJob>): Promise<void>;
   remove(id: string): Promise<void>;
   getDueJobs(before: Date, limit: number): Promise<ScheduledJob[]>;
-  getByStatus(status: JobStatus, limit?: number): Promise<ScheduledJob[]>;
-  getByCampaign(campaignId: string): Promise<ScheduledJob[]>;
-  getAll(): Promise<ScheduledJob[]>;
+  claimDueJobs(
+    before: Date,
+    limit: number,
+    leaseToken: string,
+    leaseExpiresAt: Date
+  ): Promise<ScheduledJob[]>;
+  updateClaimed(id: string, leaseToken: string, updates: ClaimedJobUpdate): Promise<boolean>;
+  getByStatus(status: JobStatus, limit?: number, userId?: string): Promise<ScheduledJob[]>;
+  getByCampaign(campaignId: string, userId?: string): Promise<ScheduledJob[]>;
+  getAll(userId?: string): Promise<ScheduledJob[]>;
   count(): Promise<number>;
-  clear(): Promise<void>;
+  clear(userId?: string): Promise<void>;
 }
 
 /**

--- a/lib/scheduler/types.ts
+++ b/lib/scheduler/types.ts
@@ -172,6 +172,8 @@ export interface CreateJobInput {
   contentId: string;
   platformId: string;
   content: ScheduledJob['content'];
+  /** Original client content used only to fingerprint an idempotent request. */
+  idempotencyContent?: ScheduledJob['content'];
   scheduledTime: string;
   timezone?: string;
   maxAttempts?: number;

--- a/lib/scheduler/types.ts
+++ b/lib/scheduler/types.ts
@@ -188,6 +188,19 @@ export interface ScheduleJobResult {
   created: boolean;
 }
 
+export interface ListJobsOptions {
+  userId: string;
+  status?: JobStatus;
+  campaignId?: string;
+  limit: number;
+  offset: number;
+}
+
+export interface ListJobsResult {
+  jobs: ScheduledJob[];
+  total: number;
+}
+
 /**
  * Job queue interface
  */
@@ -215,6 +228,7 @@ export interface JobQueue {
   getByStatus(status: JobStatus, limit?: number, userId?: string): Promise<ScheduledJob[]>;
   getByCampaign(campaignId: string, userId?: string): Promise<ScheduledJob[]>;
   getAll(userId?: string): Promise<ScheduledJob[]>;
+  list(options: ListJobsOptions): Promise<ListJobsResult>;
   count(): Promise<number>;
   clear(userId?: string): Promise<void>;
 }

--- a/prisma/migrations/20260726080500_scheduler_jobs/migration.sql
+++ b/prisma/migrations/20260726080500_scheduler_jobs/migration.sql
@@ -3,6 +3,7 @@ CREATE TABLE "SchedulerJob" (
     "id" TEXT NOT NULL,
     "userId" TEXT NOT NULL,
     "idempotencyKey" TEXT NOT NULL,
+    "requestFingerprint" TEXT NOT NULL,
     "type" TEXT NOT NULL,
     "campaignId" TEXT,
     "campaignVersion" INTEGER,
@@ -55,3 +56,11 @@ ALTER TABLE "SchedulerJob"
     ADD CONSTRAINT "SchedulerJob_campaignVersionId_fkey"
     FOREIGN KEY ("campaignVersionId") REFERENCES "CampaignVersion"("id")
     ON DELETE RESTRICT ON UPDATE CASCADE;
+
+ALTER TABLE "PublishAttempt" ADD COLUMN "schedulerJobId" TEXT;
+CREATE UNIQUE INDEX "PublishAttempt_schedulerJobId_key"
+    ON "PublishAttempt"("schedulerJobId");
+ALTER TABLE "PublishAttempt"
+    ADD CONSTRAINT "PublishAttempt_schedulerJobId_fkey"
+    FOREIGN KEY ("schedulerJobId") REFERENCES "SchedulerJob"("id")
+    ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/migrations/20260726080500_scheduler_jobs/migration.sql
+++ b/prisma/migrations/20260726080500_scheduler_jobs/migration.sql
@@ -22,6 +22,7 @@ CREATE TABLE "SchedulerJob" (
     "nextRetryAt" TIMESTAMP(3),
     "leaseToken" TEXT,
     "leaseExpiresAt" TIMESTAMP(3),
+    "attemptStartedAt" TIMESTAMP(3),
     "publishedAt" TIMESTAMP(3),
     "publishedUrl" TEXT,
     "platformPostId" TEXT,
@@ -55,7 +56,7 @@ ALTER TABLE "SchedulerJob"
 ALTER TABLE "SchedulerJob"
     ADD CONSTRAINT "SchedulerJob_campaignVersionId_fkey"
     FOREIGN KEY ("campaignVersionId") REFERENCES "CampaignVersion"("id")
-    ON DELETE RESTRICT ON UPDATE CASCADE;
+    ON DELETE SET NULL ON UPDATE CASCADE;
 
 ALTER TABLE "PublishAttempt" ADD COLUMN "schedulerJobId" TEXT;
 CREATE UNIQUE INDEX "PublishAttempt_schedulerJobId_key"

--- a/prisma/migrations/20260726080500_scheduler_jobs/migration.sql
+++ b/prisma/migrations/20260726080500_scheduler_jobs/migration.sql
@@ -1,0 +1,57 @@
+-- Add a tenant-owned durable scheduler queue with idempotency and bounded leases.
+CREATE TABLE "SchedulerJob" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "idempotencyKey" TEXT NOT NULL,
+    "type" TEXT NOT NULL,
+    "campaignId" TEXT,
+    "campaignVersion" INTEGER,
+    "campaignVersionId" TEXT,
+    "approvedContentHash" TEXT,
+    "variantId" TEXT,
+    "contentId" TEXT NOT NULL,
+    "platformId" TEXT NOT NULL,
+    "content" TEXT NOT NULL,
+    "scheduledAt" TIMESTAMP(3) NOT NULL,
+    "timezone" TEXT NOT NULL,
+    "status" TEXT NOT NULL DEFAULT 'scheduled',
+    "attempts" INTEGER NOT NULL DEFAULT 0,
+    "maxAttempts" INTEGER NOT NULL DEFAULT 5,
+    "lastAttemptAt" TIMESTAMP(3),
+    "nextRetryAt" TIMESTAMP(3),
+    "leaseToken" TEXT,
+    "leaseExpiresAt" TIMESTAMP(3),
+    "publishedAt" TIMESTAMP(3),
+    "publishedUrl" TEXT,
+    "platformPostId" TEXT,
+    "errorCode" TEXT,
+    "error" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    CONSTRAINT "SchedulerJob_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "SchedulerJob_userId_idempotencyKey_key"
+    ON "SchedulerJob"("userId", "idempotencyKey");
+CREATE INDEX "SchedulerJob_userId_status_idx"
+    ON "SchedulerJob"("userId", "status");
+CREATE INDEX "SchedulerJob_status_scheduledAt_idx"
+    ON "SchedulerJob"("status", "scheduledAt");
+CREATE INDEX "SchedulerJob_status_nextRetryAt_idx"
+    ON "SchedulerJob"("status", "nextRetryAt");
+CREATE INDEX "SchedulerJob_leaseExpiresAt_idx"
+    ON "SchedulerJob"("leaseExpiresAt");
+CREATE INDEX "SchedulerJob_campaignId_idx"
+    ON "SchedulerJob"("campaignId");
+CREATE INDEX "SchedulerJob_campaignVersionId_idx"
+    ON "SchedulerJob"("campaignVersionId");
+
+ALTER TABLE "SchedulerJob"
+    ADD CONSTRAINT "SchedulerJob_userId_fkey"
+    FOREIGN KEY ("userId") REFERENCES "User"("id")
+    ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "SchedulerJob"
+    ADD CONSTRAINT "SchedulerJob_campaignVersionId_fkey"
+    FOREIGN KEY ("campaignVersionId") REFERENCES "CampaignVersion"("id")
+    ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/migrations/20260726102500_scheduler_platform_quotas/migration.sql
+++ b/prisma/migrations/20260726102500_scheduler_platform_quotas/migration.sql
@@ -1,0 +1,15 @@
+CREATE TABLE "SchedulerPlatformQuota" (
+    "platformId" TEXT NOT NULL,
+    "windowStart" TIMESTAMP(3) NOT NULL,
+    "windowDuration" INTEGER NOT NULL,
+    "requestCount" INTEGER NOT NULL DEFAULT 0,
+    "requestLimit" INTEGER NOT NULL,
+    "dailyCount" INTEGER,
+    "dailyLimit" INTEGER,
+    "dailyResetAt" TIMESTAMP(3),
+    "backoffUntil" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "SchedulerPlatformQuota_pkey" PRIMARY KEY ("platformId")
+);

--- a/prisma/migrations/20260726121500_external_identities/migration.sql
+++ b/prisma/migrations/20260726121500_external_identities/migration.sql
@@ -1,0 +1,20 @@
+-- Persist external provider subjects before issuing application sessions.
+CREATE TABLE "ExternalIdentity" (
+    "id" TEXT NOT NULL,
+    "provider" TEXT NOT NULL,
+    "externalId" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    CONSTRAINT "ExternalIdentity_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "ExternalIdentity_provider_externalId_key"
+    ON "ExternalIdentity"("provider", "externalId");
+CREATE INDEX "ExternalIdentity_userId_idx"
+    ON "ExternalIdentity"("userId");
+
+ALTER TABLE "ExternalIdentity"
+    ADD CONSTRAINT "ExternalIdentity_userId_fkey"
+    FOREIGN KEY ("userId") REFERENCES "User"("id")
+    ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -308,6 +308,7 @@ model SchedulerJob {
   nextRetryAt         DateTime?
   leaseToken          String?
   leaseExpiresAt      DateTime?
+  attemptStartedAt    DateTime?
   publishedAt         DateTime?
   publishedUrl        String?
   platformPostId      String?
@@ -317,7 +318,7 @@ model SchedulerJob {
   updatedAt           DateTime  @updatedAt
 
   user               User             @relation(fields: [userId], references: [id], onDelete: Cascade)
-  campaignVersionRow CampaignVersion? @relation(fields: [campaignVersionId], references: [id], onDelete: Restrict)
+  campaignVersionRow CampaignVersion? @relation(fields: [campaignVersionId], references: [id], onDelete: SetNull)
   publishAttempt     PublishAttempt?
 
   @@unique([userId, idempotencyKey])

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -27,10 +27,28 @@ model User {
   updatedAt    DateTime @updatedAt
 
   // Relations
-  campaigns        Campaign[]
-  auditLogs        AuditLog[]
-  platformAccounts PlatformAccount[]
-  schedulerJobs    SchedulerJob[]
+  campaigns          Campaign[]
+  auditLogs          AuditLog[]
+  platformAccounts   PlatformAccount[]
+  externalIdentities ExternalIdentity[]
+  schedulerJobs      SchedulerJob[]
+}
+
+// Durable mapping from an external provider subject to its local tenant owner.
+// Email is deliberately not used as an identity key because an unverified
+// provider claim must never silently take over an existing local account.
+model ExternalIdentity {
+  id         String   @id @default(cuid())
+  provider   String
+  externalId String
+  userId     String
+  createdAt  DateTime @default(now())
+  updatedAt  DateTime @updatedAt
+
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@unique([provider, externalId])
+  @@index([userId])
 }
 
 // Tenant-owned provider credentials. Token values are encrypted by the
@@ -333,17 +351,17 @@ model SchedulerJob {
 // Shared scheduler dispatch quota. PostgreSQL transactions serialize reservations
 // per platform so overlapping workers cannot each consume a process-local limit.
 model SchedulerPlatformQuota {
-  platformId     String   @id
+  platformId     String    @id
   windowStart    DateTime
   windowDuration Int
-  requestCount   Int      @default(0)
+  requestCount   Int       @default(0)
   requestLimit   Int
   dailyCount     Int?
   dailyLimit     Int?
   dailyResetAt   DateTime?
   backoffUntil   DateTime?
-  createdAt      DateTime @default(now())
-  updatedAt      DateTime @updatedAt
+  createdAt      DateTime  @default(now())
+  updatedAt      DateTime  @updatedAt
 }
 
 // Series model for content series

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -30,6 +30,7 @@ model User {
   campaigns        Campaign[]
   auditLogs        AuditLog[]
   platformAccounts PlatformAccount[]
+  schedulerJobs    SchedulerJob[]
 }
 
 // Tenant-owned provider credentials. Token values are encrypted by the
@@ -112,6 +113,7 @@ model CampaignVersion {
   publishAttempts     PublishAttempt[]
   decisions           CampaignDecision[]
   scheduledPosts      ScheduledPost[]
+  schedulerJobs       SchedulerJob[]
 
   @@unique([campaignId, version])
   @@unique([campaignId, snapshotHash])
@@ -276,6 +278,51 @@ model ScheduledPost {
   @@index([campaignVersionId])
   @@index([status])
   @@index([scheduledAt])
+}
+
+// Tenant-owned durable publish queue. A processing lease is never retried
+// automatically after expiry because the provider result may be unknown;
+// reconciliation must establish the provider outcome first.
+model SchedulerJob {
+  id                  String    @id @default(cuid())
+  userId              String
+  idempotencyKey      String
+  type                String
+  campaignId          String?
+  campaignVersion     Int?
+  campaignVersionId   String?
+  approvedContentHash String?
+  variantId           String?
+  contentId           String
+  platformId          String
+  content             String
+  scheduledAt         DateTime
+  timezone            String
+  status              String    @default("scheduled")
+  attempts            Int       @default(0)
+  maxAttempts         Int       @default(5)
+  lastAttemptAt       DateTime?
+  nextRetryAt         DateTime?
+  leaseToken          String?
+  leaseExpiresAt      DateTime?
+  publishedAt         DateTime?
+  publishedUrl        String?
+  platformPostId      String?
+  errorCode           String?
+  error               String?
+  createdAt           DateTime  @default(now())
+  updatedAt           DateTime  @updatedAt
+
+  user               User             @relation(fields: [userId], references: [id], onDelete: Cascade)
+  campaignVersionRow CampaignVersion? @relation(fields: [campaignVersionId], references: [id], onDelete: Restrict)
+
+  @@unique([userId, idempotencyKey])
+  @@index([userId, status])
+  @@index([status, scheduledAt])
+  @@index([status, nextRetryAt])
+  @@index([leaseExpiresAt])
+  @@index([campaignId])
+  @@index([campaignVersionId])
 }
 
 // Series model for content series

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -192,11 +192,13 @@ model PublishAttempt {
   auditEventId      String?
   errorCode         String?
   requestedBy       String
+  schedulerJobId    String?   @unique
   requestedAt       DateTime  @default(now())
   completedAt       DateTime?
 
   campaign        Campaign        @relation(fields: [campaignId], references: [id], onDelete: Cascade)
   campaignVersion CampaignVersion @relation(fields: [campaignVersionId], references: [id], onDelete: Cascade)
+  schedulerJob    SchedulerJob?   @relation(fields: [schedulerJobId], references: [id], onDelete: SetNull)
 
   @@index([campaignId, requestedAt])
   @@index([campaignVersionId, variantId])
@@ -287,6 +289,7 @@ model SchedulerJob {
   id                  String    @id @default(cuid())
   userId              String
   idempotencyKey      String
+  requestFingerprint  String
   type                String
   campaignId          String?
   campaignVersion     Int?
@@ -315,6 +318,7 @@ model SchedulerJob {
 
   user               User             @relation(fields: [userId], references: [id], onDelete: Cascade)
   campaignVersionRow CampaignVersion? @relation(fields: [campaignVersionId], references: [id], onDelete: Restrict)
+  publishAttempt     PublishAttempt?
 
   @@unique([userId, idempotencyKey])
   @@index([userId, status])

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -330,6 +330,22 @@ model SchedulerJob {
   @@index([campaignVersionId])
 }
 
+// Shared scheduler dispatch quota. PostgreSQL transactions serialize reservations
+// per platform so overlapping workers cannot each consume a process-local limit.
+model SchedulerPlatformQuota {
+  platformId     String   @id
+  windowStart    DateTime
+  windowDuration Int
+  requestCount   Int      @default(0)
+  requestLimit   Int
+  dailyCount     Int?
+  dailyLimit     Int?
+  dailyResetAt   DateTime?
+  backoffUntil   DateTime?
+  createdAt      DateTime @default(now())
+  updatedAt      DateTime @updatedAt
+}
+
 // Series model for content series
 model Series {
   id          String   @id @default(cuid())


### PR DESCRIPTION
## Summary
- persist tenant-owned scheduler jobs in PostgreSQL with per-user idempotency keys
- atomically claim due work with bounded leases and quarantine expired unknown provider outcomes
- scope scheduler reads and mutations to the authenticated owner
- add migration, queue contract tests, API coverage, and PostgreSQL restart/concurrency/tenant integration coverage

## Safety
- production fails closed when durable persistence is unavailable
- expired processing leases become reconciliation_required and are never automatically republished
- provider reconciliation and the recurring Azure trigger remain follow-up Gate 3C slices

## Validation
- pnpm run marketing:validate
- pnpm run type-check
- pnpm run lint (passes with existing warnings)
- changed-file Prettier check
- pnpm exec prisma validate
- pnpm test -- --runInBand (37 suites, 282 tests; 2 environment-dependent suites skipped locally)
- pnpm run build

Note: the repository-wide Prettier check reports the existing Windows checkout line-ending baseline across 482 untouched files; every changed JS/TS file passes Prettier.