### PR TITLE
Add exact release evidence verification

### DIFF
--- a/.github/workflows/azure-webapps-node.yml
+++ b/.github/workflows/azure-webapps-node.yml
@@ -75,6 +75,8 @@ jobs:
           pnpm run db:migrate:deploy
           pnpm test
         env:
+          APP_COMMIT: ${{ github.sha }}
+          APP_ENVIRONMENT: ${{ github.event.inputs.environment || 'dev' }}
           JWT_SECRET: test-secret-key-for-deployment-ci
           DATABASE_URL: postgresql://omnipost:omnipost@localhost:5432/omnipost_ci?sslmode=disable
 
@@ -282,6 +284,9 @@ jobs:
           package: node-app.zip
 
       - name: Verify deployment health
+        env:
+          EXPECTED_COMMIT: ${{ github.sha }}
+          EXPECTED_ENVIRONMENT: ${{ github.event.inputs.environment || 'dev' }}
         run: |
           echo "Waiting 30 seconds for app to start..."
           sleep 30
@@ -293,15 +298,21 @@ jobs:
           RETRY_COUNT=0
 
           while [ $RETRY_COUNT -lt $MAX_RETRIES ]; do
-            HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" "${APP_URL}/api/health" || echo "000")
-            
-            if [ "$HTTP_CODE" = "200" ]; then
-              echo "✅ Health check passed! App is running."
-              curl -s "${APP_URL}/api/health" | jq .
+            HEALTH_RESPONSE=$(curl --silent --show-error --fail "${APP_URL}/api/health" || true)
+            ACTUAL_COMMIT=$(jq -r '.commit // empty' <<<"$HEALTH_RESPONSE")
+            ACTUAL_ENVIRONMENT=$(jq -r '.environment // empty' <<<"$HEALTH_RESPONSE")
+            VERSION=$(jq -r '.version // empty' <<<"$HEALTH_RESPONSE")
+            BUILT_AT=$(jq -r '.builtAt // empty' <<<"$HEALTH_RESPONSE")
+
+            if [ "$ACTUAL_COMMIT" = "$EXPECTED_COMMIT" ] && \
+               [ "$ACTUAL_ENVIRONMENT" = "$EXPECTED_ENVIRONMENT" ] && \
+               [ -n "$VERSION" ] && [ -n "$BUILT_AT" ]; then
+              echo "✅ Health check passed for the expected deployment artifact."
+              jq '{status, version, commit, builtAt, environment}' <<<"$HEALTH_RESPONSE"
               exit 0
             else
               RETRY_COUNT=$((RETRY_COUNT + 1))
-              echo "⚠️  Attempt $RETRY_COUNT/$MAX_RETRIES: Health check returned $HTTP_CODE"
+              echo "⚠️  Attempt $RETRY_COUNT/$MAX_RETRIES: expected $EXPECTED_ENVIRONMENT/$EXPECTED_COMMIT, observed ${ACTUAL_ENVIRONMENT:-missing}/${ACTUAL_COMMIT:-missing}"
               if [ $RETRY_COUNT -lt $MAX_RETRIES ]; then
                 echo "Retrying in 10 seconds..."
                 sleep 10
@@ -309,7 +320,7 @@ jobs:
             fi
           done
 
-          echo "❌ Health check failed after $MAX_RETRIES attempts"
+          echo "❌ Expected deployment artifact was not verified after $MAX_RETRIES attempts"
           echo "Deployment may have issues. Check Azure logs:"
           echo "az webapp log tail --name ${{ env.APP_NAME }} --resource-group ${{ env.RESOURCE_GROUP }}"
           exit 1

--- a/.github/workflows/azure-webapps-node.yml
+++ b/.github/workflows/azure-webapps-node.yml
@@ -299,16 +299,17 @@ jobs:
 
           while [ $RETRY_COUNT -lt $MAX_RETRIES ]; do
             HEALTH_RESPONSE=$(curl --silent --show-error --fail "${APP_URL}/api/health" || true)
