### PR TITLE
fix(scheduler): resolve cron secret with managed identity

### DIFF
--- a/.github/workflows/terraform-dev.yml
+++ b/.github/workflows/terraform-dev.yml
@@ -69,7 +69,9 @@ jobs:
           az webapp config appsettings set \
             --resource-group nl-dev-omnipost-rg \
             --name nl-dev-omnipost-web \
-            --settings 'CRON_SECRET=@Microsoft.KeyVault(SecretUri=https://nl-dev-omnipost-kv.vault.azure.net/secrets/omnipost-scheduler-cron-secret)' \
+            --settings \
+              'CRON_SECRET=@Microsoft.KeyVault(SecretUri=https://nl-dev-omnipost-kv.vault.azure.net/secrets/omnipost-scheduler-cron-secret)' \
+              'SCHEDULER_CRON_SECRET_URI=https://nl-dev-omnipost-kv.vault.azure.net/secrets/omnipost-scheduler-cron-secret' \
             --output none
           az webapp restart \
             --resource-group nl-dev-omnipost-rg \

--- a/__tests__/lib/scheduler-cron-auth.test.ts
+++ b/__tests__/lib/scheduler-cron-auth.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, jest, test } from '@jest/globals';
 import {
   getSchedulerCronAuthDiagnostics,
   getSchedulerCronSecret,
+  hasSchedulerCronCredential,
   isSchedulerCronRequestAuthorized,
 } from '../../lib/scheduler/cron-auth';
 
