### PR TITLE
fix(scheduler): allow cron auth through proxy

### DIFF
--- a/__tests__/proxy.test.ts
+++ b/__tests__/proxy.test.ts
@@ -355,6 +355,31 @@ describe('proxy (root middleware on /api/:path*)', () => {
       expect(response.status).toBe(200);
       expect(response._requestHeaders).toBeUndefined();
     });
+
+    test('allows the exact scheduler processor to validate its cron secret', () => {
+      const proxy = loadProxy();
+      const request = createMockNextRequest({
+        pathname: '/api/scheduler/process',
+      });
+      const response = proxy(request) as Record<string, unknown>;
+
+      expect(response.status).toBe(200);
+      expect(response._requestHeaders).toBeUndefined();
+    });
+
+    test('does not exempt scheduler processor subpaths from JWT authentication', async () => {
+      const proxy = loadProxy();
+      const request = createMockNextRequest({
+        pathname: '/api/scheduler/process/admin',
+      });
+      const response = proxy(request) as {
+        status: number;
+        json: () => Promise<{ message: string }>;
+      };
+
+      expect(response.status).toBe(401);
+      await expect(response.json()).resolves.toEqual({ message: 'Authentication required' });
+    });
   });
 
   // ------------------------------------------------------------------

--- a/proxy.ts
+++ b/proxy.ts
@@ -20,9 +20,9 @@ const authenticatedPaths = [
   '/api/scheduler',
 ];
 
-// Provider callbacks cannot carry the browser's Authorization header. These
-// exact routes enforce their own sealed, expiring OAuth state boundary.
-const authenticationExemptPaths = ['/api/platforms/x/callback'];
+// These exact machine/provider routes enforce their own dedicated
+// authentication boundary and cannot carry the browser's JWT.
+const authenticationExemptPaths = ['/api/platforms/x/callback', '/api/scheduler/process'];
 
 // Define paths that require admin authentication
 const adminPaths = ['/api/feature-flags', '/api/audit'];


### PR DESCRIPTION
## Summary
- exempt only `/api/scheduler/process` from browser JWT proxy authentication
- retain the route's dedicated cron-secret validation boundary
- keep scheduler subpaths and user-facing scheduler APIs JWT-protected
- add proxy regression coverage for the exact exemption and protected subpaths

## Root cause
The Azure Container Apps job reached production with the expected dedicated header, but `proxy.ts` matched the `/api/scheduler` prefix and returned `401 {"message":"Authentication required"}` before the route's cron-secret validator ran.

## Validation
- `pnpm exec jest __tests__/proxy.test.ts __tests__/lib/scheduler-cron-auth.test.ts --runInBand` - 52 passed
- `pnpm exec tsc --noEmit --incremental false` - passed
- `pnpm run lint` - passed (existing warnings only)
- `pnpm test -- --runInBand` - 314 passed, 11 skipped
- touched files pass Prettier
- repo-wide format check remains on its existing unrelated baseline