### PR TITLE
fix: enforce authoritative platform readiness

### DIFF
--- a/__tests__/api/scheduler-routes.test.ts
+++ b/__tests__/api/scheduler-routes.test.ts
@@ -324,6 +324,12 @@ describe('Scheduler API Routes', () => {
 
     test('replays an idempotent campaign request without duplicating its audit attempt', async () => {
       mockFindIdempotentReplay.mockResolvedValueOnce({ job: sampleJob, created: false });
+      mockGetPublishReadiness.mockResolvedValue({
+        canPublish: false,
+        platform: 'twitter',
+        reason: 'disconnected',
+        message: 'Connect X before publishing',
+      });
       const contentHash = `sha256:${'a'.repeat(64)}`;
       const response = await POST(
         createRequest('POST', {
@@ -342,6 +348,7 @@ describe('Scheduler API Routes', () => {
 
       expect(response.status).toBe(200);
       expect(mockFindIdempotentReplay).toHaveBeenCalledTimes(1);
+      expect(mockGetPublishReadiness).not.toHaveBeenCalled();
       expect(mockAssertApprovedForQueue).not.toHaveBeenCalled();
       expect(mockScheduleCampaign).not.toHaveBeenCalled();
     });

--- a/__tests__/api/scheduler-routes.test.ts
+++ b/__tests__/api/scheduler-routes.test.ts
@@ -46,6 +46,24 @@ jest.mock('../../lib/campaigns/repository', () => ({
   assertApprovedForQueue: mockAssertApprovedForQueue,
 }));
 
+const mockGetPublishReadiness = jest.fn<
+  (
+    userId: string,
+    platformSlug: string
+  ) => Promise<
+    | { canPublish: true; platform: 'twitter' }
+    | {
+        canPublish: false;
+        platform: string;
+        reason: 'coming_soon' | 'disconnected';
+        message: string;
+      }
+  >
+>();
+jest.mock('../../lib/platforms/readiness', () => ({
+  getPublishReadiness: mockGetPublishReadiness,
+}));
+
 // Mock the sanitize module
 jest.mock('../../app/api/_utils/sanitize', () => ({
   sanitizeText: jest.fn((val: string) => val),
@@ -111,6 +129,7 @@ describe('Scheduler API Routes', () => {
     mockSchedule.mockResolvedValue({ job: sampleJob, created: true });
     mockFindIdempotentReplay.mockResolvedValue(null);
     mockScheduleCampaign.mockResolvedValue({ job: sampleJob, created: true });
+    mockGetPublishReadiness.mockResolvedValue({ canPublish: true, platform: 'twitter' });
     mockAssertApprovedForQueue.mockResolvedValue({
       campaignRowId: 'campaign-row-1',
       versionId: 'version-1',
@@ -369,6 +388,12 @@ describe('Scheduler API Routes', () => {
     });
 
     test('rejects coming-soon platforms before scheduling', async () => {
+      mockGetPublishReadiness.mockResolvedValueOnce({
+        canPublish: false,
+        platform: 'facebook',
+        reason: 'coming_soon',
+        message: 'Facebook publishing is coming soon',
+      });
       const comingSoonJob = {
         type: 'standalone',
         contentId: 'content-1',
@@ -383,6 +408,30 @@ describe('Scheduler API Routes', () => {
 
       expect(response.status).toBe(400);
       expect(data.message).toContain('Facebook publishing is coming soon');
+      expect(mockSchedule).not.toHaveBeenCalled();
+    });
+
+    test('rejects a disconnected supported platform before scheduling', async () => {
+      mockGetPublishReadiness.mockResolvedValueOnce({
+        canPublish: false,
+        platform: 'twitter',
+        reason: 'disconnected',
+        message: 'Connect X before publishing',
+      });
+
+      const response = await POST(
+        createRequest('POST', {
+          type: 'standalone',
+          contentId: 'content-1',
+          platformId: 'twitter',
+          content: { text: 'Hello world' },
+          scheduledTime: '2026-04-01T12:00:00Z',
+        })
+      );
+      const data = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(data.message).toContain('Connect X before publishing');
       expect(mockSchedule).not.toHaveBeenCalled();
     });
 

--- a/__tests__/lib/scheduler-adapters.test.ts
+++ b/__tests__/lib/scheduler-adapters.test.ts
@@ -74,7 +74,13 @@ describe('Scheduler platform adapters', () => {
       .map(platform => platform.slug)
       .sort();
 
-    expect(comingSoonSlugs).toEqual(['facebook', 'instagram', 'tiktok']);
+    expect(comingSoonSlugs).toEqual([
+      'custom-channel',
+      'facebook',
+      'instagram',
+      'linkedin',
+      'tiktok',
+    ]);
   });
 
   test('X publishes through the v2 create-post contract and returns an X URL', async () => {

--- a/app/(dashboard)/content/new/page.tsx
+++ b/app/(dashboard)/content/new/page.tsx
@@ -10,6 +10,7 @@ import { useRouter } from 'next/navigation';
 import { useAuth } from '@/components/providers/AuthProvider';
 import { LoadingSpinner } from '@/components/ui/LoadingSpinner';
 import { useAnalytics } from '@/hooks/useAnalytics';
+import { apiClient } from '@/lib/api-client';
 import { platforms } from '@/lib/config/platforms';
 import { DEFAULT_PLATFORM_CONFIGS } from '@/types/campaign';
 import type { PostStatus } from '@/types/campaign';
@@ -37,6 +38,7 @@ interface PlatformState {
   slug: string;
   name: string;
   enabled: boolean;
+  connected: boolean;
   hashtags: string;
   comingSoon?: boolean;
 }
@@ -116,11 +118,41 @@ export function ContentCreatePage() {
       .map(p => ({
         slug: p.slug,
         name: p.name,
-        enabled: p.defaultContentFlow !== false && !p.comingSoon,
+        enabled: false,
+        connected: false,
         hashtags: (DEFAULT_PLATFORM_CONFIGS[p.slug]?.defaultHashtags ?? []).join(', '),
         comingSoon: p.comingSoon,
       }))
   );
+
+  useEffect(() => {
+    if (!isAuthenticated) return;
+
+    void apiClient
+      .get<{
+        connections: {
+          twitter: { connected: boolean; configured: boolean; status: string };
+        };
+      }>('/api/platforms/connections')
+      .then(response => {
+        const xReady =
+          response.connections.twitter.connected &&
+          response.connections.twitter.configured &&
+          response.connections.twitter.status === 'connected';
+        setPlatformStates(previous =>
+          previous.map(platform => ({
+            ...platform,
+            connected: platform.slug === 'twitter' && xReady,
+            enabled: platform.slug === 'twitter' && xReady,
+          }))
+        );
+      })
+      .catch(() => {
+        setPlatformStates(previous =>
+          previous.map(platform => ({ ...platform, connected: false, enabled: false }))
+        );
+      });
+  }, [isAuthenticated]);
 
   // Step 3: Schedule
   const [scheduleMode, setScheduleMode] = useState<'now' | 'schedule'>('now');
@@ -164,7 +196,9 @@ export function ContentCreatePage() {
 
   const togglePlatform = useCallback((slug: string) => {
     setPlatformStates(prev =>
-      prev.map(p => (p.slug === slug && !p.comingSoon ? { ...p, enabled: !p.enabled } : p))
+      prev.map(p =>
+        p.slug === slug && !p.comingSoon && p.connected ? { ...p, enabled: !p.enabled } : p
+      )
     );
   }, []);
 
@@ -389,6 +423,7 @@ export function ContentCreatePage() {
             const color = getCharColor(body.length, charLimit);
             const fillPercent = Math.min((body.length / charLimit) * 100, 100);
             const isComingSoon = platform.comingSoon;
+            const isDisconnected = !isComingSoon && !platform.connected;
 
             return (
               <div
@@ -404,7 +439,13 @@ export function ContentCreatePage() {
                   </div>
                   <div className={styles.platformToggle}>
                     <span className={styles.toggleLabel}>
-                      {isComingSoon ? 'Unavailable' : platform.enabled ? 'Included' : 'Excluded'}
+                      {isComingSoon
+                        ? 'Unavailable'
+                        : isDisconnected
+                          ? 'Not connected'
+                          : platform.enabled
+                            ? 'Included'
+                            : 'Excluded'}
                     </span>
                     <button
                       type="button"
@@ -413,11 +454,13 @@ export function ContentCreatePage() {
                       aria-label={
                         isComingSoon
                           ? `${platform.name} is coming soon`
-                          : `${platform.enabled ? 'Exclude' : 'Include'} ${platform.name}`
+                          : isDisconnected
+                            ? `${platform.name} is not connected`
+                            : `${platform.enabled ? 'Exclude' : 'Include'} ${platform.name}`
                       }
                       role="switch"
                       aria-checked={platform.enabled}
-                      disabled={isComingSoon}
+                      disabled={isComingSoon || isDisconnected}
                     >
                       <span className={styles.toggleKnob} />
                     </button>

--- a/app/api/scheduler/route.ts
+++ b/app/api/scheduler/route.ts
@@ -13,7 +13,7 @@ import { isAuthenticated, getCurrentUserId } from '@/app/api/_utils/auth';
 import { Errors, withErrorHandling } from '@/app/api/_utils/errors';
 import { withRateLimit, RateLimitPresets } from '@/app/api/_utils/rateLimit';
 import { sanitizeText, validateAndSanitize } from '@/app/api/_utils/sanitize';
-import { platforms } from '@/lib/config/platforms';
+import { getPublishReadiness } from '@/lib/platforms/readiness';
 import { assertApprovedForQueue } from '@/lib/campaigns/repository';
 import { campaignErrorResponse } from '@/app/api/campaigns/_errors';
 
@@ -93,13 +93,6 @@ const createJobSchema = z
       }
     }
   });
-
-function getComingSoonPlatformName(platformId: string): string | undefined {
-  const normalizedPlatformId = platformId.toLowerCase();
-  const platform = platforms.find(p => p.slug === normalizedPlatformId);
-
-  return platform?.comingSoon ? platform.name : undefined;
-}
 
 function isIdempotencyConflict(error: unknown): boolean {
   return (
@@ -185,9 +178,9 @@ export const POST = withRateLimit(
     }
 
     const data = validation.data;
-    const comingSoonPlatformName = getComingSoonPlatformName(data.platformId);
-    if (comingSoonPlatformName) {
-      return Errors.badRequest(`${comingSoonPlatformName} publishing is coming soon`);
+    const readiness = await getPublishReadiness(currentUserId, data.platformId);
+    if (!readiness.canPublish) {
+      return Errors.badRequest(readiness.message);
     }
 
     const scheduler = getScheduler();

--- a/app/api/scheduler/route.ts
+++ b/app/api/scheduler/route.ts
@@ -178,11 +178,6 @@ export const POST = withRateLimit(
     }
 
     const data = validation.data;
-    const readiness = await getPublishReadiness(currentUserId, data.platformId);
-    if (!readiness.canPublish) {
-      return Errors.badRequest(readiness.message);
-    }
-
     const scheduler = getScheduler();
     const requestScheduleInput = {
       type: data.type,
@@ -213,6 +208,11 @@ export const POST = withRateLimit(
         }
         throw error;
       }
+    }
+
+    const readiness = await getPublishReadiness(currentUserId, data.platformId);
+    if (!readiness.canPublish) {
+      return Errors.badRequest(readiness.message);
     }
 
     let approvalBinding: Awaited<ReturnType<typeof assertApprovedForQueue>> | undefined;

--- a/app/onboarding/page.tsx
+++ b/app/onboarding/page.tsx
@@ -11,6 +11,8 @@ import { useAuth } from '@/components/providers/AuthProvider';
 import Header from '@/components/ui/Header';
 import { LoadingSpinner } from '@/components/ui/LoadingSpinner';
 import { useAnalytics } from '@/hooks/useAnalytics';
+import { apiClient } from '@/lib/api-client';
+import { platforms as platformCatalog } from '@/lib/config/platforms';
 import styles from '@/styles/Onboarding.module.css';
 
 interface Platform {
@@ -18,14 +20,25 @@ interface Platform {
   name: string;
   icon: string;
   connected: boolean;
+  comingSoon: boolean;
 }
 
-const INITIAL_PLATFORMS: Platform[] = [
-  { id: 'facebook', name: 'Facebook', icon: 'f', connected: false },
-  { id: 'instagram', name: 'Instagram', icon: 'ig', connected: false },
-  { id: 'linkedin', name: 'LinkedIn', icon: 'in', connected: false },
-  { id: 'twitter', name: 'Twitter', icon: 'X', connected: false },
-];
+const PLATFORM_ICONS: Record<string, string> = {
+  facebook: 'f',
+  instagram: 'ig',
+  linkedin: 'in',
+  twitter: 'X',
+};
+
+const INITIAL_PLATFORMS: Platform[] = platformCatalog
+  .filter(platform => ['facebook', 'instagram', 'linkedin', 'twitter'].includes(platform.slug))
+  .map(platform => ({
+    id: platform.slug,
+    name: platform.name,
+    icon: PLATFORM_ICONS[platform.slug] ?? platform.name.charAt(0),
+    connected: false,
+    comingSoon: Boolean(platform.comingSoon),
+  }));
 
 const TOTAL_STEPS = 3;
 
@@ -51,10 +64,13 @@ function StepConnectPlatforms({
             onClick={() => onToggleConnect(platform.id)}
             aria-label={`Connect ${platform.name}`}
             aria-pressed={platform.connected}
+            disabled={platform.comingSoon}
           >
             <span className={styles.platformIcon}>{platform.icon}</span>
             <span className={styles.platformName}>{platform.name}</span>
-            {platform.connected ? (
+            {platform.comingSoon ? (
+              <span className={styles.platformStatus}>Coming Soon</span>
+            ) : platform.connected ? (
               <span className={styles.platformStatus}>Connected</span>
             ) : (
               <span className={styles.connectButton}>Connect</span>
@@ -81,9 +97,10 @@ function StepCreatePost({
 }) {
   return (
     <>
-      <h2 className={styles.stepTitle}>Create Your First Post</h2>
+      <h2 className={styles.stepTitle}>Prepare Your First Draft</h2>
       <p className={styles.stepDescription}>
-        Write something to publish across your connected platforms.
+        Sketch content for a platform that is actually connected to this account. Nothing is
+        published or saved as a post from onboarding.
       </p>
       <textarea
         className={styles.postTextarea}
@@ -94,16 +111,23 @@ function StepCreatePost({
       />
       <fieldset className={styles.platformCheckboxes}>
         <legend>Select platforms</legend>
-        {platforms.map(platform => (
-          <label key={platform.id} className={styles.checkboxLabel}>
-            <input
-              type="checkbox"
-              checked={selectedPlatforms.has(platform.id)}
-              onChange={() => onTogglePlatform(platform.id)}
-            />
-            {platform.name}
-          </label>
-        ))}
+        {!platforms.some(platform => platform.connected) && (
+          <p className={styles.stepDescription}>
+            No supported platform is connected. Return to Platform Connections to connect X.
+          </p>
+        )}
+        {platforms
+          .filter(platform => platform.connected)
+          .map(platform => (
+            <label key={platform.id} className={styles.checkboxLabel}>
+              <input
+                type="checkbox"
+                checked={selectedPlatforms.has(platform.id)}
+                onChange={() => onTogglePlatform(platform.id)}
+              />
+              {platform.name}
+            </label>
+          ))}
       </fieldset>
     </>
   );
@@ -152,13 +176,43 @@ function ProgressIndicator({ currentStep }: { readonly currentStep: number }) {
 export default function OnboardingPage() {
   const router = useRouter();
   const { isAuthenticated, isLoading } = useAuth();
-  const { trackOnboardingStep, trackPlatformConnected, trackPostPublished } = useAnalytics({
+  const { trackOnboardingStep } = useAnalytics({
     trackPageView: true,
   });
   const [step, setStep] = useState(1);
   const [platforms, setPlatforms] = useState<Platform[]>(INITIAL_PLATFORMS);
   const [postContent, setPostContent] = useState('');
   const [selectedPlatforms, setSelectedPlatforms] = useState<Set<string>>(new Set());
+
+  useEffect(() => {
+    if (!isAuthenticated) return;
+    void apiClient
+      .get<{
+        connections: {
+          twitter: { connected: boolean; configured: boolean; status: string };
+        };
+      }>('/api/platforms/connections')
+      .then(response => {
+        const xReady =
+          response.connections.twitter.connected &&
+          response.connections.twitter.configured &&
+          response.connections.twitter.status === 'connected';
+        setPlatforms(current =>
+          current.map(platform =>
+            platform.id === 'twitter'
+              ? { ...platform, connected: xReady }
+              : { ...platform, connected: false }
+          )
+        );
+        setSelectedPlatforms(current =>
+          xReady && current.has('twitter') ? new Set(['twitter']) : new Set()
+        );
+      })
+      .catch(() => {
+        setPlatforms(current => current.map(platform => ({ ...platform, connected: false })));
+        setSelectedPlatforms(new Set());
+      });
+  }, [isAuthenticated]);
 
   // Restore progress from sessionStorage on mount
   useEffect(() => {
@@ -167,12 +221,10 @@ export default function OnboardingPage() {
       if (saved) {
         const data = JSON.parse(saved) as {
           step: number;
-          platforms: Platform[];
           postContent: string;
           selectedPlatforms: string[];
         };
         if (data.step) setStep(data.step);
-        if (data.platforms) setPlatforms(data.platforms);
         if (data.postContent) setPostContent(data.postContent);
         if (data.selectedPlatforms) setSelectedPlatforms(new Set(data.selectedPlatforms));
       }
@@ -189,9 +241,9 @@ export default function OnboardingPage() {
   }, [isAuthenticated, isLoading, router]);
 
   const handleToggleConnect = (platformId: string) => {
-    setPlatforms(prev =>
-      prev.map(p => (p.id === platformId ? { ...p, connected: !p.connected } : p))
-    );
+    const platform = platforms.find(item => item.id === platformId);
+    if (!platform || platform.comingSoon || platform.connected) return;
+    router.push('/settings/platforms');
   };
 
   const handleTogglePlatform = (platformId: string) => {
@@ -212,7 +264,6 @@ export default function OnboardingPage() {
         'onboarding-progress',
         JSON.stringify({
           step: nextStep,
-          platforms,
           postContent,
           selectedPlatforms: Array.from(selectedPlatforms),
         })
@@ -225,22 +276,6 @@ export default function OnboardingPage() {
   const handleNext = () => {
     const stepNames = ['connect-platforms', 'create-post', 'complete'];
     trackOnboardingStep(step, stepNames[step - 1] || 'unknown', false);
-
-    if (step === 1) {
-      const connectedCount = platforms.filter(p => p.connected).length;
-      if (connectedCount > 0) {
-        platforms
-          .filter(p => p.connected)
-          .forEach(p => {
-            trackPlatformConnected(p.name, connectedCount);
-          });
-      }
-    }
-
-    if (step === 2 && postContent.trim()) {
-      const platformNames = Array.from(selectedPlatforms);
-      trackPostPublished(platformNames, true);
-    }
 
     if (step < TOTAL_STEPS) {
       const nextStep = step + 1;

--- a/lib/config/platforms.ts
+++ b/lib/config/platforms.ts
@@ -38,7 +38,13 @@ export const platforms: Platform[] = [
     description: 'Instagram photo sharing platform',
     comingSoon: true,
   },
-  { id: 3, name: 'LinkedIn', slug: 'linkedin', description: 'LinkedIn professional network' },
+  {
+    id: 3,
+    name: 'LinkedIn',
+    slug: 'linkedin',
+    description: 'LinkedIn professional network',
+    comingSoon: true,
+  },
   { id: 4, name: 'X', slug: 'twitter', description: 'X social network' },
   {
     id: 5,
@@ -54,6 +60,7 @@ export const platforms: Platform[] = [
     name: 'Custom Channel',
     slug: 'custom-channel',
     description: 'Custom publishing channel',
+    comingSoon: true,
   },
 ];
 

--- a/lib/platforms/readiness.ts
+++ b/lib/platforms/readiness.ts
@@ -1,0 +1,55 @@
+import { getPlatformBySlug } from '@/lib/config/platforms';
+import { isPlatformTokenEncryptionConfigured } from '@/lib/platforms/x/crypto';
+import { isXOAuthClientConfigured } from '@/lib/platforms/x/oauth';
+import { getXConnectionStatus } from '@/lib/platforms/x/repository';
+
+export type PublishReadiness =
+  | { canPublish: true; platform: 'twitter' }
+  | {
+      canPublish: false;
+      platform: string;
+      reason: 'unknown' | 'coming_soon' | 'unconfigured' | 'disconnected';
+      message: string;
+    };
+
+export async function getPublishReadiness(
+  userId: string,
+  platformSlug: string
+): Promise<PublishReadiness> {
+  const normalizedSlug = platformSlug.toLowerCase();
+  const platform = getPlatformBySlug(normalizedSlug);
+  if (!platform) {
+    return {
+      canPublish: false,
+      platform: normalizedSlug,
+      reason: 'unknown',
+      message: 'This publishing platform is not supported',
+    };
+  }
+  if (platform.comingSoon || platform.slug !== 'twitter') {
+    return {
+      canPublish: false,
+      platform: platform.slug,
+      reason: 'coming_soon',
+      message: `${platform.name} publishing is coming soon`,
+    };
+  }
+  if (!isXOAuthClientConfigured() || !isPlatformTokenEncryptionConfigured()) {
+    return {
+      canPublish: false,
+      platform: platform.slug,
+      reason: 'unconfigured',
+      message: 'X publishing is not configured',
+    };
+  }
+  const connection = await getXConnectionStatus(userId);
+  if (!connection.connected) {
+    return {
+      canPublish: false,
+      platform: platform.slug,
+      reason: 'disconnected',
+      message: 'Connect X before publishing',
+    };
+  }
+  return { canPublish: true, platform: 'twitter' };
+}


### PR DESCRIPTION
## Summary

- make X publish readiness server-authoritative
- prevent onboarding and the composer from treating unsupported or disconnected platforms as usable
- mark LinkedIn and Custom Channel as Coming Soon
- reject unsupported, unconfigured, and disconnected destinations before scheduler enqueue
- clarify that onboarding content sketch does not publish or save a post

## Validation

- pnpm exec tsc --noEmit --incremental false
- focused ESLint on all changed files
- pnpm test -- --runInBand scheduler route and adapter tests (21 passed)

## Notes

- X is the only currently publishable platform.
- Browser state is never accepted as proof of connection.
- Full pnpm check-all remains unsuitable on this Windows checkout because the repository existing CRLF baseline causes the format gate to report hundreds of untouched files; CI on Linux is authoritative.