### PR TITLE
Fix content details and delivery status

### DIFF
--- a/__tests__/lib/local-content.test.ts
+++ b/__tests__/lib/local-content.test.ts
@@ -1,0 +1,70 @@
+import {
+  getContentStatusLabel,
+  synchronizeContentStatuses,
+  type StoredContent,
+} from '@/lib/content/local-content';
+
+const baseContent: StoredContent = {
+  id: 'content-1',
+  title: 'Post',
+  body: 'Post body',
+  summary: '',
+  platforms: [],
+  status: 'scheduled',
+  scheduledTime: '2026-07-27T10:00:00.000Z',
+  createdAt: '2026-07-27T09:00:00.000Z',
+  updatedAt: '2026-07-27T09:00:00.000Z',
+  schedulerJobIds: ['job-1', 'job-2'],
+};
+
+describe('synchronizeContentStatuses', () => {
+  it('shows published only when every linked scheduler job is published', () => {
+    expect(
+      synchronizeContentStatuses(
+        [baseContent],
+        [
+          { id: 'job-1', contentId: 'content-1', status: 'published' },
+          { id: 'job-2', contentId: 'content-1', status: 'published' },
+        ]
+      )
+    ).toEqual([expect.objectContaining({ status: 'published' })]);
+  });
+
+  it('shows publishing while a linked scheduler job is processing', () => {
+    expect(
+      synchronizeContentStatuses(
+        [baseContent],
+        [
+          { id: 'job-1', contentId: 'content-1', status: 'published' },
+          { id: 'job-2', contentId: 'content-1', status: 'processing' },
+        ]
+      )
+    ).toEqual([expect.objectContaining({ status: 'processing' })]);
+  });
+
+  it('keeps an unlinked legacy content card unchanged', () => {
+    const legacy = { ...baseContent, schedulerJobIds: undefined, status: 'queued' as const };
+    expect(
+      synchronizeContentStatuses(
+        [legacy],
+        [{ id: 'job-1', contentId: 'content-1', status: 'published' }]
+      )
+    ).toEqual([legacy]);
+  });
+
+  it('does not adopt a job whose content ID does not match the card', () => {
+    expect(
+      synchronizeContentStatuses(
+        [baseContent],
+        [
+          { id: 'job-1', contentId: 'other-content', status: 'published' },
+          { id: 'job-2', contentId: 'content-1', status: 'published' },
+        ]
+      )
+    ).toEqual([baseContent]);
+  });
+
+  it('does not present a legacy scheduled status as live tracking', () => {
+    expect(getContentStatusLabel('scheduled')).toBe('Tracking unavailable');
+  });
+});

