### PR TITLE
Add a provider-isolated Pinterest Sandbox contract

### DIFF
--- a/__tests__/api/platforms.test.ts
+++ b/__tests__/api/platforms.test.ts
@@ -111,10 +111,18 @@ describe('Platforms API', () => {
       // Assertions
       expect(response.status).toBe(200);
       expect(Array.isArray(data)).toBe(true);
-      expect(data).toHaveLength(6); // Includes TikTok plus custom channel
+      expect(data).toHaveLength(7); // Includes TikTok, Pinterest Sandbox, and custom channel
       expect(data[0]).toHaveProperty('id', 1);
       expect(data[0]).toHaveProperty('name', 'Facebook');
       expect(data[1]).toHaveProperty('name', 'Instagram'); // Updated order
+      expect(data).toContainEqual(
+        expect.objectContaining({
+          name: 'Pinterest Sandbox',
+          slug: 'pinterest',
+          comingSoon: true,
+          requiresMedia: true,
+        })
+      );
       expect(data[2]).toHaveProperty('name', 'LinkedIn');
       expect(data[4]).toHaveProperty('name', 'TikTok');
     });

--- a/__tests__/lib/pinterest-sandbox.test.ts
+++ b/__tests__/lib/pinterest-sandbox.test.ts
@@ -1,0 +1,94 @@
+import {
+  PINTEREST_SANDBOX_API_URL,
+  PinterestSandboxApiError,
+  PinterestSandboxClient,
+} from '@/lib/platforms/pinterest/sandbox';
+
+describe('Pinterest Sandbox client', () => {
+  const config = { accessToken: 'sandbox-token', boardId: 'board-123' };
+
+  function jsonResponse(payload: unknown, status = 200): Response {
+    return {
+      ok: status >= 200 && status < 300,
+      status,
+      statusText: status === 403 ? 'Forbidden' : 'OK',
+      json: async () => payload,
+      clone: () => jsonResponse(payload, status),
+    } as Response;
+  }
+
+  test('creates an image Pin only against the sandbox host', async () => {
+    const request = jest.fn() as jest.MockedFunction<typeof fetch>;
+    request.mockResolvedValue(jsonResponse({ id: 'pin-123', link: 'https://example.com' }, 201));
+
+    await expect(
+      new PinterestSandboxClient(config, request).createPin({
+        title: 'Sandbox contract',
+        description: 'Provider-isolated test',
+        imageUrl: 'https://cdn.example.com/test.png',
+      })
+    ).resolves.toEqual({ id: 'pin-123', link: 'https://example.com' });
+
+    expect(request).toHaveBeenCalledWith(
+      `${PINTEREST_SANDBOX_API_URL}/pins`,
+      expect.objectContaining({
+        method: 'POST',
+        headers: {
+          Authorization: 'Bearer sandbox-token',
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          board_id: 'board-123',
+          title: 'Sandbox contract',
+          description: 'Provider-isolated test',
+          media_source: {
+            source_type: 'image_url',
+            url: 'https://cdn.example.com/test.png',
+          },
+        }),
+      })
+    );
+  });
+
+  test('supports read and cleanup without switching to production', async () => {
+    const request = jest.fn() as jest.MockedFunction<typeof fetch>;
+    request
+      .mockResolvedValueOnce(jsonResponse({ id: 'pin-123' }))
+      .mockResolvedValueOnce(jsonResponse(null, 204));
+    const client = new PinterestSandboxClient(config, request);
+
+    await expect(client.getPin('pin-123')).resolves.toEqual({ id: 'pin-123' });
+    await expect(client.deletePin('pin-123')).resolves.toBeUndefined();
+    expect(request.mock.calls.map(([url]) => url)).toEqual([
+      `${PINTEREST_SANDBOX_API_URL}/pins/pin-123`,
+      `${PINTEREST_SANDBOX_API_URL}/pins/pin-123`,
+    ]);
+  });
+
+  test('preserves provider status without exposing credentials', async () => {
+    const request = jest.fn() as jest.MockedFunction<typeof fetch>;
+    request.mockResolvedValue(jsonResponse({ message: 'Trial access required' }, 403));
+
+    const operation = new PinterestSandboxClient(config, request).createPin({
+      title: 'Sandbox contract',
+      description: 'Provider-isolated test',
+      imageUrl: 'https://cdn.example.com/test.png',
+    });
+
+    await expect(operation).rejects.toBeInstanceOf(PinterestSandboxApiError);
+    await expect(operation).rejects.toMatchObject({ response: { status: 403 } });
+    await expect(operation).rejects.not.toThrow('sandbox-token');
+  });
+
+  test('rejects non-HTTPS media before contacting Pinterest', async () => {
+    const request = jest.fn() as jest.MockedFunction<typeof fetch>;
+    await expect(
+      new PinterestSandboxClient(config, request).createPin({
+        title: 'Sandbox contract',
+        description: 'Provider-isolated test',
+        imageUrl: 'http://cdn.example.com/test.png',
+      })
+    ).rejects.toThrow('Pinterest media URL must use HTTPS');
+    expect(request).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/lib/scheduler-adapters.test.ts
+++ b/__tests__/lib/scheduler-adapters.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, jest, test } from '@jest/globals';
-import { getAdapter, TwitterAdapter } from '../../lib/scheduler/adapters';
+import { getAdapter, PinterestSandboxAdapter, TwitterAdapter } from '../../lib/scheduler/adapters';
+import type { PinterestSandboxClient } from '@/lib/platforms/pinterest/sandbox';
 import { platformConfigurations, platforms } from '../../lib/config/platforms';
 
 const originalNodeEnv = process.env.NODE_ENV;
@@ -79,8 +80,38 @@ describe('Scheduler platform adapters', () => {
       'facebook',
       'instagram',
       'linkedin',
+      'pinterest',
       'tiktok',
     ]);
+  });
+
+  test('Pinterest Sandbox requires media and retains sandbox evidence', async () => {
+    const createPin = jest.fn(async () => ({ id: 'pin-123' }));
+    const adapter = new PinterestSandboxAdapter({ createPin } as unknown as PinterestSandboxClient);
+
+    expect(adapter.validateContent({ text: 'Image-free Pin' })).toMatchObject({
+      valid: false,
+      errors: expect.arrayContaining(['Pinterest Sandbox posts require an image URL']),
+    });
+
+    await expect(
+      adapter.publish({
+        text: 'Sandbox-only Pin',
+        mediaUrls: ['https://cdn.example.com/test.png'],
+        hashtags: ['OmniPost'],
+      })
+    ).resolves.toEqual(
+      expect.objectContaining({
+        id: 'pin-123',
+        url: 'https://www.pinterest.com/pin/pin-123/',
+        platformData: { id: 'pin-123', environment: 'sandbox' },
+      })
+    );
+    expect(createPin).toHaveBeenCalledWith({
+      title: 'Sandbox-only Pin',
+      description: 'Sandbox-only Pin\n\n#OmniPost',
+      imageUrl: 'https://cdn.example.com/test.png',
+    });
   });
 
   test('X publishes through the v2 create-post contract and returns an X URL', async () => {

--- a/app/(marketing)/privacy/page.tsx
+++ b/app/(marketing)/privacy/page.tsx
@@ -1,0 +1,168 @@
+import type { Metadata } from 'next';
+import styles from '@/styles/Privacy.module.css';
+
+export const metadata: Metadata = {
+  title: 'Privacy Policy | OmniPost',
+  description: 'How OmniPost collects, uses, protects, and shares personal information.',
+};
+
+const EFFECTIVE_DATE = '28 July 2026';
+
+export default function PrivacyPage() {
+  return (
+    <article className={styles.page}>
+      <div className={styles.container}>
+        <header className={styles.header}>
+          <p className={styles.eyebrow}>Legal</p>
+          <h1>Privacy Policy</h1>
+          <p className={styles.updated}>Effective {EFFECTIVE_DATE}</p>
+          <p className={styles.intro}>
+            This policy explains how OmniPost collects, uses, stores, and shares information when
+            you use our website and social publishing service.
+          </p>
+        </header>
+
+        <section>
+          <h2>Information we collect</h2>
+          <p>We collect information in the following categories:</p>
+          <ul>
+            <li>
+              <strong>Account information:</strong> your username, email address, authentication
+              information, and account role.
+            </li>
+            <li>
+              <strong>Content and workflow information:</strong> drafts, campaign details,
+              schedules, approvals, publishing results, and other content you choose to provide.
+            </li>
+            <li>
+              <strong>Connected-platform information:</strong> account identifiers, permissions, and
+              access credentials supplied through a platform authorisation flow. Provider
+              credentials are encrypted before storage and are not returned through our APIs.
+            </li>
+            <li>
+              <strong>Usage and security information:</strong> product events, request metadata, IP
+              address, browser or device information, and audit records used to operate and protect
+              the service.
+            </li>
+            <li>
+              <strong>Support and contact information:</strong> information you send when you ask
+              for support, submit a form, or communicate with us.
+            </li>
+          </ul>
+        </section>
+
+        <section>
+          <h2>Cookies and similar technologies</h2>
+          <p>
+            OmniPost uses cookies and similar browser storage where needed to keep you signed in,
+            protect authorisation flows, remember service state, and understand product usage. You
+            can control cookies through your browser, but blocking essential cookies may prevent
+            parts of the service from working.
+          </p>
+        </section>
+
+        <section>
+          <h2>How we use information</h2>
+          <p>We use information to:</p>
+          <ul>
+            <li>provide, secure, maintain, and improve OmniPost;</li>
+            <li>authenticate users and keep accounts separated;</li>
+            <li>adapt, schedule, publish, and track content at your direction;</li>
+            <li>connect to third-party platforms you authorise;</li>
+            <li>measure service reliability and investigate abuse or security incidents; and</li>
+            <li>respond to support requests and comply with legal obligations.</li>
+          </ul>
+        </section>
+
+        <section>
+          <h2>Third-party platforms and service providers</h2>
+          <p>
+            When you connect a social platform, OmniPost sends and receives information through that
+            platform&apos;s API according to the permissions you grant. Your use of that platform
+            remains subject to its own terms and privacy policy. We also use infrastructure,
+            database, authentication, email, monitoring, and AI service providers to operate
+            OmniPost. Those providers process information under their own agreements and privacy
+            commitments while helping us deliver the service.
+          </p>
+        </section>
+
+        <section>
+          <h2>Sharing</h2>
+          <p>
+            We do not sell personal information. We share information with service providers and
+            connected platforms as described above, when you direct us to do so, when required by
+            law, or when necessary to protect OmniPost, our users, or others. If OmniPost is
+            involved in a merger, acquisition, financing, or sale of assets, information may be
+            transferred as part of that transaction subject to applicable law.
+          </p>
+        </section>
+
+        <section>
+          <h2>Retention and deletion</h2>
+          <p>
+            We retain information for as long as needed to provide the service, meet legal and
+            security obligations, resolve disputes, and enforce agreements. Retention periods vary
+            by data type and operational need. You can disconnect a platform to revoke
+            OmniPost&apos;s access. To request account or data deletion, email us at the address
+            below.
+          </p>
+        </section>
+
+        <section>
+          <h2>Security</h2>
+          <p>
+            We use administrative, technical, and organisational safeguards designed to protect
+            information. No online service can guarantee absolute security, so please use a strong
+            password and protect access to your accounts.
+          </p>
+        </section>
+
+        <section>
+          <h2>Your choices and rights</h2>
+          <p>
+            Depending on where you live, you may have rights to access, correct, delete, restrict,
+            or receive a copy of your personal information, or to object to certain processing. You
+            may also withdraw a connected platform&apos;s permission through OmniPost or that
+            platform. Contact us to make a request. We may need to verify your identity before
+            completing it.
+          </p>
+        </section>
+
+        <section>
+          <h2>International processing</h2>
+          <p>
+            OmniPost and its providers may process information in countries other than the one where
+            you live. Where required, we use appropriate safeguards for international data
+            transfers.
+          </p>
+        </section>
+
+        <section>
+          <h2>Children</h2>
+          <p>
+            OmniPost is not directed to children under 13, and we do not knowingly collect their
+            personal information. If you believe a child has provided information to us, please
+            contact us.
+          </p>
+        </section>
+
+        <section>
+          <h2>Changes to this policy</h2>
+          <p>
+            We may update this policy as OmniPost changes. We will post the updated policy here and
+            revise the effective date. If a change materially affects your rights, we will provide
+            additional notice where required.
+          </p>
+        </section>
+
+        <section>
+          <h2>Contact</h2>
+          <p>
+            Questions or privacy requests can be sent to{' '}
+            <a href="mailto:omniposthq@gmail.com">omniposthq@gmail.com</a>.
+          </p>
+        </section>
+      </div>
+    </article>
+  );
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -7,7 +7,7 @@ import type { MetadataRoute } from 'next';
 
 const BASE_URL =
   process.env.NEXT_PUBLIC_SITE_URL || 'https://nl-dev-omnipost-web.azurewebsites.net';
-const lastModified = new Date('2026-03-30');
+const lastModified = new Date('2026-07-28');
 
 export default function sitemap(): MetadataRoute.Sitemap {
   return [
@@ -22,6 +22,12 @@ export default function sitemap(): MetadataRoute.Sitemap {
       lastModified,
       changeFrequency: 'monthly',
       priority: 0.9,
+    },
+    {
+      url: `${BASE_URL}/privacy`,
+      lastModified,
+      changeFrequency: 'yearly',
+      priority: 0.4,
     },
     {
       url: `${BASE_URL}/signup`,

--- a/docs/runbooks/PINTEREST_SANDBOX.md
+++ b/docs/runbooks/PINTEREST_SANDBOX.md
@@ -1,0 +1,43 @@
+# Pinterest Sandbox integration proof
+
+Pinterest's API v5 Sandbox is a provider-operated test data plane. Sandbox
+tokens cannot be used in production, and Sandbox Pins and boards remain
+separate from production entities. Treat this as provider contract evidence,
+not proof that OmniPost can publish a public production Pin.
+
+## Operator prerequisites
+
+1. Create or use an OmniPost-owned Pinterest business account.
+2. Create a Pinterest developer app and obtain Trial or Standard access.
+3. Generate a Sandbox access token in the app's Configure tab.
+4. Create a non-group Sandbox board owned by the same account.
+5. Select a public HTTPS image URL containing no secrets or personal data.
+
+Never commit the token. Store deployed values as secret references.
+
+## Controlled smoke
+
+Set these values only in the staffed shell:
+
+- `PINTEREST_SANDBOX_ACCESS_TOKEN`
+- `PINTEREST_SANDBOX_BOARD_ID`
+- `PINTEREST_SANDBOX_IMAGE_URL`
+
+Run `pnpm smoke:pinterest-sandbox`. The script creates a Sandbox Pin, reads it
+back by ID, prints nonsecret JSON evidence, and deletes it in `finally`.
+
+Set `PINTEREST_SANDBOX_RETAIN_PIN=true` only when the staffed operator explicitly
+needs temporary visual evidence. Delete the retained Pin after capture.
+
+## Acceptance boundary
+
+Record the result as `provider_sandbox`, never `live_publish`. Do not enable the
+Pinterest card for ordinary scheduling until OAuth, encrypted tenant-scoped
+tokens, disconnect/revocation, idempotency, and production access are separately
+implemented and accepted.
+
+Official references:
+
+- [Pinterest API Sandbox](https://developers.pinterest.com/docs/developer-tools/sandbox/)
+- [Pinterest access tiers](https://developers.pinterest.com/docs/key-concepts/access-tiers/)
+- [Create Pin](https://developers.pinterest.com/docs/api/v5/pins-create/)

--- a/lib/config/platforms.ts
+++ b/lib/config/platforms.ts
@@ -57,6 +57,15 @@ export const platforms: Platform[] = [
   },
   {
     id: 6,
+    name: 'Pinterest Sandbox',
+    slug: 'pinterest',
+    description: 'Pinterest provider-operated sandbox',
+    defaultContentFlow: false,
+    requiresMedia: true,
+    comingSoon: true,
+  },
+  {
+    id: 7,
     name: 'Custom Channel',
     slug: 'custom-channel',
     description: 'Custom publishing channel',
@@ -97,6 +106,12 @@ export const platformConfigurations: Record<string, PlatformConfig> = {
     apiKey: process.env.TIKTOK_API_KEY || '',
     required: true,
     capabilities: ['video'],
+  },
+  pinterest: {
+    apiUrl: 'https://api-sandbox.pinterest.com/v5/pins',
+    apiKey: '',
+    required: false,
+    capabilities: ['image'],
   },
   'custom-channel': {
     apiUrl: 'https://api.customchannel.com/publish',

--- a/lib/platforms/pinterest/sandbox.ts
+++ b/lib/platforms/pinterest/sandbox.ts
@@ -1,0 +1,137 @@
+import { z } from 'zod';
+
+export const PINTEREST_SANDBOX_API_URL = 'https://api-sandbox.pinterest.com/v5';
+const PINTEREST_SANDBOX_TIMEOUT_MS = 15_000;
+
+const sandboxConfigSchema = z.object({
+  accessToken: z.string().trim().min(1),
+  boardId: z.string().trim().min(1),
+});
+
+const imageUrlSchema = z
+  .string()
+  .url()
+  .refine(value => new URL(value).protocol === 'https:', 'Pinterest media URL must use HTTPS');
+
+const createPinResponseSchema = z.object({
+  id: z.string().min(1),
+  link: z.string().optional(),
+});
+
+const getPinResponseSchema = z.object({
+  id: z.string().min(1),
+});
+
+export interface PinterestSandboxConfig {
+  accessToken: string;
+  boardId: string;
+}
+
+export interface PinterestSandboxPinInput {
+  title: string;
+  description: string;
+  imageUrl: string;
+  link?: string;
+}
+
+export interface PinterestSandboxPin {
+  id: string;
+  link?: string;
+}
+
+export class PinterestSandboxApiError extends Error {
+  readonly response: { status: number; data?: { message?: string } };
+
+  constructor(status: number, message?: string) {
+    super(
+      message
+        ? `Pinterest Sandbox API error: ${status} - ${message}`
+        : `Pinterest Sandbox API error: ${status}`
+    );
+    this.name = 'PinterestSandboxApiError';
+    this.response = { status, data: message ? { message } : undefined };
+  }
+}
+
+function configuredValue(name: 'PINTEREST_SANDBOX_ACCESS_TOKEN' | 'PINTEREST_SANDBOX_BOARD_ID') {
+  return (process.env[name] ?? process.env[`CUSTOMCONNSTR_${name}`])?.trim();
+}
+
+export function getPinterestSandboxConfig(): PinterestSandboxConfig {
+  return sandboxConfigSchema.parse({
+    accessToken: configuredValue('PINTEREST_SANDBOX_ACCESS_TOKEN'),
+    boardId: configuredValue('PINTEREST_SANDBOX_BOARD_ID'),
+  });
+}
+
+export function isPinterestSandboxConfigured(): boolean {
+  return sandboxConfigSchema.safeParse({
+    accessToken: configuredValue('PINTEREST_SANDBOX_ACCESS_TOKEN'),
+    boardId: configuredValue('PINTEREST_SANDBOX_BOARD_ID'),
+  }).success;
+}
+
+async function providerMessage(response: Response): Promise<string | undefined> {
+  const payload = (await response
+    .clone()
+    .json()
+    .catch(() => null)) as { message?: unknown } | null;
+  return typeof payload?.message === 'string' ? payload.message : response.statusText || undefined;
+}
+
+export class PinterestSandboxClient {
+  constructor(
+    private readonly config: PinterestSandboxConfig = getPinterestSandboxConfig(),
+    private readonly request: typeof fetch = fetch
+  ) {}
+
+  async createPin(input: PinterestSandboxPinInput): Promise<PinterestSandboxPin> {
+    const imageUrl = imageUrlSchema.parse(input.imageUrl);
+    const response = await this.call('/pins', {
+      method: 'POST',
+      body: JSON.stringify({
+        board_id: this.config.boardId,
+        title: input.title.slice(0, 100),
+        description: input.description.slice(0, 800),
+        link: input.link,
+        media_source: {
+          source_type: 'image_url',
+          url: imageUrl,
+        },
+      }),
+    });
+
+    return createPinResponseSchema.parse(await response.json());
+  }
+
+  async getPin(pinId: string): Promise<PinterestSandboxPin> {
+    const response = await this.call(`/pins/${encodeURIComponent(pinId)}`, { method: 'GET' });
+    return getPinResponseSchema.parse(await response.json());
+  }
+
+  async deletePin(pinId: string): Promise<void> {
+    await this.call(`/pins/${encodeURIComponent(pinId)}`, { method: 'DELETE' });
+  }
+
+  private async call(path: string, init: RequestInit): Promise<Response> {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), PINTEREST_SANDBOX_TIMEOUT_MS);
+    try {
+      const response = await this.request(`${PINTEREST_SANDBOX_API_URL}${path}`, {
+        ...init,
+        headers: {
+          Authorization: `Bearer ${this.config.accessToken}`,
+          'Content-Type': 'application/json',
+        },
+        cache: 'no-store',
+        signal: controller.signal,
+      });
+      if (!response.ok) {
+        throw new PinterestSandboxApiError(response.status, await providerMessage(response));
+      }
+      return response;
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+}

--- a/lib/scheduler/adapters.ts
+++ b/lib/scheduler/adapters.ts
@@ -12,6 +12,7 @@ import {
 } from './types';
 import { getPlatformConfig } from '@/lib/config/platforms';
 import { getValidXAccessToken } from '@/lib/platforms/x/repository';
+import { PinterestSandboxClient } from '@/lib/platforms/pinterest/sandbox';
 import { generatePlatformPostId } from '@/lib/utils/id';
 
 /**
@@ -616,6 +617,57 @@ export class TikTokAdapter extends BasePlatformAdapter {
 }
 
 /**
+ * Pinterest's provider-operated sandbox. This adapter intentionally cannot be
+ * pointed at the production API host.
+ */
+export class PinterestSandboxAdapter extends BasePlatformAdapter {
+  platformId = 'pinterest';
+
+  constructor(private readonly client?: PinterestSandboxClient) {
+    super();
+  }
+
+  getMaxLength(): number {
+    return 800;
+  }
+
+  async publish(content: ScheduledJob['content']): Promise<PlatformPublishResult> {
+    const imageUrl = content.mediaUrls?.[0];
+    if (!imageUrl) throw new Error('Pinterest Sandbox posts require an image URL');
+
+    const pin = await (this.client ?? new PinterestSandboxClient()).createPin({
+      title: content.text,
+      description: this.formatContent(content),
+      imageUrl,
+    });
+
+    return {
+      id: pin.id,
+      url: `https://www.pinterest.com/pin/${pin.id}/`,
+      platformData: { ...pin, environment: 'sandbox' },
+    };
+  }
+
+  validateContent(content: ScheduledJob['content']): ValidationResult {
+    const result = super.validateContent(content);
+    if (!content.mediaUrls?.[0]) {
+      result.errors.push('Pinterest Sandbox posts require an image URL');
+      result.valid = false;
+    }
+    return result;
+  }
+
+  private formatContent(content: ScheduledJob['content']): string {
+    const hashtags = content.hashtags?.map(value => (value.startsWith('#') ? value : `#${value}`));
+    return hashtags?.length ? `${content.text}\n\n${hashtags.join(' ')}` : content.text;
+  }
+
+  protected getMockUrl(postId: string): string {
+    return `https://www.pinterest.com/pin/${postId}/`;
+  }
+}
+
+/**
  * Adapter registry
  */
 const adapters = new Map<string, PlatformAdapter>();
@@ -624,6 +676,7 @@ adapters.set('linkedin', new LinkedInAdapter());
 adapters.set('facebook', new FacebookAdapter());
 adapters.set('instagram', new InstagramAdapter());
 adapters.set('tiktok', new TikTokAdapter());
+adapters.set('pinterest', new PinterestSandboxAdapter());
 
 /**
  * Get adapter for a platform

--- a/lib/scheduler/types.ts
+++ b/lib/scheduler/types.ts
@@ -134,6 +134,7 @@ export const RATE_LIMITS: Record<string, RateLimitConfig> = {
   linkedin: { requests: 100, window: 86400 }, // 100/day
   facebook: { requests: 200, window: 3600 }, // 200/hour
   instagram: { requests: 200, window: 3600 }, // 200/hour
+  pinterest: { requests: 50, window: 3600 }, // Conservative local guard; provider headers remain authoritative
   'custom-channel': { requests: 1000, window: 3600 }, // 1000/hour
 };
 

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "test:coverage": "jest --coverage",
     "renovate:verify": "npx --yes --package renovate -- renovate-config-validator --strict",
     "marketing:validate": "node scripts/validate-marketing-contracts.mjs",
+    "smoke:pinterest-sandbox": "node scripts/pinterest-sandbox-smoke.mjs",
     "db:generate": "prisma generate",
     "db:migrate": "prisma migrate dev",
     "db:migrate:deploy": "prisma migrate deploy",

--- a/scripts/pinterest-sandbox-smoke.mjs
+++ b/scripts/pinterest-sandbox-smoke.mjs
@@ -1,0 +1,65 @@
+const apiUrl = 'https://api-sandbox.pinterest.com/v5';
+const accessToken = process.env.PINTEREST_SANDBOX_ACCESS_TOKEN?.trim();
+const boardId = process.env.PINTEREST_SANDBOX_BOARD_ID?.trim();
+const imageUrl = process.env.PINTEREST_SANDBOX_IMAGE_URL?.trim();
+const retainPin = process.env.PINTEREST_SANDBOX_RETAIN_PIN === 'true';
+
+if (!accessToken || !boardId || !imageUrl) {
+  throw new Error(
+    'PINTEREST_SANDBOX_ACCESS_TOKEN, PINTEREST_SANDBOX_BOARD_ID, and PINTEREST_SANDBOX_IMAGE_URL are required'
+  );
+}
+
+if (new URL(imageUrl).protocol !== 'https:') {
+  throw new Error('PINTEREST_SANDBOX_IMAGE_URL must use HTTPS');
+}
+
+async function request(path, init) {
+  const response = await fetch(`${apiUrl}${path}`, {
+    ...init,
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+      'Content-Type': 'application/json',
+    },
+  });
+  if (!response.ok) {
+    throw new Error(`Pinterest Sandbox request failed: ${response.status}`);
+  }
+  return response;
+}
+
+let pinId;
+try {
+  const create = await request('/pins', {
+    method: 'POST',
+    body: JSON.stringify({
+      board_id: boardId,
+      title: 'OmniPost sandbox contract',
+      description: 'Controlled provider-isolated integration test',
+      media_source: { source_type: 'image_url', url: imageUrl },
+    }),
+  });
+  const created = await create.json();
+  if (typeof created.id !== 'string' || !created.id) {
+    throw new Error('Pinterest Sandbox create response did not include a Pin ID');
+  }
+  pinId = created.id;
+
+  const read = await request(`/pins/${encodeURIComponent(pinId)}`, { method: 'GET' });
+  const fetched = await read.json();
+  if (fetched.id !== pinId) throw new Error('Pinterest Sandbox read-back ID did not match');
+
+  console.log(
+    JSON.stringify({
+      provider: 'pinterest',
+      environment: 'sandbox',
+      contract: 'create-read',
+      pinId,
+      retained: retainPin,
+    })
+  );
+} finally {
+  if (pinId && !retainPin) {
+    await request(`/pins/${encodeURIComponent(pinId)}`, { method: 'DELETE' });
+  }
+}

--- a/styles/Privacy.module.css
+++ b/styles/Privacy.module.css
@@ -1,0 +1,101 @@
+.page {
+  padding: 8rem 1.5rem 5rem;
+  background:
+    radial-gradient(circle at top right, rgb(124 58 237 / 10%), transparent 30rem), #f8fafc;
+  color: #172033;
+}
+
+.container {
+  width: min(100%, 52rem);
+  margin: 0 auto;
+  padding: 3rem;
+  border: 1px solid #e2e8f0;
+  border-radius: 1.25rem;
+  background: #ffffff;
+  box-shadow: 0 1.5rem 4rem rgb(15 23 42 / 8%);
+}
+
+.header {
+  padding-bottom: 2rem;
+  border-bottom: 1px solid #e2e8f0;
+}
+
+.eyebrow {
+  margin: 0 0 0.75rem;
+  color: #6d28d9;
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.header h1 {
+  margin: 0;
+  color: #111827;
+  font-size: clamp(2.25rem, 7vw, 3.5rem);
+  line-height: 1.05;
+}
+
+.updated {
+  margin: 0.8rem 0 0;
+  color: #64748b;
+  font-size: 0.95rem;
+}
+
+.intro {
+  max-width: 44rem;
+  margin: 1.5rem 0 0;
+  color: #334155;
+  font-size: 1.15rem;
+  line-height: 1.75;
+}
+
+.container section {
+  padding-top: 2rem;
+}
+
+.container h2 {
+  margin: 0 0 0.75rem;
+  color: #1e293b;
+  font-size: 1.35rem;
+}
+
+.container p,
+.container li {
+  color: #475569;
+  line-height: 1.75;
+}
+
+.container p {
+  margin: 0;
+}
+
+.container ul {
+  margin: 0.75rem 0 0;
+  padding-left: 1.35rem;
+}
+
+.container li + li {
+  margin-top: 0.6rem;
+}
+
+.container strong {
+  color: #334155;
+}
+
+.container a {
+  color: #6d28d9;
+  font-weight: 600;
+  text-decoration: underline;
+  text-underline-offset: 0.18em;
+}
+
+@media (max-width: 640px) {
+  .page {
+    padding: 6.5rem 1rem 3rem;
+  }
+
+  .container {
+    padding: 1.75rem;
+  }
+}


### PR DESCRIPTION
## What changed

- add a Pinterest Sandbox platform entry and image-only scheduler adapter
- hard-code the provider client to `https://api-sandbox.pinterest.com/v5` so this slice cannot target production
- validate HTTPS media and Zod-validate configuration/provider responses
- preserve provider HTTP status metadata without exposing tokens
- add create/read/delete client coverage and adapter tests
- add `pnpm smoke:pinterest-sandbox`, which creates and reads a Sandbox Pin and deletes it in `finally` by default
- publish the previously missing `/privacy` route required for a Pinterest app request and add it to the sitemap
- document account, Trial approval, sandbox token, board, evidence, and cleanup boundaries

## Why

X's API Playground is a local mock and cannot prove real provider authentication or write behavior. Pinterest offers a separate provider-operated API v5 Sandbox with sandbox-specific tokens and Pin/board CRUD isolated from production data. This gives OmniPost a credible no-public-side-effect integration surface while X production acceptance remains blocked on credits.

Pinterest also requires a public privacy-policy URL before an app request can be submitted. OmniPost's footer already linked to `/privacy`, but production returned 404. This PR closes that public trust and registration gap with a plain-language policy grounded in the current implementation.

## Validation

- `pnpm run marketing:validate`: passed
- `pnpm exec tsc --noEmit --incremental false`: passed
- full ESLint: 0 errors (existing warnings only)
- `pnpm format:check`: passed
- `pnpm test -- --runInBand`: 45 suites / 329 tests passed; 2 suites / 11 tests skipped
- `pnpm build`: passed and statically generated `/privacy`
- `git diff --check`: passed

`pnpm check-all` reached TypeScript and encountered a Windows `EPERM` lock on `tsconfig.tsbuildinfo` from an earlier timed-out process. The equivalent type-check with incremental output disabled and every remaining gate passed independently.

## Acceptance boundary

This PR does not contain a token and does not claim a live provider call. Pinterest remains `comingSoon` in ordinary scheduling. A staffed sandbox smoke requires:

1. explicit approval of the privacy-policy wording and deployment of this PR;
2. human completion of Pinterest's reCAPTCHA and final app-request submission;
3. Pinterest Trial approval;
4. a 30-day sandbox token, a non-group sandbox board, and a public non-sensitive HTTPS test image.

Record resulting evidence as `provider_sandbox`, never `live_publish`.
