### PR TITLE
Fix content status pagination and schedule details

### DIFF
--- a/__tests__/lib/local-content.test.ts
+++ b/__tests__/lib/local-content.test.ts
@@ -1,4 +1,5 @@
 import {
+  fetchAllSchedulerJobs,
   getContentStatusLabel,
   synchronizeContentStatuses,
   type StoredContent,
@@ -66,5 +67,40 @@ describe('synchronizeContentStatuses', () => {
 
   it('does not present a legacy scheduled status as live tracking', () => {
     expect(getContentStatusLabel('scheduled')).toBe('Tracking unavailable');
+  });
+});
+
+describe('fetchAllSchedulerJobs', () => {
+  const originalFetch = global.fetch;
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  it('loads every scheduler page before deriving content status', async () => {
+    global.fetch = jest
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          jobs: [{ id: 'job-1', contentId: 'content-1', status: 'scheduled' }],
+          total: 2,
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          jobs: [{ id: 'job-2', contentId: 'content-1', status: 'published' }],
+          total: 2,
+        }),
+      });
+
+    await expect(fetchAllSchedulerJobs()).resolves.toHaveLength(2);
+    expect(global.fetch).toHaveBeenNthCalledWith(1, '/api/scheduler?limit=500&offset=0', {
+      signal: undefined,
+    });
+    expect(global.fetch).toHaveBeenNthCalledWith(2, '/api/scheduler?limit=500&offset=1', {
+      signal: undefined,
+    });
   });
 });

--- a/app/(dashboard)/content/[id]/ContentDetail.tsx
+++ b/app/(dashboard)/content/[id]/ContentDetail.tsx
@@ -7,10 +7,10 @@ import { useAuth } from '@/components/providers/AuthProvider';
 import { LoadingSpinner } from '@/components/ui/LoadingSpinner';
 import {
   formatContentDate,
+  fetchAllSchedulerJobs,
   getContentStatusLabel,
   loadStoredContent,
   synchronizeContentStatuses,
-  type SchedulerJobSnapshot,
   type StoredContent,
 } from '@/lib/content/local-content';
 import styles from '@/styles/ContentDetail.module.css';
@@ -49,18 +49,16 @@ export default function ContentDetail({ contentId }: ContentDetailProps) {
 
     if (!stored || !isAuthenticated) return;
 
-    let active = true;
-    void fetch('/api/scheduler?limit=100')
-      .then(async response => {
-        if (!response.ok) return;
-        const payload = (await response.json()) as { jobs?: SchedulerJobSnapshot[] };
-        const synchronized = synchronizeContentStatuses([stored], payload.jobs ?? [])[0];
-        if (active) setContent(synchronized);
+    const controller = new AbortController();
+    void fetchAllSchedulerJobs(controller.signal)
+      .then(jobs => {
+        const synchronized = synchronizeContentStatuses([stored], jobs)[0];
+        if (!controller.signal.aborted) setContent(synchronized);
       })
       .catch(() => undefined);
 
     return () => {
-      active = false;
+      controller.abort();
     };
   }, [contentId, isAuthenticated]);
 
@@ -89,10 +87,7 @@ export default function ContentDetail({ contentId }: ContentDetailProps) {
   }
 
   const platforms = content.platforms.filter(platform => platform.enabled);
-  const hasSchedule =
-    content.status === 'scheduled' ||
-    content.status === 'queued' ||
-    content.status === 'processing';
+  const hasSchedule = Boolean(content.scheduledTime);
 
   return (
     <div className={styles.page}>

--- a/app/(dashboard)/content/page.tsx
+++ b/app/(dashboard)/content/page.tsx
@@ -13,11 +13,11 @@ import { LoadingSpinner } from '@/components/ui/LoadingSpinner';
 import { useAnalytics } from '@/hooks/useAnalytics';
 import {
   formatContentDate,
+  fetchAllSchedulerJobs,
   getContentStatusLabel,
   loadStoredContent,
   synchronizeContentStatuses,
   type ContentStatus,
-  type SchedulerJobSnapshot,
   type StoredContent,
 } from '@/lib/content/local-content';
 import styles from '@/styles/ContentList.module.css';
@@ -60,18 +60,16 @@ export function ContentListPage() {
   useEffect(() => {
     if (!isAuthenticated) return;
 
-    let active = true;
-    void fetch('/api/scheduler?limit=100')
-      .then(async response => {
-        if (!response.ok) return;
-        const payload = (await response.json()) as { jobs?: SchedulerJobSnapshot[] };
-        const jobs = payload.jobs ?? [];
-        if (active) setItems(previous => synchronizeContentStatuses(previous, jobs));
+    const controller = new AbortController();
+    void fetchAllSchedulerJobs(controller.signal)
+      .then(jobs => {
+        if (!controller.signal.aborted)
+          setItems(previous => synchronizeContentStatuses(previous, jobs));
       })
       .catch(() => undefined);
 
     return () => {
-      active = false;
+      controller.abort();
     };
   }, [isAuthenticated]);
 

--- a/lib/content/local-content.ts
+++ b/lib/content/local-content.ts
@@ -20,6 +20,11 @@ export interface SchedulerJobSnapshot {
     | 'cancelled';
 }
 
+interface SchedulerJobsResponse {
+  jobs?: SchedulerJobSnapshot[];
+  total?: number;
+}
+
 export interface StoredPlatform {
   slug: string;
   name: string;
@@ -111,6 +116,24 @@ export function synchronizeContentStatuses(
 
     return status === item.status ? item : { ...item, status };
   });
+}
+
+export async function fetchAllSchedulerJobs(signal?: AbortSignal): Promise<SchedulerJobSnapshot[]> {
+  const jobs: SchedulerJobSnapshot[] = [];
+  const limit = 500;
+  let offset = 0;
+
+  while (true) {
+    const response = await fetch(`/api/scheduler?limit=${limit}&offset=${offset}`, { signal });
+    if (!response.ok) throw new Error('Unable to load scheduler status');
+
+    const payload = (await response.json()) as SchedulerJobsResponse;
+    const page = payload.jobs ?? [];
+    jobs.push(...page);
+
+    if (page.length === 0 || jobs.length >= (payload.total ?? 0)) return jobs;
+    offset += page.length;
+  }
 }
 
 export function formatContentDate(iso: string, includeTime = false): string {


### PR DESCRIPTION
## Follow-up to PR #196

Addresses the two Codex bot findings posted after PR #196 merged.

- Paginate the authenticated scheduler response until its returned total is reached, so cards with retained job IDs are not capped at the first 100 jobs.
- Keep showing a post's publishing time whenever scheduledTime exists, including published and failed states.
- Add paginator coverage alongside the existing status aggregation tests.

## Validation

- pnpm type-check
- pnpm test -- local-content.test.ts --runInBand (6 passing)
- Focused ESLint and Prettier checks
- pnpm build
