### PR TITLE
chore(scheduler): add safe auth diagnostics

### DIFF
--- a/__tests__/lib/scheduler-cron-auth.test.ts
+++ b/__tests__/lib/scheduler-cron-auth.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, test } from '@jest/globals';
 import {
+  getSchedulerCronAuthDiagnostics,
   getSchedulerCronSecret,
   isSchedulerCronRequestAuthorized,
 } from '../../lib/scheduler/cron-auth';
@@ -73,5 +74,19 @@ describe('scheduler cron request authentication', () => {
     const request = new Request('https://example.test', { headers });
 
     expect(isSchedulerCronRequestAuthorized(request, 'scheduler-secret')).toBe(false);
+  });
+
+  it('reports only presence and byte lengths for rejected requests', () => {
+    const request = new Request('https://example.test', {
+      headers: { 'X-OmniPost-Cron-Secret': 'wrong-secret' },
+    });
+
+    expect(getSchedulerCronAuthDiagnostics(request, 'scheduler-secret')).toEqual({
+      expectedBytes: 16,
+      directHeaderPresent: true,
+      directHeaderBytes: 12,
+      authorizationHeaderPresent: false,
+      authorizationHeaderBytes: 0,
+    });
   });
 });

--- a/app/api/scheduler/process/route.ts
+++ b/app/api/scheduler/process/route.ts
@@ -7,6 +7,7 @@
 import { NextResponse } from 'next/server';
 import { getScheduler } from '@/lib/scheduler';
 import {
+  getSchedulerCronAuthDiagnostics,
   getSchedulerCronSecret,
   isSchedulerCronRequestAuthorized,
 } from '@/lib/scheduler/cron-auth';
@@ -38,6 +39,10 @@ export const POST = withRateLimit(
     // Validate authorization with constant-time comparison
     if (cronSecret) {
       if (!isSchedulerCronRequestAuthorized(request, cronSecret)) {
+        console.warn(
+          '[Scheduler] Cron authentication rejected:',
+          getSchedulerCronAuthDiagnostics(request, cronSecret)
+        );
         return Errors.unauthorized('Unauthorized');
       }
     }

--- a/lib/scheduler/cron-auth.ts
+++ b/lib/scheduler/cron-auth.ts
@@ -28,3 +28,16 @@ export function isSchedulerCronRequestAuthorized(request: Request, cronSecret: s
     crypto.timingSafeEqual(expectedBuffer, candidateBuffer)
   );
 }
+
+export function getSchedulerCronAuthDiagnostics(request: Request, cronSecret: string) {
+  const directSecret = request.headers.get('x-omnipost-cron-secret');
+  const authorization = request.headers.get('authorization');
+
+  return {
+    expectedBytes: Buffer.byteLength(cronSecret),
+    directHeaderPresent: directSecret !== null,
+    directHeaderBytes: Buffer.byteLength(directSecret ?? ''),
+    authorizationHeaderPresent: authorization !== null,
+    authorizationHeaderBytes: Buffer.byteLength(authorization ?? ''),
+  };
+}


### PR DESCRIPTION
## Summary
- log only scheduler auth header presence and byte lengths on rejection
- never log secret values or hashes
- add focused diagnostics coverage

## Why
The deployed job secret and App Service configuration both match the single Key Vault version, but protected requests still return 401. This telemetry distinguishes a missing/altered header from a live-worker secret mismatch.

## Validation
- scheduler auth tests: 10/10 passed
- TypeScript: passed
- targeted Prettier: passed