--- a/app/(dashboard)/content/[id]/ContentDetail.tsx
+++ b/app/(dashboard)/content/[id]/ContentDetail.tsx
@@ -1,0 +1,182 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import { useAuth } from '@/components/providers/AuthProvider';
+import { LoadingSpinner } from '@/components/ui/LoadingSpinner';
+import {
+  formatContentDate,
+  getContentStatusLabel,
+  loadStoredContent,
+  synchronizeContentStatuses,
+  type SchedulerJobSnapshot,
+  type StoredContent,
+} from '@/lib/content/local-content';
+import styles from '@/styles/ContentDetail.module.css';
+
+interface ContentDetailProps {
+  readonly contentId: string;
+}
+
+function getStatusClass(status: StoredContent['status']): string {
+  switch (status) {
+    case 'published':
+      return styles.statusPublished;
+    case 'failed':
+      return styles.statusFailed;
+    case 'scheduled':
+    case 'queued':
+    case 'processing':
+      return styles.statusScheduled;
+    default:
+      return styles.statusDraft;
+  }
+}
+
+export default function ContentDetail({ contentId }: ContentDetailProps) {
+  const { isAuthenticated, isLoading } = useAuth();
+  const router = useRouter();
+  const [content, setContent] = useState<StoredContent | null | undefined>(undefined);
+
+  useEffect(() => {
+    if (!isAuthenticated && !isLoading) router.push('/login');
+  }, [isAuthenticated, isLoading, router]);
+
+  useEffect(() => {
+    const stored = loadStoredContent().find(item => item.id === contentId) ?? null;
+    setContent(stored);
+
+    if (!stored || !isAuthenticated) return;
+
+    let active = true;
+    void fetch('/api/scheduler?limit=100')
+      .then(async response => {
+        if (!response.ok) return;
+        const payload = (await response.json()) as { jobs?: SchedulerJobSnapshot[] };
+        const synchronized = synchronizeContentStatuses([stored], payload.jobs ?? [])[0];
+        if (active) setContent(synchronized);
+      })
+      .catch(() => undefined);
+
+    return () => {
+      active = false;
+    };
+  }, [contentId, isAuthenticated]);
+
+  if (isLoading || content === undefined)
+    return <LoadingSpinner size="lg" label="Loading content..." />;
+  if (!isAuthenticated) return null;
+
+  if (!content) {
+    return (
+      <div className={styles.page}>
+        <div className={styles.notFound}>
+          <p className={styles.eyebrow}>Content details</p>
+          <h1>That post is not available in this session.</h1>
+          <p>Return to your content list or create a new post.</p>
+          <div className={styles.actions}>
+            <Link href="/content" className={styles.secondaryButton}>
+              Back to content
+            </Link>
+            <Link href="/content/new" className={styles.primaryButton}>
+              Create new
+            </Link>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  const platforms = content.platforms.filter(platform => platform.enabled);
+  const hasSchedule =
+    content.status === 'scheduled' ||
+    content.status === 'queued' ||
+    content.status === 'processing';
+
+  return (
+    <div className={styles.page}>
+      <div className={styles.topBar}>
+        <Link href="/content" className={styles.backLink}>
+          ← All content
+        </Link>
+        <Link href="/content/new" className={styles.primaryButton}>
+          + Create new
+        </Link>
+      </div>
+
+      <section className={styles.header} aria-labelledby="content-title">
+        <div>
+          <p className={styles.eyebrow}>Content details</p>
+          <h1 id="content-title">{content.title || 'Untitled'}</h1>
+          <p className={styles.summary}>
+            {content.summary || 'Review the post before its next publishing step.'}
+          </p>
+        </div>
+        <span className={`${styles.status} ${getStatusClass(content.status)}`}>
+          {getContentStatusLabel(content.status, content.schedulerJobIds)}
+        </span>
+      </section>
+
+      <section className={styles.statusPanel} aria-label="Publishing status">
+        <div>
+          <p className={styles.panelLabel}>{hasSchedule ? 'Publishing time' : 'Created'}</p>
+          <p className={styles.panelValue}>
+            {hasSchedule
+              ? formatContentDate(content.scheduledTime, true)
+              : formatContentDate(content.createdAt, true)}
+          </p>
+        </div>
+        <div>
+          <p className={styles.panelLabel}>Destinations</p>
+          <p className={styles.panelValue}>
+            {platforms.length} platform{platforms.length === 1 ? '' : 's'}
+          </p>
+        </div>
+        <div>
+          <p className={styles.panelLabel}>Length</p>
+          <p className={styles.panelValue}>{content.body.length} characters</p>
+        </div>
+      </section>
+
+      <section className={styles.detailCard} aria-labelledby="post-copy-heading">
+        <div className={styles.sectionHeading}>
+          <div>
+            <p className={styles.eyebrow}>Post copy</p>
+            <h2 id="post-copy-heading">Ready for review</h2>
+          </div>
+          <span className={styles.characterCount}>{content.body.length} characters</span>
+        </div>
+        <p className={styles.postBody}>{content.body || 'No post copy was saved.'}</p>
+      </section>
+
+      <section className={styles.detailCard} aria-labelledby="destinations-heading">
+        <div className={styles.sectionHeading}>
+          <div>
+            <p className={styles.eyebrow}>Destinations</p>
+            <h2 id="destinations-heading">Selected platforms</h2>
+          </div>
+        </div>
+        {platforms.length > 0 ? (
+          <ul className={styles.platformList}>
+            {platforms.map(platform => (
+              <li key={platform.slug} className={styles.platformItem}>
+                <span className={styles.platformInitial} aria-hidden="true">
+                  {platform.name.charAt(0)}
+                </span>
+                <span>{platform.name}</span>
+                {platform.hashtags ? (
+                  <span className={styles.hashtags}>{platform.hashtags}</span>
+                ) : null}
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <p className={styles.emptyPlatforms}>
+            No publishing platforms were selected for this post.
+          </p>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/app/(dashboard)/content/[id]/page.tsx
+++ b/app/(dashboard)/content/[id]/page.tsx
@@ -1,0 +1,16 @@
+import type { Metadata } from 'next';
+import ContentDetail from './ContentDetail';
+
+export const metadata: Metadata = {
+  title: 'Content details',
+  description: 'Review content, publishing status, schedule, and selected platforms.',
+};
+
+interface PageProps {
+  readonly params: Promise<{ id: string }>;
+}
+
+export default async function ContentDetailPage({ params }: PageProps) {
+  const { id } = await params;
+  return <ContentDetail contentId={id} />;
+}

--- a/app/(dashboard)/content/new/page.tsx
+++ b/app/(dashboard)/content/new/page.tsx
@@ -15,13 +15,12 @@ import { platforms } from '@/lib/config/platforms';
 import { DEFAULT_PLATFORM_CONFIGS } from '@/types/campaign';
 import type { PostStatus } from '@/types/campaign';
 import type { JobType } from '@/lib/scheduler/types';
+import { CONTENT_STORAGE_KEY, type StoredContent } from '@/lib/content/local-content';
 import styles from '@/styles/ContentCreate.module.css';
 
 // ── Constants ───────────────────────────────────────────────────────────────
 
 const STEPS = ['Write Content', 'Platform Adaptation', 'Schedule'] as const;
-const STORAGE_KEY = 'omnipost_content_drafts';
-
 /** Character limits per platform slug */
 const PLATFORM_CHAR_LIMITS: Record<string, number> = {
   twitter: 280,
@@ -43,18 +42,6 @@ interface PlatformState {
   comingSoon?: boolean;
 }
 
-interface ContentDraft {
-  id: string;
-  title: string;
-  body: string;
-  summary: string;
-  platforms: PlatformState[];
-  status: PostStatus;
-  scheduledTime: string;
-  createdAt: string;
-  updatedAt: string;
-}
-
 // ── Helpers ─────────────────────────────────────────────────────────────────
 
 function generateId(): string {
@@ -73,19 +60,19 @@ function getCharColor(current: number, limit: number): 'green' | 'yellow' | 'red
   return 'red';
 }
 
-function loadDrafts(): ContentDraft[] {
+function loadDrafts(): StoredContent[] {
   if (typeof window === 'undefined') return [];
   try {
-    const raw = sessionStorage.getItem(STORAGE_KEY);
-    return raw ? (JSON.parse(raw) as ContentDraft[]) : [];
+    const raw = sessionStorage.getItem(CONTENT_STORAGE_KEY);
+    return raw ? (JSON.parse(raw) as StoredContent[]) : [];
   } catch {
     return [];
   }
 }
 
-function saveDrafts(drafts: ContentDraft[]): void {
+function saveDrafts(drafts: StoredContent[]): void {
   if (typeof window === 'undefined') return;
-  sessionStorage.setItem(STORAGE_KEY, JSON.stringify(drafts));
+  sessionStorage.setItem(CONTENT_STORAGE_KEY, JSON.stringify(drafts));
 }
 
 // ── Component ───────────────────────────────────────────────────────────────
@@ -208,7 +195,7 @@ export function ContentCreatePage() {
 
   const saveDraft = useCallback(() => {
     const drafts = loadDrafts();
-    const draft: ContentDraft = {
+    const draft: StoredContent = {
       id: generateId(),
       title,
       body,
@@ -234,6 +221,7 @@ export function ContentCreatePage() {
     const time =
       scheduleMode === 'now' ? new Date().toISOString() : new Date(scheduledTime).toISOString();
     const status: PostStatus = scheduleMode === 'now' ? 'queued' : 'scheduled';
+    const contentId = generateId();
 
     try {
       // Create a scheduler job for each enabled platform
@@ -247,7 +235,7 @@ export function ContentCreatePage() {
 
         const jobPayload = {
           type: 'standalone' as JobType,
-          contentId: generateId(),
+          contentId,
           platformId: platform.slug,
           content: {
             text: adaptedText,
@@ -257,32 +245,35 @@ export function ContentCreatePage() {
           timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
         };
 
-        return fetch('/api/scheduler', {
+        const response = await fetch('/api/scheduler', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify(jobPayload),
         });
+
+        if (!response.ok) {
+          const errorBody = (await response.json().catch(() => ({}))) as {
+            error?: string;
+            message?: string;
+          };
+          throw new Error(
+            errorBody.error ||
+              errorBody.message ||
+              `Scheduler rejected the request (${response.status})`
+          );
+        }
+
+        const payload = (await response.json()) as { job?: { id?: string } };
+        if (!payload.job?.id) throw new Error('Scheduler did not return a job ID');
+        return payload.job.id;
       });
 
-      const responses = await Promise.all(jobPromises);
-      const failedResponse = responses.find(response => !response.ok);
-
-      if (failedResponse) {
-        const errorBody = (await failedResponse.json().catch(() => ({}))) as {
-          error?: string;
-          message?: string;
-        };
-        throw new Error(
-          errorBody.error ||
-            errorBody.message ||
-            `Scheduler rejected the request (${failedResponse.status})`
-        );
-      }
+      const schedulerJobIds = await Promise.all(jobPromises);
 
       // Save to sessionStorage as well
       const drafts = loadDrafts();
-      const draft: ContentDraft = {
-        id: generateId(),
+      const draft: StoredContent = {
+        id: contentId,
         title,
         body,
         summary,
@@ -291,6 +282,7 @@ export function ContentCreatePage() {
         scheduledTime: time,
         createdAt: new Date().toISOString(),
         updatedAt: new Date().toISOString(),
+        schedulerJobIds,
       };
       saveDrafts([draft, ...drafts]);
 

--- a/app/(dashboard)/content/page.tsx
+++ b/app/(dashboard)/content/page.tsx
@@ -11,80 +11,31 @@ import { useRouter } from 'next/navigation';
 import { useAuth } from '@/components/providers/AuthProvider';
 import { LoadingSpinner } from '@/components/ui/LoadingSpinner';
 import { useAnalytics } from '@/hooks/useAnalytics';
+import {
+  formatContentDate,
+  getContentStatusLabel,
+  loadStoredContent,
+  synchronizeContentStatuses,
+  type ContentStatus,
+  type SchedulerJobSnapshot,
+  type StoredContent,
+} from '@/lib/content/local-content';
 import styles from '@/styles/ContentList.module.css';
 
 // ── Constants ───────────────────────────────────────────────────────────────
 
-const STORAGE_KEY = 'omnipost_content_drafts';
-
-// ── Types ───────────────────────────────────────────────────────────────────
-
-type ContentStatus = 'pending' | 'scheduled' | 'queued' | 'published' | 'failed';
-
-interface StoredPlatform {
-  slug: string;
-  name: string;
-  enabled: boolean;
-  hashtags: string;
-}
-
-interface StoredContent {
-  id: string;
-  title: string;
-  body: string;
-  summary: string;
-  platforms: StoredPlatform[];
-  status: ContentStatus;
-  scheduledTime: string;
-  createdAt: string;
-  updatedAt: string;
-}
-
 // ── Helpers ─────────────────────────────────────────────────────────────────
 
-function loadDrafts(): StoredContent[] {
-  if (typeof window === 'undefined') return [];
-  try {
-    const raw = sessionStorage.getItem(STORAGE_KEY);
-    return raw ? (JSON.parse(raw) as StoredContent[]) : [];
-  } catch {
-    return [];
-  }
-}
-
-function getDisplayStatus(status: ContentStatus): 'Draft' | 'Scheduled' | 'Published' {
+function getBadgeClass(status: ContentStatus): string {
   switch (status) {
     case 'published':
-      return 'Published';
+      return styles.badgePublished;
     case 'scheduled':
     case 'queued':
-      return 'Scheduled';
-    default:
-      return 'Draft';
-  }
-}
-
-function getBadgeClass(status: ContentStatus): string {
-  const display = getDisplayStatus(status);
-  switch (display) {
-    case 'Published':
-      return styles.badgePublished;
-    case 'Scheduled':
+    case 'processing':
       return styles.badgeScheduled;
     default:
       return styles.badgeDraft;
-  }
-}
-
-function formatDate(iso: string): string {
-  try {
-    return new Date(iso).toLocaleDateString(undefined, {
-      month: 'short',
-      day: 'numeric',
-      year: 'numeric',
-    });
-  } catch {
-    return '';
   }
 }
 
@@ -103,8 +54,26 @@ export function ContentListPage() {
   }, [isAuthenticated, isLoading, router]);
 
   useEffect(() => {
-    setItems(loadDrafts());
+    setItems(loadStoredContent());
   }, []);
+
+  useEffect(() => {
+    if (!isAuthenticated) return;
+
+    let active = true;
+    void fetch('/api/scheduler?limit=100')
+      .then(async response => {
+        if (!response.ok) return;
+        const payload = (await response.json()) as { jobs?: SchedulerJobSnapshot[] };
+        const jobs = payload.jobs ?? [];
+        if (active) setItems(previous => synchronizeContentStatuses(previous, jobs));
+      })
+      .catch(() => undefined);
+
+    return () => {
+      active = false;
+    };
+  }, [isAuthenticated]);
 
   const handleItemClick = useCallback(
     (item: StoredContent) => {
@@ -158,14 +127,15 @@ export function ContentListPage() {
           return (
             <Link
               key={item.id}
-              href="/content/new"
+              href={`/content/${item.id}`}
               className={styles.contentItem}
+              aria-label={`View details for ${item.title || 'untitled content'}`}
               onClick={() => handleItemClick(item)}
             >
               <div className={styles.contentItemInfo}>
                 <h3 className={styles.contentItemTitle}>{item.title || 'Untitled'}</h3>
                 <div className={styles.contentItemMeta}>
-                  <span>{formatDate(item.createdAt)}</span>
+                  <span>{formatContentDate(item.createdAt)}</span>
                   {item.body && <span>{item.body.length} chars</span>}
                 </div>
               </div>
@@ -175,7 +145,12 @@ export function ContentListPage() {
                     {enabledPlatforms.length} platform{enabledPlatforms.length !== 1 ? 's' : ''}
                   </span>
                 )}
-                <span className={getBadgeClass(item.status)}>{getDisplayStatus(item.status)}</span>
+                <span className={getBadgeClass(item.status)}>
+                  {getContentStatusLabel(item.status, item.schedulerJobIds)}
+                </span>
+                <span className={styles.viewDetails} aria-hidden="true">
+                  View details →
+                </span>
               </div>
             </Link>
           );

--- a/lib/content/local-content.ts
+++ b/lib/content/local-content.ts
@@ -1,0 +1,128 @@
+export type ContentStatus =
+  | 'pending'
+  | 'scheduled'
+  | 'queued'
+  | 'processing'
+  | 'published'
+  | 'failed';
+
+export interface SchedulerJobSnapshot {
+  id: string;
+  contentId: string;
+  status:
+    | 'pending'
+    | 'scheduled'
+    | 'processing'
+    | 'published'
+    | 'failed'
+    | 'dead'
+    | 'reconciliation_required'
+    | 'cancelled';
+}
+
+export interface StoredPlatform {
+  slug: string;
+  name: string;
+  enabled: boolean;
+  hashtags: string;
+}
+
+export interface StoredContent {
+  id: string;
+  title: string;
+  body: string;
+  summary: string;
+  platforms: StoredPlatform[];
+  status: ContentStatus;
+  scheduledTime: string;
+  createdAt: string;
+  updatedAt: string;
+  schedulerJobIds?: string[];
+}
+
+export const CONTENT_STORAGE_KEY = 'omnipost_content_drafts';
+
+export function loadStoredContent(): StoredContent[] {
+  if (typeof window === 'undefined') return [];
+
+  try {
+    const raw = sessionStorage.getItem(CONTENT_STORAGE_KEY);
+    return raw ? (JSON.parse(raw) as StoredContent[]) : [];
+  } catch {
+    return [];
+  }
+}
+
+export function getContentStatusLabel(status: ContentStatus, schedulerJobIds?: string[]): string {
+  if (
+    !schedulerJobIds?.length &&
+    (status === 'scheduled' || status === 'queued' || status === 'processing')
+  ) {
+    return 'Tracking unavailable';
+  }
+
+  switch (status) {
+    case 'queued':
+      return 'Queued';
+    case 'processing':
+      return 'Publishing';
+    case 'scheduled':
+      return 'Scheduled';
+    case 'published':
+      return 'Published';
+    case 'failed':
+      return 'Needs attention';
+    default:
+      return 'Draft';
+  }
+}
+
+export function synchronizeContentStatuses(
+  items: StoredContent[],
+  schedulerJobs: SchedulerJobSnapshot[]
+): StoredContent[] {
+  const jobsById = new Map(schedulerJobs.map(job => [job.id, job]));
+
+  return items.map(item => {
+    const matchingJobs = item.schedulerJobIds
+      ?.map(jobId => jobsById.get(jobId))
+      .filter((job): job is SchedulerJobSnapshot => Boolean(job && job.contentId === item.id));
+
+    if (!matchingJobs?.length || matchingJobs.length !== item.schedulerJobIds?.length) return item;
+
+    const statuses = matchingJobs.map(job => job.status);
+    let status: ContentStatus;
+
+    if (
+      statuses.some(value =>
+        ['failed', 'dead', 'reconciliation_required', 'cancelled'].includes(value)
+      )
+    ) {
+      status = 'failed';
+    } else if (statuses.every(value => value === 'published')) {
+      status = 'published';
+    } else if (statuses.some(value => value === 'processing')) {
+      status = 'processing';
+    } else if (statuses.some(value => value === 'scheduled' || value === 'pending')) {
+      status = 'scheduled';
+    } else {
+      status = item.status;
+    }
+
+    return status === item.status ? item : { ...item, status };
+  });
+}
+
+export function formatContentDate(iso: string, includeTime = false): string {
+  if (!iso) return 'Not scheduled';
+
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return 'Not scheduled';
+
+  return date.toLocaleString(undefined, {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+    ...(includeTime ? { hour: 'numeric', minute: '2-digit' } : {}),
+  });
+}

--- a/styles/ContentDetail.module.css
+++ b/styles/ContentDetail.module.css
@@ -1,0 +1,226 @@
+.page {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-lg);
+  max-width: 900px;
+  margin: 0 auto;
+  width: 100%;
+}
+
+.topBar,
+.header,
+.sectionHeading,
+.actions {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--spacing-md);
+}
+
+.backLink {
+  color: var(--color-text-secondary);
+  font-size: var(--font-size-sm);
+  text-decoration: none;
+}
+
+.backLink:hover {
+  color: var(--color-primary);
+  text-decoration: underline;
+}
+
+.primaryButton,
+.secondaryButton {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 40px;
+  padding: var(--spacing-sm) var(--spacing-lg);
+  border-radius: var(--radius-md);
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-semibold);
+  text-decoration: none;
+}
+
+.primaryButton {
+  background: var(--color-primary);
+  color: var(--color-text-inverse);
+}
+
+.primaryButton:hover {
+  background: var(--color-primary-dark);
+  text-decoration: none;
+}
+
+.secondaryButton {
+  border: 1px solid var(--color-border);
+  color: var(--color-text-heading);
+}
+
+.header {
+  align-items: flex-start;
+  padding: var(--spacing-md) 0;
+}
+
+.eyebrow,
+.panelLabel {
+  margin: 0;
+  color: var(--color-text-muted);
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-semibold);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.header h1,
+.sectionHeading h2,
+.notFound h1 {
+  color: var(--color-text-heading);
+  margin: var(--spacing-xs) 0 0;
+}
+
+.header h1,
+.notFound h1 {
+  font-size: var(--font-size-3xl);
+}
+
+.sectionHeading h2 {
+  font-size: var(--font-size-xl);
+}
+
+.summary {
+  color: var(--color-text-secondary);
+  margin: var(--spacing-sm) 0 0;
+  max-width: 640px;
+}
+
+.status {
+  border-radius: var(--radius-full);
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-semibold);
+  padding: var(--spacing-xs) var(--spacing-md);
+  white-space: nowrap;
+}
+
+.statusDraft {
+  background: var(--color-bg-tertiary);
+  color: var(--color-text-secondary);
+}
+.statusScheduled {
+  background: var(--color-info-light);
+  color: var(--color-info);
+}
+.statusPublished {
+  background: var(--color-success-bg-subtle);
+  color: var(--color-success);
+}
+.statusFailed {
+  background: #fee2e2;
+  color: #b91c1c;
+}
+
+.statusPanel,
+.detailCard,
+.notFound {
+  background: var(--color-bg-card);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+}
+
+.statusPanel {
+  display: grid;
+  gap: var(--spacing-md);
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  padding: var(--spacing-lg);
+}
+
+.panelValue {
+  color: var(--color-text-heading);
+  font-size: var(--font-size-base);
+  font-weight: var(--font-weight-semibold);
+  margin: var(--spacing-xs) 0 0;
+}
+
+.detailCard {
+  padding: var(--spacing-lg);
+}
+
+.characterCount,
+.hashtags {
+  color: var(--color-text-muted);
+  font-size: var(--font-size-sm);
+}
+
+.postBody {
+  color: var(--color-text-heading);
+  line-height: 1.7;
+  margin: var(--spacing-lg) 0 0;
+  white-space: pre-wrap;
+}
+
+.platformList {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--spacing-sm);
+  list-style: none;
+  margin: var(--spacing-lg) 0 0;
+  padding: 0;
+}
+
+.platformItem {
+  align-items: center;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  display: flex;
+  gap: var(--spacing-sm);
+  padding: var(--spacing-sm) var(--spacing-md);
+}
+
+.platformInitial {
+  align-items: center;
+  background: var(--color-primary-light);
+  border-radius: var(--radius-full);
+  color: var(--color-primary);
+  display: inline-flex;
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-bold);
+  height: 24px;
+  justify-content: center;
+  width: 24px;
+}
+
+.emptyPlatforms {
+  color: var(--color-text-secondary);
+  margin: var(--spacing-lg) 0 0;
+}
+
+.notFound {
+  align-items: flex-start;
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-md);
+  padding: var(--spacing-3xl) var(--spacing-lg);
+}
+.notFound p {
+  color: var(--color-text-secondary);
+  margin: 0;
+}
+
+@media (max-width: 640px) {
+  .topBar,
+  .header,
+  .sectionHeading {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+  .statusPanel {
+    grid-template-columns: 1fr;
+  }
+  .actions {
+    align-items: stretch;
+    flex-direction: column;
+    width: 100%;
+  }
+  .actions a {
+    width: 100%;
+  }
+}

--- a/styles/ContentList.module.css
+++ b/styles/ContentList.module.css
@@ -113,6 +113,12 @@
   flex-shrink: 0;
 }
 
+.viewDetails {
+  color: var(--color-primary);
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-semibold);
+}
+
 .platformCount {
   font-size: var(--font-size-xs);
   color: var(--color-text-secondary);
@@ -197,6 +203,7 @@
   }
 
   .contentItemRight {
+    flex-wrap: wrap;
     width: 100%;
     justify-content: space-between;
   }


### PR DESCRIPTION
## What changed

- Route content cards to a dedicated review screen instead of the new-post composer.
- Show post copy, schedule, destinations, character count, and status in the detail view.
- Store stable content and scheduler job IDs for newly created posts, then hydrate status from the authenticated scheduler response.
- Mark older cards without retained job IDs as Tracking unavailable rather than presenting a stale scheduled state.

## Why

Content cards previously always linked to /content/new, and browser-session snapshots could remain scheduled after delivery processing. The new job-ID join makes delivery state explicit without guessing about legacy or controlled posts.

## Validation

- pnpm type-check
- pnpm test -- local-content.test.ts --runInBand (5 passing)
- Focused ESLint and Prettier checks
- pnpm build