-            ACTUAL_COMMIT=$(jq -r '.commit // empty' <<<"$HEALTH_RESPONSE")
-            ACTUAL_ENVIRONMENT=$(jq -r '.environment // empty' <<<"$HEALTH_RESPONSE")
-            VERSION=$(jq -r '.version // empty' <<<"$HEALTH_RESPONSE")
-            BUILT_AT=$(jq -r '.builtAt // empty' <<<"$HEALTH_RESPONSE")
+            HEALTH_JSON=$(jq -c 'if type == "object" then . else {} end' <<<"$HEALTH_RESPONSE" 2>/dev/null || echo '{}')
+            ACTUAL_COMMIT=$(jq -r '.commit // empty' <<<"$HEALTH_JSON")
+            ACTUAL_ENVIRONMENT=$(jq -r '.environment // empty' <<<"$HEALTH_JSON")
+            VERSION=$(jq -r '.version // empty' <<<"$HEALTH_JSON")
+            BUILT_AT=$(jq -r '.builtAt // empty' <<<"$HEALTH_JSON")
 
             if [ "$ACTUAL_COMMIT" = "$EXPECTED_COMMIT" ] && \
                [ "$ACTUAL_ENVIRONMENT" = "$EXPECTED_ENVIRONMENT" ] && \
-               [ -n "$VERSION" ] && [ -n "$BUILT_AT" ]; then
+              [ -n "$VERSION" ] && [ -n "$BUILT_AT" ]; then
               echo "✅ Health check passed for the expected deployment artifact."
-              jq '{status, version, commit, builtAt, environment}' <<<"$HEALTH_RESPONSE"
+              jq '{status, version, commit, builtAt, environment}' <<<"$HEALTH_JSON"
               exit 0
             else
               RETRY_COUNT=$((RETRY_COUNT + 1))

