### PR TITLE
feat: mark OmniPost as Private Preview

### DIFF
--- a/__tests__/components/ProductStatus.test.tsx
+++ b/__tests__/components/ProductStatus.test.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, test } from '@jest/globals';
+import ProductStatus from '@/components/ui/ProductStatus';
+import { productStatus } from '@/lib/product-status';
+
+describe('ProductStatus', () => {
+  test.each(['signIn', 'header', 'footer'] as const)(
+    'uses the centralized status contract for the %s surface',
+    variant => {
+      render(<ProductStatus variant={variant} showDescription />);
+
+      expect(screen.getByLabelText(productStatus.accessibleLabel).textContent).toContain(
+        productStatus.label
+      );
+      expect(screen.getByText(productStatus.description)).not.toBeNull();
+    }
+  );
+
+  test('keeps the compact header marker free of duplicate explanatory copy', () => {
+    render(<ProductStatus variant="header" />);
+
+    expect(screen.getByLabelText(productStatus.accessibleLabel)).not.toBeNull();
+    expect(screen.queryByText(productStatus.description)).toBeNull();
+  });
+});

--- a/__tests__/lib/product-status-mount.test.ts
+++ b/__tests__/lib/product-status-mount.test.ts
@@ -1,0 +1,30 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, test } from '@jest/globals';
+
+const readSource = (...segments: string[]) =>
+  readFileSync(join(process.cwd(), ...segments), 'utf8');
+
+describe('Private Preview product-status mounts', () => {
+  test('uses the shared status component on sign-in, authenticated header, and footer', () => {
+    const login = readSource('app', 'login', 'page.tsx');
+    const header = readSource('components', 'ui', 'Header.tsx');
+    const footer = readSource('components', 'ui', 'SharedFooter.tsx');
+
+    expect(login).toContain('<ProductStatus variant="signIn" showDescription />');
+    expect(header).toContain('isAuthenticated && <ProductStatus variant="header" />');
+    expect(footer).toContain('<ProductStatus variant="footer" showDescription />');
+  });
+
+  test('defines the truthful status words in one source only', () => {
+    const status = readSource('lib', 'product-status.ts');
+    const surfaces = [
+      readSource('app', 'login', 'page.tsx'),
+      readSource('components', 'ui', 'Header.tsx'),
+      readSource('components', 'ui', 'SharedFooter.tsx'),
+    ].join('\n');
+
+    expect(status).toContain("label: 'Private Preview'");
+    expect(surfaces).not.toContain('Private Preview');
+  });
+});

