### PR TITLE
fix(scheduler): harden Azure cron authentication

### DIFF
--- a/.github/workflows/terraform-dev.yml
+++ b/.github/workflows/terraform-dev.yml
@@ -62,3 +62,15 @@ jobs:
       - name: Terraform Apply
         if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.action == 'apply' }}
         run: terraform -chdir=infra/terraform/env/dev apply -auto-approve tfplan
+
+      - name: Configure scheduler Key Vault reference
+        if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.action == 'apply' }}
+        run: |
+          az webapp config appsettings set \
+            --resource-group nl-dev-omnipost-rg \
+            --name nl-dev-omnipost-web \
+            --settings 'CRON_SECRET=@Microsoft.KeyVault(SecretUri=https://nl-dev-omnipost-kv.vault.azure.net/secrets/omnipost-scheduler-cron-secret)' \
+            --output none
+          az webapp restart \
+            --resource-group nl-dev-omnipost-rg \
+            --name nl-dev-omnipost-web

--- a/__tests__/lib/scheduler-cron-auth.test.ts
+++ b/__tests__/lib/scheduler-cron-auth.test.ts
@@ -1,5 +1,8 @@
 import { afterEach, describe, expect, test } from '@jest/globals';
-import { getSchedulerCronSecret } from '../../lib/scheduler/cron-auth';
+import {
+  getSchedulerCronSecret,
+  isSchedulerCronRequestAuthorized,
+} from '../../lib/scheduler/cron-auth';
 
 describe('scheduler cron authentication configuration', () => {
   const originalCronSecret = process.env.CRON_SECRET;
@@ -42,5 +45,33 @@ describe('scheduler cron authentication configuration', () => {
     process.env.CUSTOMCONNSTR_CRON_SECRET = '   ';
 
     expect(getSchedulerCronSecret()).toBeUndefined();
+  });
+});
+
+describe('scheduler cron request authentication', () => {
+  it('accepts the dedicated scheduler header', () => {
+    const request = new Request('https://example.test', {
+      headers: { 'X-OmniPost-Cron-Secret': 'scheduler-secret' },
+    });
+
+    expect(isSchedulerCronRequestAuthorized(request, 'scheduler-secret')).toBe(true);
+  });
+
+  it('retains Bearer compatibility', () => {
+    const request = new Request('https://example.test', {
+      headers: { Authorization: 'Bearer scheduler-secret' },
+    });
+
+    expect(isSchedulerCronRequestAuthorized(request, 'scheduler-secret')).toBe(true);
+  });
+
+  it.each([
+    ['missing headers', {}],
+    ['malformed Bearer header', { Authorization: 'scheduler-secret' }],
+    ['wrong dedicated secret', { 'X-OmniPost-Cron-Secret': 'wrong-secret' }],
+  ])('rejects %s', (_label, headers) => {
+    const request = new Request('https://example.test', { headers });
+
+    expect(isSchedulerCronRequestAuthorized(request, 'scheduler-secret')).toBe(false);
   });
 });

--- a/app/api/scheduler/process/route.ts
+++ b/app/api/scheduler/process/route.ts
@@ -4,10 +4,12 @@
  * GET - Health check for the process endpoint
  */
 
-import crypto from 'node:crypto';
 import { NextResponse } from 'next/server';
 import { getScheduler } from '@/lib/scheduler';
-import { getSchedulerCronSecret } from '@/lib/scheduler/cron-auth';
+import {
+  getSchedulerCronSecret,
+  isSchedulerCronRequestAuthorized,
+} from '@/lib/scheduler/cron-auth';
 import { Errors, withErrorHandling } from '@/app/api/_utils/errors';
 import { withRateLimit, RateLimitPresets } from '@/app/api/_utils/rateLimit';
 