--- a/__tests__/api/health.test.ts
+++ b/__tests__/api/health.test.ts
@@ -64,10 +64,30 @@ describe('GET /api/health', () => {
       expect(data.status).toBe('healthy');
       expect(data).toHaveProperty('timestamp');
       expect(data).toHaveProperty('version');
+      expect(data).toHaveProperty('commit');
+      expect(data).toHaveProperty('builtAt');
       expect(data).toHaveProperty('uptime');
       expect(data).toHaveProperty('environment');
       expect(data).not.toHaveProperty('components');
       expect(data).not.toHaveProperty('details');
+    });
+
+    it('should expose the exact artifact build stamp', async () => {
+      process.env.OMNIPOST_VERSION = '2.3.4';
+      process.env.OMNIPOST_COMMIT = '0123456789abcdef0123456789abcdef01234567';
+      process.env.OMNIPOST_BUILT_AT = '2026-08-09T16:00:00.000Z';
+      process.env.OMNIPOST_ENVIRONMENT = 'dev';
+
+      const request = createMockRequest('http://localhost:3000/api/health');
+      const response = await GET(request);
+      const data = await response.json();
+
+      expect(data).toMatchObject({
+        version: '2.3.4',
+        commit: '0123456789abcdef0123456789abcdef01234567',
+        builtAt: '2026-08-09T16:00:00.000Z',
+        environment: 'dev',
+      });
     });
 
     it('should return 200 even when JWT_SECRET is missing', async () => {

--- a/app/api/health/route.ts
+++ b/app/api/health/route.ts
@@ -42,6 +42,8 @@ interface HealthResponse {
   status: HealthStatus;
   timestamp: string;
   version: string;
+  commit: string;
+  builtAt: string;
   uptime: number;
   environment: string;
   components?: ComponentHealth[];
@@ -62,7 +64,19 @@ interface HealthResponse {
  * Get application version from package.json or environment
  */
 function getVersion(): string {
-  return process.env.npm_package_version || process.env.APP_VERSION || '0.1.0';
+  return process.env.OMNIPOST_VERSION || process.env.APP_VERSION || '0.1.0';
+}
+
+function getCommit(): string {
+  return process.env.OMNIPOST_COMMIT || 'unknown';
+}
+
+function getBuiltAt(): string {
+  return process.env.OMNIPOST_BUILT_AT || 'unknown';
+}
+
+function getEnvironment(): string {
+  return process.env.OMNIPOST_ENVIRONMENT || process.env.NODE_ENV || 'development';
 }
 
 /**
@@ -214,8 +228,10 @@ export async function GET(request: NextRequest): Promise<NextResponse<HealthResp
         status: 'healthy',
         timestamp: new Date().toISOString(),
         version: getVersion(),
+        commit: getCommit(),
+        builtAt: getBuiltAt(),
         uptime: getUptime(),
-        environment: process.env.NODE_ENV || 'development',
+        environment: getEnvironment(),
       },
       {
         status: 200,
@@ -252,8 +268,10 @@ export async function GET(request: NextRequest): Promise<NextResponse<HealthResp
       status: overallStatus,
       timestamp: new Date().toISOString(),
       version: getVersion(),
+      commit: getCommit(),
+      builtAt: getBuiltAt(),
       uptime: getUptime(),
-      environment: process.env.NODE_ENV || 'development',
+      environment: getEnvironment(),
       components,
       details: {
         memory: {

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -77,8 +77,10 @@ Always returns HTTP 200 if the application is running, regardless of configurati
   "status": "healthy",
   "timestamp": "2025-12-05T10:30:00.000Z",
   "version": "1.0.0",
+  "commit": "0123456789abcdef0123456789abcdef01234567",
+  "builtAt": "2026-08-09T16:00:00.000Z",
   "uptime": 86400,
-  "environment": "production"
+  "environment": "dev"
 }
 ```
 
@@ -91,6 +93,8 @@ Returns HTTP 200 for "healthy" or "degraded" status. Returns HTTP 503 only for "
   "status": "healthy",
   "timestamp": "2025-12-05T10:30:00.000Z",
   "version": "1.0.0",
+  "commit": "0123456789abcdef0123456789abcdef01234567",
+  "builtAt": "2026-08-09T16:00:00.000Z",
   "uptime": 86400,
   "environment": "production",
   "components": [

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -65,3 +65,16 @@ curl https://nl-dev-omnipost-sluice.jollyfield-e2805f37.westeurope.azurecontaine
 ```
 
 Expected result: HTTP `200 OK`; Sluice readiness should include `db: "connected"`.
+
+The application health payload also exposes the non-secret artifact stamp:
+`version`, `commit`, `builtAt`, and `environment`. The deployment workflow does
+not accept HTTP 200 alone: it verifies that the live `commit` equals the exact
+GitHub Actions build SHA before the run can qualify as successful deployment
+evidence. A merge, successful build, Terraform plan, or failed deployment must
+not be reported as shipped.
+
+The GitHub Actions run URL for a successful deployment is the authoritative
+deployment and acceptance evidence. Roll back by redeploying a previously
+verified commit through the same workflow, then verify that `/api/health`
+reports that exact rollback commit. Do not change the runtime stamp separately
+from the application artifact.

--- a/docs/release/OMNIPOST_RELEASE_AUDIT.md
+++ b/docs/release/OMNIPOST_RELEASE_AUDIT.md
@@ -1,0 +1,69 @@
+# OmniPost release evidence audit
+
+Audit date: 2026-08-09
+
+This audit is the OmniPost pilot input to Baton task
+`6ed39c8a-86f8-4599-a7be-e506dd637e3b`. It does not define the canonical
+cross-organization event schema and does not send Discord messages.
+
+## Current authority
+
+- Portfolio and product: NeuralLiquid / OmniPost
+- Repository: `neuralliquid/omnipost` (active)
+- Default branch: `main`
+- Authoritative version source: `package.json`; currently `1.0.0`
+- Runtime target: Azure App Service `nl-dev-omnipost-web`
+- Current deployment environment: `dev` (documented as production-like, not
+  production)
+- Active application workflow: `.github/workflows/azure-webapps-node.yml`
+- Infrastructure source: `infra/terraform/env/dev`
+
+## Findings
+
+1. The package version is static. There is no conventional-commit bump policy,
+   protected release PR automation, or current immutable tag/GitHub Release
+   flow. The only listed GitHub Release predates the current deployment model.
+2. A push to `main` starts the dev deployment workflow. A successful merge or
+   build is not deployment evidence; the deploy and post-deploy acceptance
+   steps must both succeed.
+3. Before this pilot the health endpoint reported a version but not the source
+   commit or build timestamp, so a central read-only collector could not prove
+   that a successful health response represented the workflow SHA.
+4. There is no repository scheduled Discord digest. No Discord webhook or
+   portfolio marker belongs in this product repository.
+5. Deployment rollback was not tied to an exact runtime revision. The supported
+   procedure is now to redeploy a previously verified commit and confirm the
+   same commit through the health endpoint.
+
+## Pilot contract
+
+The standalone artifact embeds `version`, `commit`, `builtAt`, and
+`environment`. `/api/health` exposes those non-secret fields. The deployment
+workflow accepts a deployment only when the live commit equals `github.sha` and
+the version and build timestamp are present.
+
+The successful GitHub Actions deployment run supplies the evidence URL and
+publication timestamp. The repository and workflow SHA supply immutable source
+identity. Acceptance is `passed` only after the exact-SHA health check succeeds;
+otherwise it is `failed` or `unknown` and must not enter a shipped rollup.
+
+## Central collector boundary
+
+`neuralliquid-org` owns the NeuralLiquid Discord secret, schedule, read-only
+source access, state, and the independent `nl/omnipost/weekly` Monday window.
+OmniPost remains authoritative for its version, deployed SHA, environment,
+deployment result, health evidence, and rollback procedure. The central
+collector must never infer shipment from merged pull requests.
+
+The shared `org-meta` schema and compatibility policy must be finalized before
+OmniPost emits a schema-versioned event payload. This pilot deliberately avoids
+creating a competing product-local schema.
+
+## Remaining standardization work
+
+- Choose and protect the version bump and release PR mechanism.
+- Create immutable tags, GitHub Releases, and changelogs for releasable builds.
+- Have the owner-repository collector normalize successful deployment evidence
+  into the canonical schema after that schema is approved.
+- Prove dry-run replay and duplicate suppression in `neuralliquid-org` before
+  enabling the Monday collector or changing any legacy notification.

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,8 +1,22 @@
 import { NextConfig } from 'next';
+import packageJson from './package.json';
+
+const buildVersion = process.env.APP_VERSION || packageJson.version;
+const buildCommit = process.env.APP_COMMIT || process.env.GITHUB_SHA || 'unknown';
+const builtAt = process.env.APP_BUILT_AT || new Date().toISOString();
+const deploymentEnvironment = process.env.APP_ENVIRONMENT || 'development';
 
 const nextConfig: NextConfig = {
   reactStrictMode: true,
   output: 'standalone', // Optimized production build with minimal dependencies
+  // Embed only non-secret provenance in the artifact. This prevents a failed
+  // deployment from advertising a SHA that never reached the running app.
+  env: {
+    OMNIPOST_VERSION: buildVersion,
+    OMNIPOST_COMMIT: buildCommit,
+    OMNIPOST_BUILT_AT: builtAt,
+    OMNIPOST_ENVIRONMENT: deploymentEnvironment,
+  },
   images: {
     remotePatterns: [
       {


### PR DESCRIPTION
## What changed

- embed version, commit SHA, build time, and deployment environment into the standalone artifact
- expose the non-secret artifact stamp through `/api/health`
- require post-deploy health to report the exact workflow SHA and expected environment
- document exact-revision rollback and the OmniPost release-evidence audit

## Why

A successful build, merge, or HTTP 200 did not prove which OmniPost revision was live. This makes deployed-artifact identity explicit and prevents the Azure workflow from reporting success for a stale runtime.

## Boundaries

Discord schedules, secrets, delivery state, and the canonical cross-organization schema remain outside OmniPost. No provider behavior or production data is changed.

## Verification

- TypeScript passed
- changed-file formatting and lint passed
- focused health tests: 15/15 passed
- legitimate Jest suites: 54 suites, 366 passed, 13 skipped
- production build with sentinel SHA passed; SHA confirmed in the server artifact

`pnpm check-all` remains baseline-red because 518 pre-existing files fail Prettier. Unfiltered Jest also discovers four Playwright specs and one setup-only file.

## Deployment caveat

Current `main` Azure run 31319462208 failed before deployment because migration `20260809090000_durable_analytics_events` detected pre-existing duplicate attribution tokens. That production-data recovery is independent of this PR; this PR must not be described as deployed until exact-SHA health verification passes.