@@ -86,6 +87,8 @@ describe('scheduler cron authentication configuration', () => {
     global.fetch = fetchMock;
 
     await expect(getSchedulerCronSecret()).resolves.toBe('current-key-vault-secret');
+    await expect(getSchedulerCronSecret()).resolves.toBe('current-key-vault-secret');
+    expect(fetchMock).toHaveBeenCalledTimes(2);
     expect(fetchMock).toHaveBeenNthCalledWith(
       1,
       expect.objectContaining({
@@ -109,6 +112,24 @@ describe('scheduler cron authentication configuration', () => {
 });
 
 describe('scheduler cron request authentication', () => {
+  it.each([
+    ['missing headers', {}],
+    ['blank dedicated header', { 'X-OmniPost-Cron-Secret': ' ' }],
+    ['malformed Bearer header', { Authorization: 'scheduler-secret' }],
+  ])('rejects unsupported credential shape: %s', (_label, headers) => {
+    const request = new Request('https://example.test', { headers });
+
+    expect(hasSchedulerCronCredential(request)).toBe(false);
+  });
+
+  it('admits supported credential shapes for constant-time validation', () => {
+    const request = new Request('https://example.test', {
+      headers: { 'X-OmniPost-Cron-Secret': 'candidate-secret' },
+    });
+
+    expect(hasSchedulerCronCredential(request)).toBe(true);
+  });
+
   it('accepts the dedicated scheduler header', () => {
     const request = new Request('https://example.test', {
       headers: { 'X-OmniPost-Cron-Secret': 'scheduler-secret' },

--- a/__tests__/lib/scheduler-cron-auth.test.ts
+++ b/__tests__/lib/scheduler-cron-auth.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, test } from '@jest/globals';
+import { afterEach, describe, expect, jest, test } from '@jest/globals';
 import {
   getSchedulerCronAuthDiagnostics,
   getSchedulerCronSecret,
@@ -8,8 +8,14 @@ import {
 describe('scheduler cron authentication configuration', () => {
   const originalCronSecret = process.env.CRON_SECRET;
   const originalCustomConnectionString = process.env.CUSTOMCONNSTR_CRON_SECRET;
+  const originalIdentityEndpoint = process.env.IDENTITY_ENDPOINT;
+  const originalIdentityHeader = process.env.IDENTITY_HEADER;
+  const originalSecretUri = process.env.SCHEDULER_CRON_SECRET_URI;
+  const originalFetch = global.fetch;
 
   afterEach(() => {
+    jest.restoreAllMocks();
+
     if (originalCronSecret === undefined) delete process.env.CRON_SECRET;
     else process.env.CRON_SECRET = originalCronSecret;
 
@@ -18,34 +24,87 @@ describe('scheduler cron authentication configuration', () => {
     } else {
       process.env.CUSTOMCONNSTR_CRON_SECRET = originalCustomConnectionString;
     }
+
+    if (originalIdentityEndpoint === undefined) delete process.env.IDENTITY_ENDPOINT;
+    else process.env.IDENTITY_ENDPOINT = originalIdentityEndpoint;
+
+    if (originalIdentityHeader === undefined) delete process.env.IDENTITY_HEADER;
+    else process.env.IDENTITY_HEADER = originalIdentityHeader;
+
+    if (originalSecretUri === undefined) delete process.env.SCHEDULER_CRON_SECRET_URI;
+    else process.env.SCHEDULER_CRON_SECRET_URI = originalSecretUri;
+
+    if (originalFetch === undefined) delete (global as { fetch?: typeof fetch }).fetch;
+    else global.fetch = originalFetch;
   });
 
-  test('prefers the standard environment variable', () => {
+  test('prefers the standard environment variable', async () => {
     process.env.CRON_SECRET = ' direct-secret ';
     process.env.CUSTOMCONNSTR_CRON_SECRET = 'connection-string-secret';
 
-    expect(getSchedulerCronSecret()).toBe('direct-secret');
+    await expect(getSchedulerCronSecret()).resolves.toBe('direct-secret');
   });
 
-  test('uses the Azure custom connection string convention', () => {
+  test('uses the Azure custom connection string convention', async () => {
     delete process.env.CRON_SECRET;
     process.env.CUSTOMCONNSTR_CRON_SECRET = ' azure-secret ';
 
-    expect(getSchedulerCronSecret()).toBe('azure-secret');
+    await expect(getSchedulerCronSecret()).resolves.toBe('azure-secret');
   });
 
-  test('falls back when the standard variable is blank', () => {
+  test('falls back when the standard variable is blank', async () => {
     process.env.CRON_SECRET = '   ';
     process.env.CUSTOMCONNSTR_CRON_SECRET = 'azure-secret';
 
-    expect(getSchedulerCronSecret()).toBe('azure-secret');
+    await expect(getSchedulerCronSecret()).resolves.toBe('azure-secret');
   });
 
-  test('treats blank values as missing', () => {
+  test('treats blank values as missing', async () => {
     process.env.CRON_SECRET = '   ';
     process.env.CUSTOMCONNSTR_CRON_SECRET = '   ';
 
-    expect(getSchedulerCronSecret()).toBeUndefined();
+    await expect(getSchedulerCronSecret()).resolves.toBeUndefined();
+  });
+
+  test('uses managed identity to resolve the current Key Vault value', async () => {
+    process.env.CRON_SECRET = 'stale-environment-secret';
+    process.env.IDENTITY_ENDPOINT = 'http://127.0.0.1:41741/msi/token';
+    process.env.IDENTITY_HEADER = 'identity-header';
+    process.env.SCHEDULER_CRON_SECRET_URI =
+      'https://example.vault.azure.net/secrets/scheduler-secret';
+
+    const fetchMock = jest
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ access_token: 'managed-identity-token' }),
+      } as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ value: ' current-key-vault-secret ' }),
+      } as Response);
+    global.fetch = fetchMock;
+
+    await expect(getSchedulerCronSecret()).resolves.toBe('current-key-vault-secret');
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        hostname: '127.0.0.1',
+        searchParams: expect.any(URLSearchParams),
+      }),
+      {
+        headers: { 'X-IDENTITY-HEADER': 'identity-header' },
+        signal: expect.any(AbortSignal),
+      }
+    );
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ hostname: 'example.vault.azure.net' }),
+      {
+        headers: { Authorization: 'Bearer managed-identity-token' },
+        signal: expect.any(AbortSignal),
+      }
+    );
   });
 });
 

--- a/app/api/scheduler/process/route.ts
+++ b/app/api/scheduler/process/route.ts
@@ -28,7 +28,7 @@ import { withRateLimit, RateLimitPresets } from '@/app/api/_utils/rateLimit';
 export const POST = withRateLimit(
   withErrorHandling(async (request: Request) => {
     // Verify cron secret - mandatory in production
-    const cronSecret = getSchedulerCronSecret();
+    const cronSecret = await getSchedulerCronSecret();
 
     // In production, CRON_SECRET must be configured
     if (process.env.NODE_ENV === 'production' && !cronSecret) {

--- a/app/api/scheduler/process/route.ts
+++ b/app/api/scheduler/process/route.ts
@@ -9,6 +9,7 @@ import { getScheduler } from '@/lib/scheduler';
 import {
   getSchedulerCronAuthDiagnostics,
   getSchedulerCronSecret,
+  hasSchedulerCronCredential,
   isSchedulerCronRequestAuthorized,
 } from '@/lib/scheduler/cron-auth';
 import { Errors, withErrorHandling } from '@/app/api/_utils/errors';
@@ -28,6 +29,10 @@ import { withRateLimit, RateLimitPresets } from '@/app/api/_utils/rateLimit';
 export const POST = withRateLimit(
   withErrorHandling(async (request: Request) => {
     // Verify cron secret - mandatory in production
+    if (!hasSchedulerCronCredential(request)) {
+      return Errors.unauthorized('Unauthorized');
+    }
+
     const cronSecret = await getSchedulerCronSecret();
 
     // In production, CRON_SECRET must be configured

--- a/lib/scheduler/cron-auth.ts
+++ b/lib/scheduler/cron-auth.ts
@@ -1,13 +1,69 @@
 import crypto from 'node:crypto';
 
-/**
- * Resolve the scheduler processor secret across local and Azure App Service
- * configuration conventions.
- */
-export function getSchedulerCronSecret(): string | undefined {
+const KEY_VAULT_RESOURCE = 'https://vault.azure.net';
+const MANAGED_IDENTITY_API_VERSION = '2019-08-01';
+const KEY_VAULT_API_VERSION = '7.4';
+const SECRET_LOOKUP_TIMEOUT_MS = 5_000;
+
+async function fetchWithTimeout(input: URL, init: RequestInit): Promise<Response> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), SECRET_LOOKUP_TIMEOUT_MS);
+
+  try {
+    return await fetch(input, { ...init, signal: controller.signal });
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+function getEnvironmentCronSecret(): string | undefined {
   return (
     process.env.CRON_SECRET?.trim() || process.env.CUSTOMCONNSTR_CRON_SECRET?.trim() || undefined
   );
+}
+
+async function getManagedIdentityCronSecret(): Promise<string | undefined> {
+  const identityEndpoint = process.env.IDENTITY_ENDPOINT?.trim();
+  const identityHeader = process.env.IDENTITY_HEADER?.trim();
+  const secretUri = process.env.SCHEDULER_CRON_SECRET_URI?.trim();
+
+  if (!identityEndpoint || !identityHeader || !secretUri) return undefined;
+
+  try {
+    const tokenUrl = new URL(identityEndpoint);
+    tokenUrl.searchParams.set('resource', KEY_VAULT_RESOURCE);
+    tokenUrl.searchParams.set('api-version', MANAGED_IDENTITY_API_VERSION);
+
+    const tokenResponse = await fetchWithTimeout(tokenUrl, {
+      headers: { 'X-IDENTITY-HEADER': identityHeader },
+    });
+    if (!tokenResponse.ok) return undefined;
+
+    const tokenBody = (await tokenResponse.json()) as { access_token?: unknown };
+    if (typeof tokenBody.access_token !== 'string' || !tokenBody.access_token) return undefined;
+
+    const keyVaultUrl = new URL(secretUri);
+    keyVaultUrl.searchParams.set('api-version', KEY_VAULT_API_VERSION);
+
+    const secretResponse = await fetchWithTimeout(keyVaultUrl, {
+      headers: { Authorization: `Bearer ${tokenBody.access_token}` },
+    });
+    if (!secretResponse.ok) return undefined;
+
+    const secretBody = (await secretResponse.json()) as { value?: unknown };
+    return typeof secretBody.value === 'string' ? secretBody.value.trim() || undefined : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Resolve the scheduler secret directly from Key Vault when managed identity
+ * is available. Environment configuration remains a fail-safe for local and
+ * transitional deployments.
+ */
+export async function getSchedulerCronSecret(): Promise<string | undefined> {
+  return (await getManagedIdentityCronSecret()) ?? getEnvironmentCronSecret();
 }
 
 /**

--- a/lib/scheduler/cron-auth.ts
+++ b/lib/scheduler/cron-auth.ts
@@ -4,6 +4,12 @@ const KEY_VAULT_RESOURCE = 'https://vault.azure.net';
 const MANAGED_IDENTITY_API_VERSION = '2019-08-01';
 const KEY_VAULT_API_VERSION = '7.4';
 const SECRET_LOOKUP_TIMEOUT_MS = 5_000;
+const SECRET_CACHE_TTL_MS = 5 * 60_000;
+const SECRET_NEGATIVE_CACHE_TTL_MS = 30_000;
+
+let secretCache:
+  | { configurationKey: string; value: string | undefined; expiresAt: number }
+  | undefined;
 
 async function fetchWithTimeout(input: URL, init: RequestInit): Promise<Response> {
   const controller = new AbortController();
@@ -20,6 +26,21 @@ function getEnvironmentCronSecret(): string | undefined {
   return (
     process.env.CRON_SECRET?.trim() || process.env.CUSTOMCONNSTR_CRON_SECRET?.trim() || undefined
   );
+}
+
+function getSecretConfigurationKey(): string {
+  return crypto
+    .createHash('sha256')
+    .update(
+      JSON.stringify([
+        process.env.IDENTITY_ENDPOINT ?? '',
+        process.env.IDENTITY_HEADER ?? '',
+        process.env.SCHEDULER_CRON_SECRET_URI ?? '',
+        process.env.CRON_SECRET ?? '',
+        process.env.CUSTOMCONNSTR_CRON_SECRET ?? '',
+      ])
+    )
+    .digest('hex');
 }
 
 async function getManagedIdentityCronSecret(): Promise<string | undefined> {
@@ -63,7 +84,31 @@ async function getManagedIdentityCronSecret(): Promise<string | undefined> {
  * transitional deployments.
  */
 export async function getSchedulerCronSecret(): Promise<string | undefined> {
-  return (await getManagedIdentityCronSecret()) ?? getEnvironmentCronSecret();
+  const configurationKey = getSecretConfigurationKey();
+  const now = Date.now();
+
+  if (secretCache?.configurationKey === configurationKey && secretCache.expiresAt > now) {
+    return secretCache.value;
+  }
+
+  const value = (await getManagedIdentityCronSecret()) ?? getEnvironmentCronSecret();
+  secretCache = {
+    configurationKey,
+    value,
+    expiresAt: now + (value ? SECRET_CACHE_TTL_MS : SECRET_NEGATIVE_CACHE_TTL_MS),
+  };
+
+  return value;
+}
+
+export function hasSchedulerCronCredential(request: Request): boolean {
+  const directSecret = request.headers.get('x-omnipost-cron-secret');
+  const authorization = request.headers.get('authorization');
+
+  return Boolean(
+    directSecret?.trim() ||
+    (authorization?.startsWith('Bearer ') && authorization.slice('Bearer '.length).trim())
+  );
 }
 
 /**


### PR DESCRIPTION
## Summary
- resolve the processor secret directly from Key Vault through the App Service managed-identity endpoint
- bound both identity and Key Vault requests to five seconds
- retain environment resolution as a fail-safe for local and transitional deployments
- configure the non-secret versionless Key Vault URI during Terraform apply

## Why
Azure control-plane references are resolved and the job-injected value matches Key Vault, but the active Node worker continues rejecting that value. Direct managed-identity resolution removes stale process-environment materialization from the authority path.

## Validation
- scheduler auth tests: 11/11 passed
- TypeScript: passed
- targeted Prettier and diff checks: passed