--- a/__tests__/styles/product-status-contrast.test.ts
+++ b/__tests__/styles/product-status-contrast.test.ts
@@ -1,0 +1,36 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, test } from '@jest/globals';
+
+const css = readFileSync(join(process.cwd(), 'styles', 'ProductStatus.module.css'), 'utf8');
+
+const hexToRgb = (hex: string) => {
+  const value = Number.parseInt(hex.slice(1), 16);
+  return [(value >> 16) & 255, (value >> 8) & 255, value & 255];
+};
+
+const relativeLuminance = (hex: string) => {
+  const channels = hexToRgb(hex).map(channel => {
+    const normalized = channel / 255;
+    return normalized <= 0.04045 ? normalized / 12.92 : ((normalized + 0.055) / 1.055) ** 2.4;
+  });
+
+  return 0.2126 * channels[0] + 0.7152 * channels[1] + 0.0722 * channels[2];
+};
+
+const contrastRatio = (foreground: string, background: string) => {
+  const lighter = Math.max(relativeLuminance(foreground), relativeLuminance(background));
+  const darker = Math.min(relativeLuminance(foreground), relativeLuminance(background));
+  return (lighter + 0.05) / (darker + 0.05);
+};
+
+describe('ProductStatus contrast', () => {
+  test.each([
+    ['sign-in pill', '--product-status-pill-foreground', '#3a5481', '#ffffff'],
+    ['dark header pill', '--product-status-pill-foreground', '#dbeafe', '#243040'],
+    ['dark-theme footer description', '--product-status-footer-description', '#1e293b', '#94a3b8'],
+  ])('%s meets WCAG AA for normal text', (_surface, property, foreground, background) => {
+    expect(css).toContain(`${property}: ${foreground}`);
+    expect(contrastRatio(foreground, background)).toBeGreaterThanOrEqual(4.5);
+  });
+});

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -9,6 +9,7 @@ import React, { useState, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 import { useAuth } from '@/components/providers/AuthProvider';
 import Header from '@/components/ui/Header';
+import ProductStatus from '@/components/ui/ProductStatus';
 import styles from '@/styles/LoginForm.module.css';
 import pageStyles from './page.module.css';
 
@@ -82,7 +83,7 @@ export default function LoginPage() {
       await login(username, password);
       router.push('/dashboard');
     } catch (err: unknown) {
-      const errorMessage = err instanceof Error ? err.message : 'Login failed';
+      const errorMessage = err instanceof Error ? err.message : 'Sign-in failed';
       setError(errorMessage);
     } finally {
       setLoading(false);
@@ -105,7 +106,8 @@ export default function LoginPage() {
       <Header />
       <main className={pageStyles.main}>
         <div className={styles.loginContainer}>
-          <h1 className={styles.title}>Login</h1>
+          <ProductStatus variant="signIn" showDescription />
+          <h1 className={styles.title}>Sign in to OmniPost</h1>
 
           {!providersLoading && providers.length > 0 && (
             <>
@@ -170,7 +172,7 @@ export default function LoginPage() {
             </div>
 
             <button type="submit" disabled={loading} className={styles.submitButton}>
-              {loading ? 'Logging in...' : 'Login'}
+              {loading ? 'Signing in...' : 'Sign in'}
             </button>
           </form>
 

--- a/components/ui/Header.tsx
+++ b/components/ui/Header.tsx
@@ -6,6 +6,7 @@ import { usePathname, useRouter } from 'next/navigation';
 import styles from '@/styles/Header.module.css';
 import { NavigationItem, siteConfig } from '../../data/siteConfig';
 import { useAuth } from '../providers/AuthProvider';
+import ProductStatus from './ProductStatus';
 
 type ThemeMode = 'light' | 'dark';
 
@@ -156,6 +157,7 @@ const Header: React.FC = () => {
               </li>
             ))}
             <li className={`${styles.navItem} ${styles.utilityGroup}`} aria-label="Header controls">
+              {isAuthenticated && <ProductStatus variant="header" />}
               <button
                 type="button"
                 className={styles.iconToggleButton}

--- a/components/ui/ProductStatus.tsx
+++ b/components/ui/ProductStatus.tsx
@@ -1,0 +1,21 @@
+import styles from '@/styles/ProductStatus.module.css';
+import { productStatus } from '@/lib/product-status';
+
+type ProductStatusVariant = 'signIn' | 'header' | 'footer';
+
+interface ProductStatusProps {
+  readonly variant: ProductStatusVariant;
+  readonly showDescription?: boolean;
+}
+
+export default function ProductStatus({ variant, showDescription = false }: ProductStatusProps) {
+  return (
+    <div className={`${styles.status} ${styles[variant]}`}>
+      <span className={styles.pill} aria-label={productStatus.accessibleLabel}>
+        <span className={styles.signal} aria-hidden="true" />
+        {productStatus.label}
+      </span>
+      {showDescription && <p className={styles.description}>{productStatus.description}</p>}
+    </div>
+  );
+}

--- a/components/ui/SharedFooter.tsx
+++ b/components/ui/SharedFooter.tsx
@@ -4,6 +4,7 @@ import React, { useState, useEffect } from 'react';
 import Link from 'next/link';
 import styles from '@/styles/SharedFooter.module.css';
 import { siteConfig, NavigationItem } from '../../data/siteConfig';
+import ProductStatus from './ProductStatus';
 
 // Reusable arrow icon for footer links
 const ArrowIcon: React.FC = () => (
@@ -111,6 +112,7 @@ const SharedFooter: React.FC = () => {
               <span className={styles.brandName}>{siteConfig.siteName}</span>
             </Link>
             <p className={styles.brandDescription}>{siteConfig.siteDescription}</p>
+            <ProductStatus variant="footer" showDescription />
 
             {/* Social links inline with brand */}
             <div className={styles.socialLinks}>

--- a/lib/product-status.ts
+++ b/lib/product-status.ts
@@ -1,0 +1,5 @@
+export const productStatus = {
+  label: 'Private Preview',
+  accessibleLabel: 'OmniPost product status: Private Preview',
+  description: 'Available to invited teams while we refine the publishing workflow.',
+} as const;

--- a/styles/ProductStatus.module.css
+++ b/styles/ProductStatus.module.css
@@ -1,4 +1,7 @@
 .status {
+  --product-status-pill-foreground: #3a5481;
+  --product-status-footer-description: rgba(255, 255, 255, 0.78);
+
   display: flex;
   align-items: center;
   gap: 0.75rem;
@@ -15,7 +18,7 @@
   border: 1px solid color-mix(in srgb, var(--color-primary, #4a6491) 45%, transparent);
   border-radius: var(--radius-full, 9999px);
   background: color-mix(in srgb, var(--color-primary, #4a6491) 8%, transparent);
-  color: var(--color-primary-dark, #3a5481);
+  color: var(--product-status-pill-foreground);
   font-size: 0.75rem;
   font-weight: var(--font-weight-semibold, 600);
   line-height: 1;
@@ -76,7 +79,30 @@
 }
 
 .footer .description {
-  color: rgba(255, 255, 255, 0.78);
+  color: var(--product-status-footer-description);
+}
+
+@media (prefers-color-scheme: dark) {
+  .status {
+    --product-status-footer-description: #1e293b;
+  }
+
+  .header {
+    --product-status-pill-foreground: #dbeafe;
+  }
+}
+
+:global(:root[data-theme='light']) .status {
+  --product-status-pill-foreground: #3a5481;
+  --product-status-footer-description: rgba(255, 255, 255, 0.78);
+}
+
+:global(:root[data-theme='dark']) .status {
+  --product-status-footer-description: #1e293b;
+}
+
+:global(:root[data-theme='dark']) .header {
+  --product-status-pill-foreground: #dbeafe;
 }
 
 @media (max-width: 768px) {

--- a/styles/ProductStatus.module.css
+++ b/styles/ProductStatus.module.css
@@ -1,0 +1,94 @@
+.status {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  min-width: 0;
+}
+
+.pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  width: max-content;
+  min-height: 1.75rem;
+  padding: 0.25rem 0.65rem;
+  border: 1px solid color-mix(in srgb, var(--color-primary, #4a6491) 45%, transparent);
+  border-radius: var(--radius-full, 9999px);
+  background: color-mix(in srgb, var(--color-primary, #4a6491) 8%, transparent);
+  color: var(--color-primary-dark, #3a5481);
+  font-size: 0.75rem;
+  font-weight: var(--font-weight-semibold, 600);
+  line-height: 1;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+.signal {
+  width: 0.45rem;
+  height: 0.45rem;
+  flex: 0 0 auto;
+  border: 2px solid color-mix(in srgb, var(--color-accent, #3498db) 25%, transparent);
+  border-radius: 50%;
+  background: var(--color-accent, #3498db);
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--color-accent, #3498db) 14%, transparent);
+}
+
+.description {
+  max-width: 28rem;
+  margin: 0;
+  color: var(--color-text-secondary, #4a5568);
+  font-size: var(--font-size-sm, 0.875rem);
+  line-height: 1.5;
+}
+
+.signIn {
+  flex-direction: column;
+  align-items: center;
+  gap: 0.65rem;
+  margin-bottom: 1rem;
+  text-align: center;
+}
+
+.signIn .description {
+  color: var(--color-text-muted, #64748b);
+}
+
+.header {
+  flex: 0 0 auto;
+}
+
+.header .pill {
+  min-height: 2rem;
+  padding-inline: 0.7rem;
+}
+
+.footer {
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.6rem;
+}
+
+.footer .pill {
+  border-color: rgba(255, 255, 255, 0.3);
+  background: rgba(255, 255, 255, 0.1);
+  color: var(--color-text-inverse, #ffffff);
+}
+
+.footer .description {
+  color: rgba(255, 255, 255, 0.78);
+}
+
+@media (max-width: 768px) {
+  .header {
+    width: 100%;
+    padding: 0.35rem 1rem;
+  }
+}
+
+@media (max-width: 640px) {
+  .footer {
+    align-items: center;
+    text-align: center;
+  }
+}


### PR DESCRIPTION
## What changed

- define one immutable OmniPost product-status contract for `Private Preview`
- render the shared accessible release-channel marker on sign-in, the authenticated header, and the public footer
- align sign-in action copy without changing authentication behavior
- add component behavior and three-surface mount regression tests

## Why

OmniPost is still invitation-only, but that status was not consistently visible across public and authenticated journeys. Centralizing the copy prevents sign-in, header, and footer claims from drifting.

## Validation

- marketing contract validation: passed
- TypeScript: passed
- ESLint: passed with the repository's existing 120 warnings and no errors
- targeted Prettier and `git diff --check`: passed
- Jest: 56 suites / 372 tests passed; 2 PostgreSQL suites / 13 tests skipped without a local database
- production build: passed, 60 pages/routes generated
- production-mode desktop sign-in and 390px mobile full-page/footer screenshots captured and visually inspected
- repository-wide Prettier remains at the known Windows baseline (521 unrelated files); no changed file fails formatting

## Boundaries

No authentication flow, session, provider, database, Azure, deployment, or production state was changed. An authenticated-header screenshot was not fabricated; its conditional mount and accessible component behavior are covered by tests.