@@ -25,7 +27,6 @@ import { withRateLimit, RateLimitPresets } from '@/app/api/_utils/rateLimit';
 export const POST = withRateLimit(
   withErrorHandling(async (request: Request) => {
     // Verify cron secret - mandatory in production
-    const authHeader = request.headers.get('authorization');
     const cronSecret = getSchedulerCronSecret();
 
     // In production, CRON_SECRET must be configured
@@ -36,12 +37,7 @@ export const POST = withRateLimit(
 
     // Validate authorization with constant-time comparison
     if (cronSecret) {
-      const expected = `Bearer ${cronSecret}`;
-      const actual = authHeader || '';
-      if (
-        expected.length !== actual.length ||
-        !crypto.timingSafeEqual(Buffer.from(expected), Buffer.from(actual.padEnd(expected.length)))
-      ) {
+      if (!isSchedulerCronRequestAuthorized(request, cronSecret)) {
         return Errors.unauthorized('Unauthorized');
       }
     }

--- a/infra/terraform/env/dev/main.tf
+++ b/infra/terraform/env/dev/main.tf
@@ -148,13 +148,6 @@ resource "azurerm_linux_web_app" "web" {
           type  = "Custom"
           value = "@Microsoft.KeyVault(SecretUri=${azurerm_key_vault_secret.platform_token_encryption_key[0].versionless_id})"
         }
-      } : {},
-      var.enable_scheduler_processor && var.enable_key_vault ? {
-        scheduler_cron = {
-          name  = "CRON_SECRET"
-          type  = "Custom"
-          value = "@Microsoft.KeyVault(SecretUri=${azurerm_key_vault_secret.scheduler_cron[0].versionless_id})"
-        }
       } : {}
     )
     content {
@@ -413,7 +406,7 @@ resource "azurerm_container_app_job" "scheduler" {
 
       command = ["/bin/sh", "-c"]
       args = [
-        "curl --fail --silent --show-error --max-time 50 --output /dev/null --request POST --header \"Authorization: Bearer $CRON_SECRET\" --header \"User-Agent: omnipost-azure-scheduler/1.0\" \"$PROCESSOR_URL\""
+        "curl --fail --silent --show-error --max-time 50 --output /dev/null --request POST --header \"X-OmniPost-Cron-Secret: $CRON_SECRET\" --header \"User-Agent: omnipost-azure-scheduler/1.0\" \"$PROCESSOR_URL\""
       ]
 
       env {

--- a/lib/scheduler/cron-auth.ts
+++ b/lib/scheduler/cron-auth.ts
@@ -1,3 +1,5 @@
+import crypto from 'node:crypto';
+
 /**
  * Resolve the scheduler processor secret across local and Azure App Service
  * configuration conventions.
@@ -5,5 +7,24 @@
 export function getSchedulerCronSecret(): string | undefined {
   return (
     process.env.CRON_SECRET?.trim() || process.env.CUSTOMCONNSTR_CRON_SECRET?.trim() || undefined
+  );
+}
+
+/**
+ * Authenticate scheduler requests through a dedicated header, while retaining
+ * Bearer compatibility for existing callers.
+ */
+export function isSchedulerCronRequestAuthorized(request: Request, cronSecret: string): boolean {
+  const directSecret = request.headers.get('x-omnipost-cron-secret');
+  const authorization = request.headers.get('authorization');
+  const candidate =
+    directSecret ?? (authorization?.startsWith('Bearer ') ? authorization.slice(7) : '');
+
+  const expectedBuffer = Buffer.from(cronSecret);
+  const candidateBuffer = Buffer.from(candidate);
+
+  return (
+    expectedBuffer.length === candidateBuffer.length &&
+    crypto.timingSafeEqual(expectedBuffer, candidateBuffer)
   );
 }


### PR DESCRIPTION
## Summary
- send the recurring processor secret through a dedicated scheduler header while retaining Bearer compatibility
- keep constant-time comparison at the application boundary
- configure the canonical Key Vault-backed CRON_SECRET app setting and recycle App Service after Terraform apply
- remove the redundant scheduler connection string

## Production evidence
- PR #185 and Terraform apply succeeded
- recurring executions reach the processor but return HTTP 401 through Authorization
- Key Vault, App Service runtime, and Container Apps all use the same versionless secret reference
- App Service runtime secret presence/length/equality was checked without exposing values, hashes, or publishing credentials

## Validation
- scheduler auth tests: 9/9 passed
- TypeScript: passed
- Terraform fmt/validate: passed
- targeted Prettier: passed