### PR TITLE
feat(scheduler): add recurring Azure processor

### DIFF
--- a/__tests__/lib/scheduler-adapters.test.ts
+++ b/__tests__/lib/scheduler-adapters.test.ts
@@ -1,10 +1,9 @@
 import { afterEach, describe, expect, jest, test } from '@jest/globals';
-import { getAdapter } from '../../lib/scheduler/adapters';
+import { getAdapter, TwitterAdapter } from '../../lib/scheduler/adapters';
 import { platformConfigurations, platforms } from '../../lib/config/platforms';
 
 const originalNodeEnv = process.env.NODE_ENV;
 const originalTikTokApiKey = platformConfigurations.tiktok.apiKey;
-const originalTwitterApiKey = platformConfigurations.twitter.apiKey;
 const originalTwitterApiUrl = platformConfigurations.twitter.apiUrl;
 const originalTikTokPrivacyLevel = process.env.TIKTOK_PRIVACY_LEVEL;
 const originalFetch = global.fetch;
@@ -21,7 +20,6 @@ describe('Scheduler platform adapters', () => {
   afterEach(() => {
     setNodeEnv(originalNodeEnv);
     platformConfigurations.tiktok.apiKey = originalTikTokApiKey;
-    platformConfigurations.twitter.apiKey = originalTwitterApiKey;
     platformConfigurations.twitter.apiUrl = originalTwitterApiUrl;
     if (originalTikTokPrivacyLevel === undefined) {
       delete process.env.TIKTOK_PRIVACY_LEVEL;
@@ -81,8 +79,8 @@ describe('Scheduler platform adapters', () => {
 
   test('X publishes through the v2 create-post contract and returns an X URL', async () => {
     setNodeEnv('production');
-    platformConfigurations.twitter.apiKey = 'x-user-access-token';
     platformConfigurations.twitter.apiUrl = 'https://api.x.com/2/tweets';
+    const resolveAccessToken = jest.fn(async () => 'x-user-access-token');
     const fetchMock = jest.fn<typeof fetch>().mockResolvedValue({
       ok: true,
       json: async () => ({
@@ -94,9 +92,12 @@ describe('Scheduler platform adapters', () => {
     } as Response);
     global.fetch = fetchMock;
 
-    const result = await getAdapter('twitter')?.publish({
-      text: 'Controlled live post',
-    });
+    const result = await new TwitterAdapter(resolveAccessToken).publish(
+      {
+        text: 'Controlled live post',
+      },
+      { userId: 'user-1' }
+    );
 
     expect(result).toEqual(
       expect.objectContaining({
@@ -117,6 +118,17 @@ describe('Scheduler platform adapters', () => {
         }),
       })
     );
+    expect(resolveAccessToken).toHaveBeenCalledWith('user-1');
+  });
+
+  test('X fails closed without a tenant owner in production', async () => {
+    setNodeEnv('production');
+    const resolveAccessToken = jest.fn(async () => 'unused-token');
+
+    await expect(
+      new TwitterAdapter(resolveAccessToken).publish({ text: 'Do not publish without an owner' })
+    ).rejects.toThrow('X account owner is required');
+    expect(resolveAccessToken).not.toHaveBeenCalled();
   });
 
   test('TikTok is excluded from the default text-only content flow', () => {

--- a/__tests__/lib/scheduler-cron-auth.test.ts
+++ b/__tests__/lib/scheduler-cron-auth.test.ts
@@ -1,0 +1,46 @@
+import { afterEach, describe, expect, test } from '@jest/globals';
+import { getSchedulerCronSecret } from '../../lib/scheduler/cron-auth';
+
+describe('scheduler cron authentication configuration', () => {
+  const originalCronSecret = process.env.CRON_SECRET;
+  const originalCustomConnectionString = process.env.CUSTOMCONNSTR_CRON_SECRET;
+
+  afterEach(() => {
+    if (originalCronSecret === undefined) delete process.env.CRON_SECRET;
+    else process.env.CRON_SECRET = originalCronSecret;
+
+    if (originalCustomConnectionString === undefined) {
+      delete process.env.CUSTOMCONNSTR_CRON_SECRET;
+    } else {
+      process.env.CUSTOMCONNSTR_CRON_SECRET = originalCustomConnectionString;
+    }
+  });
+
+  test('prefers the standard environment variable', () => {
+    process.env.CRON_SECRET = ' direct-secret ';
+    process.env.CUSTOMCONNSTR_CRON_SECRET = 'connection-string-secret';
+
+    expect(getSchedulerCronSecret()).toBe('direct-secret');
+  });
+
+  test('uses the Azure custom connection string convention', () => {
+    delete process.env.CRON_SECRET;
+    process.env.CUSTOMCONNSTR_CRON_SECRET = ' azure-secret ';
+
+    expect(getSchedulerCronSecret()).toBe('azure-secret');
+  });
+
+  test('falls back when the standard variable is blank', () => {
+    process.env.CRON_SECRET = '   ';
+    process.env.CUSTOMCONNSTR_CRON_SECRET = 'azure-secret';
+
+    expect(getSchedulerCronSecret()).toBe('azure-secret');
+  });
+
+  test('treats blank values as missing', () => {
+    process.env.CRON_SECRET = '   ';
+    process.env.CUSTOMCONNSTR_CRON_SECRET = '   ';
+
+    expect(getSchedulerCronSecret()).toBeUndefined();
+  });
+});

--- a/__tests__/lib/scheduler-publisher.test.ts
+++ b/__tests__/lib/scheduler-publisher.test.ts
@@ -42,6 +42,7 @@ const job: ScheduledJob = {
   maxAttempts: 5,
   createdAt: '2026-07-26T08:00:00.000Z',
   updatedAt: '2026-07-26T08:00:00.000Z',
+  createdBy: 'user-1',
 };
 
 describe('scheduler publisher request boundary', () => {
@@ -80,6 +81,7 @@ describe('scheduler publisher request boundary', () => {
 
     expect(result.success).toBe(true);
     expect(order).toEqual(['attempt', 'provider']);
+    expect(mockProviderPublish).toHaveBeenCalledWith(job.content, { userId: 'user-1' });
   });
 
   test('does not invoke the provider when attempt marking loses the lease', async () => {

--- a/app/api/scheduler/process/route.ts
+++ b/app/api/scheduler/process/route.ts
@@ -7,6 +7,7 @@
 import crypto from 'node:crypto';
 import { NextResponse } from 'next/server';
 import { getScheduler } from '@/lib/scheduler';
+import { getSchedulerCronSecret } from '@/lib/scheduler/cron-auth';
 import { Errors, withErrorHandling } from '@/app/api/_utils/errors';
 import { withRateLimit, RateLimitPresets } from '@/app/api/_utils/rateLimit';
 
@@ -25,7 +26,7 @@ export const POST = withRateLimit(
   withErrorHandling(async (request: Request) => {
     // Verify cron secret - mandatory in production
     const authHeader = request.headers.get('authorization');
-    const cronSecret = process.env.CRON_SECRET;
+    const cronSecret = getSchedulerCronSecret();
 
     // In production, CRON_SECRET must be configured
     if (process.env.NODE_ENV === 'production' && !cronSecret) {

--- a/docs/runbooks/X_CAMPAIGN_GO_LIVE.md
+++ b/docs/runbooks/X_CAMPAIGN_GO_LIVE.md
@@ -22,12 +22,12 @@ the smoke window. Use a dedicated OmniPost brand account, not a personal account
 
 1. Create an X developer project and app.
 2. Enable OAuth 2.0 user authentication.
-3. Because the alpha does not yet have an account-connection flow, configure a
-   callback URL for a trusted OAuth 2.0 PKCE client used by the technical
-   operator to complete this single-account authorization.
-4. Request `tweet.read`, `tweet.write`, and `users.read`. Request
-   `offline.access` only when refresh-token handling is in place.
-5. Authorize the exact X account chosen in step 1.
+3. Configure the exact production callback URL:
+   `https://omnipost.neuralliquid.ai/api/platforms/x/callback`.
+4. Request `tweet.read`, `tweet.write`, `users.read`, and `offline.access` so
+   OmniPost can refresh the user grant without retaining a static token.
+5. Sign in to OmniPost, open **Settings > Platform Connections**, choose
+   **Connect** for X, and authorize the exact account chosen in step 1.
 6. Confirm the X project has enough API credits for the smoke post and
    verification calls.
 
@@ -39,21 +39,16 @@ Reference the official
 and check the current [X API pricing](https://docs.x.com/x-api/getting-started/pricing)
 before the smoke window.
 
-## 3. Store the credential without exposing it
+## 3. Verify the credential boundary
 
-1. Add the token to Azure Key Vault `nl-dev-omnipost-kv` as
-   `TWITTER-ACCESS-TOKEN` using the approved secret-management interface.
-2. Record the new secret version URI without copying the secret value.
-3. Set these App Service settings on `nl-dev-omnipost-web`:
-
-   ```text
-   TWITTER_API_URL=https://api.x.com/2/tweets
-   TWITTER_ACCESS_TOKEN=@Microsoft.KeyVault(SecretUri=https://nl-dev-omnipost-kv.vault.azure.net/secrets/TWITTER-ACCESS-TOKEN/<version>)
-   ```
-
-4. Restart the App Service after the settings resolve.
-5. Verify the Key Vault reference reports `Resolved`. Never print the setting
-   value, token, or full environment.
+1. Confirm the X client ID and client secret App Service references report
+   `Resolved`. Never print a setting value, token, or full environment.
+2. Confirm **Platform Connections** shows the approved handle as `Connected`.
+3. Do not copy the user access or refresh token into Key Vault, shell history,
+   browser storage, or evidence. OmniPost encrypts the per-account grant in the
+   application database and refreshes it server-side.
+4. If the connection shows `Reconnect Required`, complete a staffed reconnect
+   before queueing content. Do not bypass it with a static bearer token.
 
 ## 4. Preflight production
 
@@ -66,13 +61,17 @@ before the smoke window.
    ```
 
 3. Open the dashboard with the production operator account.
-4. Open **Campaigns** and select **OmniPost on X - First Live Campaign**. The
+4. Open **Settings > Platform Connections** and confirm X is `Connected` to the
+   approved handle.
+5. Open **Campaigns** and select **OmniPost on X - First Live Campaign**. The
    seed reconciler adds it on dashboard load without replacing existing
    campaigns.
-5. Confirm the campaign is `draft`, contains three posts, and has only X enabled.
-6. Confirm the first adaptation is at most 280 characters, has no media, URL,
+6. Confirm the campaign is `draft`, contains three posts, and has only X enabled.
+7. Confirm the first adaptation is at most 280 characters, has no media, URL,
    mention, or hashtag, and matches the account owner's approved copy.
-7. Choose a staffed smoke window. Do not queue any other X job for that window.
+8. Confirm `nl-dev-omnipost-scheduler` has a recent successful execution and no
+   unexplained processor failures.
+9. Choose a staffed smoke window. Do not queue any other X job for that window.
 
 ## 5. Queue only the smoke post
 
@@ -103,20 +102,28 @@ published result, and a post URL beginning with `https://x.com/`.
 
 ## 6. Process the due job
 
-The current Azure alpha has no recurring scheduler trigger. From a trusted
-operator environment where `OMNIPOST_CRON_SECRET` is injected without placing
-the value in shell history, invoke the protected processor once:
+The Azure Container Apps Job `nl-dev-omnipost-scheduler` invokes the protected
+processor every two minutes. It has one replica and no platform-level retry;
+the durable scheduler owns leases, classified retries, and unknown-result
+reconciliation.
+
+For a scheduler-only smoke, first prove there are no due jobs and then start one
+execution manually:
 
 ```powershell
-Invoke-RestMethod `
-  -Method Post `
-  -Uri 'https://omnipost.neuralliquid.ai/api/scheduler/process' `
-  -Headers @{ Authorization = "Bearer $env:OMNIPOST_CRON_SECRET" }
+az containerapp job start `
+  --name nl-dev-omnipost-scheduler `
+  --resource-group nl-dev-omnipost-rg
 ```
 
-Require `processed: 1`, `successful: 1`, and `failed: 0`. If `processed` is
-zero, inspect the job and scheduled time before considering a retry. Never call
-the processor repeatedly to compensate for an unknown state.
+Require the Container Apps execution to succeed and the application summary to
+show `processed: 0`, `successful: 0`, and `failed: 0`.
+
+For the staffed X smoke, queue exactly one approved due job and let the next
+scheduled execution process it. Require `processed: 1`, `successful: 1`, and
+`failed: 0`. If `processed` is zero, inspect the job and scheduled time before
+considering any manual start. Never invoke the processor repeatedly to
+compensate for an unknown state.
 
 ## 7. Verify before expanding
 
@@ -140,18 +147,18 @@ Stop immediately on a 401/403, wrong-account post, duplicate, altered copy,
 unresolved Key Vault reference, or missing audit evidence.
 
 1. Pause the campaign and cancel pending X jobs through the scheduler API.
-2. Remove `TWITTER_ACCESS_TOKEN` from the App Service settings to restore the
-   scheduler's fail-closed behavior.
-3. Revoke or rotate the affected X token when authorization is in doubt.
+2. Disconnect X in **Settings > Platform Connections** to revoke the provider
+   grant and remove the stored credentials.
+3. Reconnect only after the account owner confirms the intended account and
+   scopes.
 4. Delete an incorrect public post only with the account owner's approval.
 5. Record the failure status and evidence in Baton before retrying.
 
 ## Known starter limitation
 
-This first path accepts a provisioned user-context access token but does not yet
-refresh OAuth tokens. Campaign data is local to the browser, the campaign screen
-does not create jobs, the server queue is memory-backed, and Azure has no
-recurring scheduler trigger. Treat an app restart, token expiry, or unknown job
-state as a stop condition. A production-grade multi-account flow must add
-encrypted per-account token storage, refresh handling, a persistent queue,
-recurring processing, revocation, and reconnect UX before broad rollout.
+The production path has encrypted per-account OAuth storage, refresh and
+revocation handling, a persistent leased queue, rate-limit coordination, and a
+recurring Azure processor. The first authentic X connect/publish/revoke proof is
+still operator- and credential-gated. Treat a wrong account, provider outcome
+requiring reconciliation, or missing audit evidence as a stop condition; do not
+expand to unattended multi-account publishing until that evidence passes.

--- a/infra/terraform/env/dev/README.md
+++ b/infra/terraform/env/dev/README.md
@@ -24,8 +24,14 @@ DNS records for `omnipost.neuralliquid.ai` are owned by
 - `nl-dev-omnipost-kv`
 - `nl-dev-omnipost-cae`
 - `nl-dev-omnipost-sluice`
+- `nl-dev-omnipost-scheduler` recurring Container Apps Job
 - `nl-dev-omnipost-psql-swc` in `swedencentral`
 - PostgreSQL database `omnipost`
+
+The scheduler job runs once every two minutes with no platform-level retry. It reads a
+versionless processor secret through managed identity and invokes the protected
+OmniPost processor. Durable leases and reconciliation state remain the authority
+for retries and unknown provider outcomes.
 
 The existing App Service managed certificate remains live in Azure but is not
 managed by this first Terraform pass because importing it as

--- a/infra/terraform/env/dev/main.tf
+++ b/infra/terraform/env/dev/main.tf
@@ -148,6 +148,13 @@ resource "azurerm_linux_web_app" "web" {
           type  = "Custom"
           value = "@Microsoft.KeyVault(SecretUri=${azurerm_key_vault_secret.platform_token_encryption_key[0].versionless_id})"
         }
+      } : {},
+      var.enable_scheduler_processor && var.enable_key_vault ? {
+        scheduler_cron = {
+          name  = "CRON_SECRET"
+          type  = "Custom"
+          value = "@Microsoft.KeyVault(SecretUri=${azurerm_key_vault_secret.scheduler_cron[0].versionless_id})"
+        }
       } : {}
     )
     content {
@@ -335,13 +342,93 @@ resource "azurerm_role_assignment" "operator_key_vault_secrets_officer" {
 }
 
 resource "azurerm_container_app_environment" "sluice" {
-  count = var.enable_sluice_gateway ? 1 : 0
+  count = var.enable_sluice_gateway || var.enable_scheduler_processor ? 1 : 0
 
   name                       = "${local.base}-cae"
   resource_group_name        = azurerm_resource_group.this.name
   location                   = azurerm_resource_group.this.location
   log_analytics_workspace_id = azurerm_log_analytics_workspace.this.id
   tags                       = merge(local.tags, { managedBy = "terraform", component = "sluice-gateway" })
+}
+
+resource "random_password" "scheduler_cron" {
+  count = var.enable_scheduler_processor && var.enable_key_vault ? 1 : 0
+
+  length           = 48
+  special          = true
+  override_special = "_%@"
+}
+
+resource "azurerm_key_vault_secret" "scheduler_cron" {
+  count = var.enable_scheduler_processor && var.enable_key_vault ? 1 : 0
+
+  name             = "omnipost-scheduler-cron-secret"
+  value_wo         = random_password.scheduler_cron[0].result
+  value_wo_version = 1
+  key_vault_id     = azurerm_key_vault.this[0].id
+  content_type     = "Bearer secret for the recurring scheduler processor"
+  tags             = merge(local.tags, { managedBy = "terraform", component = "scheduler" })
+
+  depends_on = [
+    azurerm_role_assignment.deployment_key_vault_secrets_officer,
+    azurerm_role_assignment.operator_key_vault_secrets_officer,
+    azurerm_role_assignment.web_identity_key_vault_secrets_officer,
+  ]
+}
+
+resource "azurerm_container_app_job" "scheduler" {
+  count = var.enable_scheduler_processor ? 1 : 0
+
+  name                         = "${local.base}-scheduler"
+  location                     = azurerm_resource_group.this.location
+  resource_group_name          = azurerm_resource_group.this.name
+  container_app_environment_id = azurerm_container_app_environment.sluice[0].id
+  replica_timeout_in_seconds   = 60
+  replica_retry_limit          = 0
+  tags                         = merge(local.tags, { managedBy = "terraform", component = "scheduler" })
+
+  identity {
+    type         = "UserAssigned"
+    identity_ids = [azurerm_user_assigned_identity.web_key_vault.id]
+  }
+
+  secret {
+    name                = "cron-secret"
+    identity            = azurerm_user_assigned_identity.web_key_vault.id
+    key_vault_secret_id = azurerm_key_vault_secret.scheduler_cron[0].versionless_id
+  }
+
+  schedule_trigger_config {
+    cron_expression          = "*/2 * * * *"
+    parallelism              = 1
+    replica_completion_count = 1
+  }
+
+  template {
+    container {
+      name   = "processor"
+      image  = "curlimages/curl:8.16.0@sha256:463eaf6072688fe96ac64fa623fe73e1dbe25d8ad6c34404a669ad3ce1f104b6"
+      cpu    = 0.25
+      memory = "0.5Gi"
+
+      command = ["/bin/sh", "-c"]
+      args = [
+        "curl --fail --silent --show-error --max-time 50 --output /dev/null --request POST --header \"Authorization: Bearer $CRON_SECRET\" --header \"User-Agent: omnipost-azure-scheduler/1.0\" \"$PROCESSOR_URL\""
+      ]
+
+      env {
+        name  = "PROCESSOR_URL"
+        value = "https://${var.custom_hostname}/api/scheduler/process"
+      }
+
+      env {
+        name        = "CRON_SECRET"
+        secret_name = "cron-secret"
+      }
+    }
+  }
+
+  depends_on = [azurerm_role_assignment.web_identity_key_vault_secrets_officer]
 }
 
 resource "azurerm_container_app" "sluice" {

--- a/infra/terraform/env/dev/main.tf
+++ b/infra/terraform/env/dev/main.tf
@@ -342,7 +342,7 @@ resource "azurerm_role_assignment" "operator_key_vault_secrets_officer" {
 }
 
 resource "azurerm_container_app_environment" "sluice" {
-  count = var.enable_sluice_gateway || var.enable_scheduler_processor ? 1 : 0
+  count = var.enable_sluice_gateway || (var.enable_scheduler_processor && var.enable_key_vault) ? 1 : 0
 
   name                       = "${local.base}-cae"
   resource_group_name        = azurerm_resource_group.this.name
@@ -377,7 +377,7 @@ resource "azurerm_key_vault_secret" "scheduler_cron" {
 }
 
 resource "azurerm_container_app_job" "scheduler" {
-  count = var.enable_scheduler_processor ? 1 : 0
+  count = var.enable_scheduler_processor && var.enable_key_vault ? 1 : 0
 
   name                         = "${local.base}-scheduler"
   location                     = azurerm_resource_group.this.location

--- a/infra/terraform/env/dev/outputs.tf
+++ b/infra/terraform/env/dev/outputs.tf
@@ -27,6 +27,10 @@ output "sluice_gateway_url" {
   value = var.enable_sluice_gateway ? "https://${azurerm_container_app.sluice[0].ingress[0].fqdn}" : null
 }
 
+output "scheduler_job_name" {
+  value = var.enable_scheduler_processor ? azurerm_container_app_job.scheduler[0].name : null
+}
+
 output "postgresql_server_name" {
   value = var.enable_postgresql ? azurerm_postgresql_flexible_server.this[0].name : null
 }

--- a/infra/terraform/env/dev/outputs.tf
+++ b/infra/terraform/env/dev/outputs.tf
@@ -28,7 +28,7 @@ output "sluice_gateway_url" {
 }
 
 output "scheduler_job_name" {
-  value = var.enable_scheduler_processor ? azurerm_container_app_job.scheduler[0].name : null
+  value = var.enable_scheduler_processor && var.enable_key_vault ? azurerm_container_app_job.scheduler[0].name : null
 }
 
 output "postgresql_server_name" {

--- a/infra/terraform/env/dev/variables.tf
+++ b/infra/terraform/env/dev/variables.tf
@@ -34,6 +34,12 @@ variable "enable_sluice_gateway" {
   default     = true
 }
 
+variable "enable_scheduler_processor" {
+  type        = bool
+  description = "Whether to run the durable scheduler processor every two minutes as a Container Apps Job."
+  default     = true
+}
+
 variable "sluice_image" {
   type        = string
   description = "Container image for the Sluice gateway."

--- a/lib/config/platforms.ts
+++ b/lib/config/platforms.ts
@@ -81,8 +81,8 @@ export const platformConfigurations: Record<string, PlatformConfig> = {
   },
   twitter: {
     apiUrl: process.env.TWITTER_API_URL || 'https://api.x.com/2/tweets',
-    apiKey: process.env.TWITTER_ACCESS_TOKEN || '',
-    required: true,
+    apiKey: '',
+    required: false,
     capabilities: ['text', 'image', 'video'],
   },
   tiktok: {

--- a/lib/scheduler/adapters.ts
+++ b/lib/scheduler/adapters.ts
@@ -3,8 +3,15 @@
  * Platform-specific implementations for content publishing
  */
 
-import { PlatformAdapter, PlatformPublishResult, ValidationResult, ScheduledJob } from './types';
+import {
+  PlatformAdapter,
+  PlatformPublishContext,
+  PlatformPublishResult,
+  ValidationResult,
+  ScheduledJob,
+} from './types';
 import { getPlatformConfig } from '@/lib/config/platforms';
+import { getValidXAccessToken } from '@/lib/platforms/x/repository';
 import { generatePlatformPostId } from '@/lib/utils/id';
 
 /**
@@ -155,18 +162,30 @@ abstract class BasePlatformAdapter implements PlatformAdapter {
 export class TwitterAdapter extends BasePlatformAdapter {
   platformId = 'twitter';
 
+  constructor(
+    private readonly resolveAccessToken: typeof getValidXAccessToken = getValidXAccessToken
+  ) {
+    super();
+  }
+
   getMaxLength(): number {
     return 280;
   }
 
-  async publish(content: ScheduledJob['content']): Promise<PlatformPublishResult> {
+  async publish(
+    content: ScheduledJob['content'],
+    context?: PlatformPublishContext
+  ): Promise<PlatformPublishResult> {
     const config = getPlatformConfig('twitter');
 
-    // In production, use the X API with an OAuth user-context access token.
-    if (config?.apiKey && process.env.NODE_ENV === 'production') {
-      return this.publishToTwitter(content, config);
+    if (process.env.NODE_ENV === 'production') {
+      if (!context?.userId) throw new Error('X account owner is required');
+      const accessToken = await this.resolveAccessToken(context.userId);
+      return this.publishToTwitter(content, {
+        apiUrl: config?.apiUrl ?? 'https://api.x.com/2/tweets',
+        apiKey: accessToken,
+      });
     }
-    this.assertProductionCredentials(config);
 
     // Development: simulate
     return this.simulatePublish(content, 'Twitter');

--- a/lib/scheduler/cron-auth.ts
+++ b/lib/scheduler/cron-auth.ts
@@ -1,0 +1,9 @@
+/**
+ * Resolve the scheduler processor secret across local and Azure App Service
+ * configuration conventions.
+ */
+export function getSchedulerCronSecret(): string | undefined {
+  return (
+    process.env.CRON_SECRET?.trim() || process.env.CUSTOMCONNSTR_CRON_SECRET?.trim() || undefined
+  );
+}

--- a/lib/scheduler/index.ts
+++ b/lib/scheduler/index.ts
@@ -16,6 +16,7 @@ export type {
   JobQueue,
   ClaimedJobUpdate,
   PlatformAdapter,
+  PlatformPublishContext,
   PlatformPublishResult,
   ValidationResult,
   SchedulerStats,

--- a/lib/scheduler/publisher.ts
+++ b/lib/scheduler/publisher.ts
@@ -134,7 +134,7 @@ export class Publisher {
         };
       }
       // Publish
-      const result = await adapter.publish(job.content);
+      const result = await adapter.publish(job.content, { userId: job.createdBy });
 
       return {
         success: true,

--- a/lib/scheduler/types.ts
+++ b/lib/scheduler/types.ts
@@ -240,9 +240,16 @@ export interface JobQueue {
  */
 export interface PlatformAdapter {
   platformId: string;
-  publish(content: ScheduledJob['content']): Promise<PlatformPublishResult>;
+  publish(
+    content: ScheduledJob['content'],
+    context?: PlatformPublishContext
+  ): Promise<PlatformPublishResult>;
   validateContent(content: ScheduledJob['content']): ValidationResult;
   getMaxLength(): number;
+}
+
+export interface PlatformPublishContext {
+  userId?: string;
 }
 
 /**


### PR DESCRIPTION
## Summary
- add a two-minute Azure Container Apps Job with a pinned curl image, one replica, and zero platform-level retries
- generate one processor secret in Terraform, expose it through versionless Key Vault references to both the job and App Service, and support Azure custom connection-string environment naming
- route X publishes through each job owner's encrypted OAuth grant instead of the legacy static token setting
- update the X go-live runbook for the deployed OAuth lifecycle and controlled scheduler smoke

## Safety
- the processor remains fail-closed until Terraform creates and resolves the shared secret
- the job cadence stays below the existing 50/hour admin limiter
- post-merge activation requires the explicit Terraform Dev apply workflow
- no X credentials or production posts are included

## Validation
- 300 tests passed (41 suites; 2 suites skipped by existing environment gates)
- focused scheduler/OAuth boundary tests passed
- strict TypeScript check passed with incremental output disabled locally
- ESLint: 0 errors (existing warnings remain)
- targeted Prettier checks passed
- Terraform fmt and validate passed
- post-merge App Service telemetry showed no scheduler requests after the #182 deployment