### PR TITLE
Add X secret bootstrap workflow

### DIFF
--- a/.github/workflows/bootstrap-x-oauth-secrets.yml
+++ b/.github/workflows/bootstrap-x-oauth-secrets.yml
@@ -1,0 +1,87 @@
+name: Bootstrap X OAuth Secrets
+
+on:
+  workflow_dispatch:
+    inputs:
+      confirmation:
+        description: "Type IMPORT to copy the bootstrap secrets into Key Vault"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: bootstrap-x-oauth-secrets
+  cancel-in-progress: false
+
+jobs:
+  import:
+    name: Import X OAuth secrets
+    runs-on: ubuntu-latest
+    environment: dev
+    env:
+      CONFIRMATION: ${{ inputs.confirmation }}
+      KEY_VAULT_NAME: nl-dev-omnipost-kv
+
+    steps:
+      - name: Require explicit confirmation and bootstrap values
+        shell: bash
+        env:
+          X_CLIENT_ID_BOOTSTRAP: ${{ secrets.X_CLIENT_ID_BOOTSTRAP }}
+          X_CLIENT_SECRET_BOOTSTRAP: ${{ secrets.X_CLIENT_SECRET_BOOTSTRAP }}
+        run: |
+          set -euo pipefail
+          test "$CONFIRMATION" = "IMPORT"
+          test -n "$X_CLIENT_ID_BOOTSTRAP"
+          test -n "$X_CLIENT_SECRET_BOOTSTRAP"
+
+      - name: Azure login with OIDC
+        uses: azure/login@1384c340ab2dda50fed2bee3041d1d87018aa5e8 # v2
+        with:
+          client-id: 4fc0d52a-718a-49de-a709-a12ad3965d9d
+          tenant-id: 9530cd32-9e33-47f0-9247-ed964730b580
+          subscription-id: bb4e3882-2079-4bab-8974-611bc0b8bb58
+
+      - name: Import into Key Vault without command-line values
+        shell: bash
+        env:
+          X_CLIENT_ID_BOOTSTRAP: ${{ secrets.X_CLIENT_ID_BOOTSTRAP }}
+          X_CLIENT_SECRET_BOOTSTRAP: ${{ secrets.X_CLIENT_SECRET_BOOTSTRAP }}
+        run: |
+          set -euo pipefail
+          umask 077
+          secret_dir="$(mktemp -d)"
+          trap 'rm -rf "$secret_dir"' EXIT
+
+          printf '%s' "$X_CLIENT_ID_BOOTSTRAP" > "$secret_dir/x-client-id"
+          printf '%s' "$X_CLIENT_SECRET_BOOTSTRAP" > "$secret_dir/x-client-secret"
+
+          az keyvault secret set \
+            --vault-name "$KEY_VAULT_NAME" \
+            --name X-CLIENT-ID \
+            --file "$secret_dir/x-client-id" \
+            --encoding utf-8 \
+            --content-type "X OAuth client identifier" \
+            --output none
+
+          az keyvault secret set \
+            --vault-name "$KEY_VAULT_NAME" \
+            --name X-CLIENT-SECRET \
+            --file "$secret_dir/x-client-secret" \
+            --encoding utf-8 \
+            --content-type "X OAuth confidential client secret" \
+            --output none
+
+          unset X_CLIENT_ID_BOOTSTRAP X_CLIENT_SECRET_BOOTSTRAP
+
+          for secret_name in X-CLIENT-ID X-CLIENT-SECRET; do
+            az keyvault secret show \
+              --vault-name "$KEY_VAULT_NAME" \
+              --name "$secret_name" \
+              --query id \
+              --output tsv >/dev/null
+          done
+
+          echo "Imported the two X OAuth secrets into Key Vault."

--- a/docs/AZURE_SECRETS.md
+++ b/docs/AZURE_SECRETS.md
@@ -134,6 +134,12 @@ az webapp config appsettings set \
 # X_CLIENT_SECRET. It also sets the public X_OAUTH_REDIRECT_URI. The workflow
 # discards the Azure CLI settings response so existing app settings are not
 # printed to Actions logs.
+#
+# If direct Key Vault entry is unavailable, temporarily create repository
+# secrets X_CLIENT_ID_BOOTSTRAP and X_CLIENT_SECRET_BOOTSTRAP, run the manual
+# Bootstrap X OAuth Secrets workflow with confirmation IMPORT, verify the run,
+# and delete both repository secrets immediately afterward. The workflow uses
+# OIDC and file-based Azure CLI input so values do not appear in command lines.
 ```
 
 Register the callback URI as an exact match in the X Developer Console. OmniPost


### PR DESCRIPTION
## Summary

- add a manual dev-environment OIDC workflow that copies the two temporary repository secrets into Azure Key Vault
- pass values through permission-restricted temporary files instead of process command arguments
- verify Key Vault writes without printing values or secret URIs
- document immediate deletion of the temporary GitHub copies after import

## Validation

- actionlint .github/workflows/bootstrap-x-oauth-secrets.yml
- repository YAML CLI parse
- git diff --check