### PR TITLE
fix: unify authenticated dashboard shell

### DIFF
--- a/__tests__/components/DashboardLayout.test.tsx
+++ b/__tests__/components/DashboardLayout.test.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, jest, test } from '@jest/globals';
+
+jest.mock('@/components/providers/AuthProvider', () => ({
+  useAuth: () => ({ isAuthenticated: true, isLoading: false }),
+}));
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ push: jest.fn() }),
+}));
+jest.mock('@/components/ui/Header', () => ({
+  __esModule: true,
+  default: () => <header data-testid="dashboard-header" />,
+}));
+jest.mock('@/components/ui/ErrorBoundary', () => ({
+  __esModule: true,
+  default: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+const DashboardLayout = require('../../app/(dashboard)/layout').default as React.ComponentType<{
+  children: React.ReactNode;
+}>;
+
+describe('DashboardLayout', () => {
+  test('owns one authenticated header and main landmark', () => {
+    render(
+      <DashboardLayout>
+        <p>Dashboard content</p>
+      </DashboardLayout>
+    );
+
+    expect(screen.getAllByTestId('dashboard-header')).toHaveLength(1);
+    expect(screen.getAllByRole('main')).toHaveLength(1);
+    expect(
+      screen.getByRole('link', { name: 'Skip to main content' }).getAttribute('href')
+    ).toBe('#main-content');
+    expect(screen.getByRole('main').getAttribute('id')).toBe('main-content');
+    expect(screen.queryByText('Dashboard content')).not.toBeNull();
+  });
+});

--- a/__tests__/components/DashboardLayout.test.tsx
+++ b/__tests__/components/DashboardLayout.test.tsx
@@ -32,9 +32,9 @@ describe('DashboardLayout', () => {
     expect(screen.getAllByTestId('dashboard-header')).toHaveLength(1);
     expect(screen.getAllByRole('main')).toHaveLength(1);
     expect(screen.getByRole('link', { name: 'Skip to main content' }).getAttribute('href')).toBe(
-      '#main-content'
+      '#dashboard-main-content'
     );
-    expect(screen.getByRole('main').getAttribute('id')).toBe('main-content');
+    expect(screen.getByRole('main').getAttribute('id')).toBe('dashboard-main-content');
     expect(screen.queryByText('Dashboard content')).not.toBeNull();
   });
 });

--- a/__tests__/components/DashboardLayout.test.tsx
+++ b/__tests__/components/DashboardLayout.test.tsx
@@ -31,9 +31,9 @@ describe('DashboardLayout', () => {
 
     expect(screen.getAllByTestId('dashboard-header')).toHaveLength(1);
     expect(screen.getAllByRole('main')).toHaveLength(1);
-    expect(
-      screen.getByRole('link', { name: 'Skip to main content' }).getAttribute('href')
-    ).toBe('#main-content');
+    expect(screen.getByRole('link', { name: 'Skip to main content' }).getAttribute('href')).toBe(
+      '#main-content'
+    );
     expect(screen.getByRole('main').getAttribute('id')).toBe('main-content');
     expect(screen.queryByText('Dashboard content')).not.toBeNull();
   });

--- a/app/(dashboard)/automation/AutomationContent.tsx
+++ b/app/(dashboard)/automation/AutomationContent.tsx
@@ -5,7 +5,6 @@
  * Handles interactive tool selection and modal display
  */
 
-import Layout from '@/components/layouts/Layout';
 import ToolGrid from '@/components/automation/ToolGrid';
 import LoadingState from '@/components/ui/LoadingState';
 import ErrorMessage from '@/components/ui/ErrorMessage';
@@ -41,10 +40,7 @@ export default function AutomationContent({ initialTools, initialError }: Automa
   ];
 
   return (
-    <Layout
-      title="Workflow Automation"
-      description="Leverage system architecture expertise to automate repetitive tasks in your content workflow."
-    >
+    <>
       <div className={styles.container}>
         <div className={styles.section}>
           <div className={styles.automation}>
@@ -70,6 +66,6 @@ export default function AutomationContent({ initialTools, initialError }: Automa
           </div>
         </div>
       </div>
-    </Layout>
+    </>
   );
 }

--- a/app/(dashboard)/campaigns/CampaignList.tsx
+++ b/app/(dashboard)/campaigns/CampaignList.tsx
@@ -7,7 +7,6 @@
 
 import { useState } from 'react';
 import Link from 'next/link';
-import Layout from '@/components/layouts/Layout';
 import { CampaignCard, CampaignForm, EmptyState } from '@/components/campaigns';
 import { Button, LoadingSpinner } from '@/components/ui';
 import { useCampaign } from '@/hooks/useCampaign';
@@ -99,10 +98,7 @@ export default function CampaignList() {
     statusFilter === 'all' ? campaigns : campaigns.filter(c => c.status === statusFilter);
 
   return (
-    <Layout
-      title="Campaign Management"
-      description="Create and manage multi-platform content campaigns"
-    >
+    <>
       <div className={styles.container}>
         <h1 className={styles.pageTitle}>Campaigns</h1>
         <p className={styles.pageDescription}>
@@ -171,6 +167,6 @@ export default function CampaignList() {
           </Link>
         </div>
       </div>
-    </Layout>
+    </>
   );
 }

--- a/app/(dashboard)/campaigns/[id]/CampaignDetail.tsx
+++ b/app/(dashboard)/campaigns/[id]/CampaignDetail.tsx
@@ -8,7 +8,6 @@
 import { useState, useEffect } from 'react';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
-import Layout from '@/components/layouts/Layout';
 import { CampaignForm } from '@/components/campaigns';
 import { Button, LoadingSpinner, EmptyState, StatusBadge, FormField } from '@/components/ui';
 import { useCampaign } from '@/hooks/useCampaign';
@@ -62,20 +61,20 @@ export default function CampaignDetail({ campaignId }: CampaignDetailProps) {
   // Show loading state while data is being loaded from localStorage
   if (isLoading) {
     return (
-      <Layout title="Loading Campaign" description="">
+      <>
         <div className={styles.container}>
           <div className={styles.loadingContainer}>
             <LoadingSpinner size="lg" />
             <p className={styles.loadingText}>Loading campaign...</p>
           </div>
         </div>
-      </Layout>
+      </>
     );
   }
 
   if (!campaign) {
     return (
-      <Layout title="Campaign Not Found" description="">
+      <>
         <div className={styles.container}>
           <EmptyState
             variant="error"
@@ -87,7 +86,7 @@ export default function CampaignDetail({ campaignId }: CampaignDetailProps) {
             }}
           />
         </div>
-      </Layout>
+      </>
     );
   }
 
@@ -218,7 +217,7 @@ export default function CampaignDetail({ campaignId }: CampaignDetailProps) {
     campaign.status === 'paused';
 
   return (
-    <Layout title={campaign.name} description={campaign.description}>
+    <>
       <div className={styles.container}>
         {/* Header */}
         <div className={styles.headerActions}>
@@ -331,9 +330,7 @@ export default function CampaignDetail({ campaignId }: CampaignDetailProps) {
                   <button
                     key={platform.platformId}
                     type="button"
-                    className={`${styles.platformOption} ${
-                      platform.enabled ? styles.selected : ''
-                    }`}
+                    className={`${styles.platformOption} ${platform.enabled ? styles.selected : ''}`}
                     onClick={() => handleTogglePlatform(platform.platformId)}
                     aria-pressed={platform.enabled}
                     style={{ cursor: 'pointer' }}
@@ -661,6 +658,6 @@ export default function CampaignDetail({ campaignId }: CampaignDetailProps) {
           </Link>
         </div>
       </div>
-    </Layout>
+    </>
   );
 }

--- a/app/(dashboard)/content-adaptation/page.tsx
+++ b/app/(dashboard)/content-adaptation/page.tsx
@@ -4,7 +4,6 @@
  */
 
 import { Metadata } from 'next';
-import Layout from '@/components/layouts/Layout';
 import WorkflowDiagram from '@/components/adaptation/WorkflowDiagram';
 import AdaptationExamples from '@/components/adaptation/AdaptationExamples';
 import NavigationLinks from '@/components/ui/NavigationLinks';
@@ -50,10 +49,7 @@ export default async function ContentAdaptationPage() {
   ];
 
   return (
-    <Layout
-      title="Content Adaptation Strategies"
-      description="Strategic approaches for adapting your technical content to different platforms."
-    >
+    <>
       <div className={styles.container}>
         <div className={styles.section}>
           {error ? (
@@ -77,6 +73,6 @@ export default async function ContentAdaptationPage() {
           />
         </div>
       </div>
-    </Layout>
+    </>
   );
 }

--- a/app/(dashboard)/layout.tsx
+++ b/app/(dashboard)/layout.tsx
@@ -8,8 +8,9 @@
 import { useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 import { useAuth } from '@/components/providers/AuthProvider';
-import { ErrorBoundary } from '@/components/ui';
+import ErrorBoundary from '@/components/ui/ErrorBoundary';
 import Header from '@/components/ui/Header';
+import layoutStyles from '@/styles/MainLayout.module.css';
 import styles from '@/styles/shared.module.css';
 
 export default function DashboardLayout({ children }: { readonly children: React.ReactNode }) {
@@ -25,10 +26,13 @@ export default function DashboardLayout({ children }: { readonly children: React
   if (isLoading) {
     return (
       <>
+        <a href="#main-content" className={layoutStyles.skipLink}>
+          Skip to main content
+        </a>
         <Header />
-        <div className={styles.container}>
+        <main id="main-content" className={styles.container} tabIndex={-1}>
           <div>Loading...</div>
-        </div>
+        </main>
       </>
     );
   }
@@ -39,10 +43,13 @@ export default function DashboardLayout({ children }: { readonly children: React
 
   return (
     <>
+      <a href="#main-content" className={layoutStyles.skipLink}>
+        Skip to main content
+      </a>
       <Header />
-      <div className={styles.container}>
+      <main id="main-content" className={styles.container} tabIndex={-1}>
         <ErrorBoundary>{children}</ErrorBoundary>
-      </div>
+      </main>
     </>
   );
 }

--- a/app/(dashboard)/layout.tsx
+++ b/app/(dashboard)/layout.tsx
@@ -26,11 +26,11 @@ export default function DashboardLayout({ children }: { readonly children: React
   if (isLoading) {
     return (
       <>
-        <a href="#main-content" className={layoutStyles.skipLink}>
+        <a href="#dashboard-main-content" className={layoutStyles.skipLink}>
           Skip to main content
         </a>
         <Header />
-        <main id="main-content" className={styles.container} tabIndex={-1}>
+        <main id="dashboard-main-content" className={styles.container} tabIndex={-1}>
           <div>Loading...</div>
         </main>
       </>
@@ -43,11 +43,11 @@ export default function DashboardLayout({ children }: { readonly children: React
 
   return (
     <>
-      <a href="#main-content" className={layoutStyles.skipLink}>
+      <a href="#dashboard-main-content" className={layoutStyles.skipLink}>
         Skip to main content
       </a>
       <Header />
-      <main id="main-content" className={styles.container} tabIndex={-1}>
+      <main id="dashboard-main-content" className={styles.container} tabIndex={-1}>
         <ErrorBoundary>{children}</ErrorBoundary>
       </main>
     </>

--- a/app/(dashboard)/series/SeriesContent.tsx
+++ b/app/(dashboard)/series/SeriesContent.tsx
@@ -7,7 +7,6 @@
 
 import { useState } from 'react';
 import Link from 'next/link';
-import Layout from '@/components/layouts/Layout';
 import SeriesForm from '@/components/series/SeriesForm';
 import SeriesCard from '@/components/series/SeriesCard';
 import EmptyState from '@/components/series/EmptyState';
@@ -41,10 +40,7 @@ export default function SeriesContent() {
   };
 
   return (
-    <Layout
-      title="Manage Content Series"
-      description="Create and manage your technical content series"
-    >
+    <>
       <div className={styles.container}>
         {/* Page Header */}
         <header className={styles.pageHeader}>
@@ -162,6 +158,6 @@ export default function SeriesContent() {
           </Link>
         </nav>
       </div>
-    </Layout>
+    </>
   );
 }


### PR DESCRIPTION
## Summary

- make the authenticated dashboard layout the single owner of header and main content
- remove nested marketing Layout wrappers from automation, campaigns, campaign detail, content adaptation, and series
- preserve page metadata in each App Router page
- add a keyboard skip link and a regression test for one header and one main landmark

## Validation

- pnpm exec tsc --noEmit --incremental false
- focused ESLint on all changed files
- pnpm test -- --runInBand __tests__/components/DashboardLayout.test.tsx (1 passed)
- verified no dashboard child imports or renders components/layouts/Layout

## Notes

Full pnpm check-all remains unsuitable on this Windows checkout because the repository existing CRLF baseline causes the format gate to report hundreds of untouched files; CI on Linux is authoritative.