### PR TITLE
fix(scheduler): pin Key Vault managed identity

### DIFF
--- a/.github/workflows/terraform-dev.yml
+++ b/.github/workflows/terraform-dev.yml
@@ -72,6 +72,7 @@ jobs:
             --settings \
               'CRON_SECRET=@Microsoft.KeyVault(SecretUri=https://nl-dev-omnipost-kv.vault.azure.net/secrets/omnipost-scheduler-cron-secret)' \
               'SCHEDULER_CRON_SECRET_URI=https://nl-dev-omnipost-kv.vault.azure.net/secrets/omnipost-scheduler-cron-secret' \
+              'SCHEDULER_MANAGED_IDENTITY_CLIENT_ID=30dae5c1-1175-4f09-8efa-2773bcf4b1f7' \
             --output none
           az webapp restart \
             --resource-group nl-dev-omnipost-rg \

--- a/.github/workflows/terraform-dev.yml
+++ b/.github/workflows/terraform-dev.yml
@@ -66,13 +66,14 @@ jobs:
       - name: Configure scheduler Key Vault reference
         if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.action == 'apply' }}
         run: |
+          MANAGED_IDENTITY_CLIENT_ID="$(terraform -chdir=infra/terraform/env/dev output -raw web_key_vault_identity_client_id)"
           az webapp config appsettings set \
             --resource-group nl-dev-omnipost-rg \
             --name nl-dev-omnipost-web \
             --settings \
               'CRON_SECRET=@Microsoft.KeyVault(SecretUri=https://nl-dev-omnipost-kv.vault.azure.net/secrets/omnipost-scheduler-cron-secret)' \
               'SCHEDULER_CRON_SECRET_URI=https://nl-dev-omnipost-kv.vault.azure.net/secrets/omnipost-scheduler-cron-secret' \
-              'SCHEDULER_MANAGED_IDENTITY_CLIENT_ID=30dae5c1-1175-4f09-8efa-2773bcf4b1f7' \
+              "SCHEDULER_MANAGED_IDENTITY_CLIENT_ID=${MANAGED_IDENTITY_CLIENT_ID}" \
             --output none
           az webapp restart \
             --resource-group nl-dev-omnipost-rg \

--- a/__tests__/lib/scheduler-cron-auth.test.ts
+++ b/__tests__/lib/scheduler-cron-auth.test.ts
@@ -12,6 +12,7 @@ describe('scheduler cron authentication configuration', () => {
   const originalIdentityEndpoint = process.env.IDENTITY_ENDPOINT;
   const originalIdentityHeader = process.env.IDENTITY_HEADER;
   const originalSecretUri = process.env.SCHEDULER_CRON_SECRET_URI;
+  const originalManagedIdentityClientId = process.env.SCHEDULER_MANAGED_IDENTITY_CLIENT_ID;
   const originalFetch = global.fetch;
 
   afterEach(() => {
@@ -34,6 +35,12 @@ describe('scheduler cron authentication configuration', () => {
 
     if (originalSecretUri === undefined) delete process.env.SCHEDULER_CRON_SECRET_URI;
     else process.env.SCHEDULER_CRON_SECRET_URI = originalSecretUri;
+
+    if (originalManagedIdentityClientId === undefined) {
+      delete process.env.SCHEDULER_MANAGED_IDENTITY_CLIENT_ID;
+    } else {
+      process.env.SCHEDULER_MANAGED_IDENTITY_CLIENT_ID = originalManagedIdentityClientId;
+    }
 
     if (originalFetch === undefined) delete (global as { fetch?: typeof fetch }).fetch;
     else global.fetch = originalFetch;
@@ -73,6 +80,7 @@ describe('scheduler cron authentication configuration', () => {
     process.env.IDENTITY_HEADER = 'identity-header';
     process.env.SCHEDULER_CRON_SECRET_URI =
       'https://example.vault.azure.net/secrets/scheduler-secret';
+    process.env.SCHEDULER_MANAGED_IDENTITY_CLIENT_ID = 'managed-identity-client-id';
 
     const fetchMock = jest
       .fn<typeof fetch>()
@@ -100,6 +108,8 @@ describe('scheduler cron authentication configuration', () => {
         signal: expect.any(AbortSignal),
       }
     );
+    const tokenRequestUrl = fetchMock.mock.calls[0][0] as URL;
+    expect(tokenRequestUrl.searchParams.get('client_id')).toBe('managed-identity-client-id');
     expect(fetchMock).toHaveBeenNthCalledWith(
       2,
       expect.objectContaining({ hostname: 'example.vault.azure.net' }),

--- a/lib/scheduler/cron-auth.ts
+++ b/lib/scheduler/cron-auth.ts
@@ -36,6 +36,7 @@ function getSecretConfigurationKey(): string {
         process.env.IDENTITY_ENDPOINT ?? '',
         process.env.IDENTITY_HEADER ?? '',
         process.env.SCHEDULER_CRON_SECRET_URI ?? '',
+        process.env.SCHEDULER_MANAGED_IDENTITY_CLIENT_ID ?? '',
         process.env.CRON_SECRET ?? '',
         process.env.CUSTOMCONNSTR_CRON_SECRET ?? '',
       ])
@@ -47,6 +48,7 @@ async function getManagedIdentityCronSecret(): Promise<string | undefined> {
   const identityEndpoint = process.env.IDENTITY_ENDPOINT?.trim();
   const identityHeader = process.env.IDENTITY_HEADER?.trim();
   const secretUri = process.env.SCHEDULER_CRON_SECRET_URI?.trim();
+  const managedIdentityClientId = process.env.SCHEDULER_MANAGED_IDENTITY_CLIENT_ID?.trim();
 
   if (!identityEndpoint || !identityHeader || !secretUri) return undefined;
 
@@ -54,6 +56,7 @@ async function getManagedIdentityCronSecret(): Promise<string | undefined> {
     const tokenUrl = new URL(identityEndpoint);
     tokenUrl.searchParams.set('resource', KEY_VAULT_RESOURCE);
     tokenUrl.searchParams.set('api-version', MANAGED_IDENTITY_API_VERSION);
+    if (managedIdentityClientId) tokenUrl.searchParams.set('client_id', managedIdentityClientId);
 
     const tokenResponse = await fetchWithTimeout(tokenUrl, {
       headers: { 'X-IDENTITY-HEADER': identityHeader },


### PR DESCRIPTION
## Summary
- request the Key Vault token through the existing user-assigned identity explicitly by client ID
- include identity selection in the secret-cache configuration key
- configure the non-secret client ID during Terraform apply

## Why
The web app has both system- and user-assigned identities. Managed-identity token requests for the Key Vault identity must specify its client ID; otherwise the lookup can fail and fall back to the stale process environment.

## Validation
- scheduler auth tests: 15/15 passed
- TypeScript: passed
- targeted Prettier and diff checks: passed